### PR TITLE
allow static builds on windows

### DIFF
--- a/CoordgenConfig.hpp
+++ b/CoordgenConfig.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifndef STATIC_COORDGEN
+
 #ifdef IN_COORDGEN
 #ifdef WIN32
 #define EXPORT_COORDGEN __declspec(dllexport)
@@ -14,5 +16,11 @@
 #else
 #define EXPORT_COORDGEN
 #endif
+
+#endif
+
+#else
+
+#define EXPORT_COORDGEN
 
 #endif


### PR DESCRIPTION
On the RDKit side we often need to build the backend libraries statically linked. This enables that for coordgenlibs on Windows.
It's connected to https://github.com/rdkit/rdkit/pull/1910.