### PR TITLE
Add maeparser transitive Boost::iostreams dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(coordgen)
 
 
 file(GLOB SOURCES "*.cpp")
-find_package(Boost)
+find_package(Boost COMPONENTS iostreams REQUIRED)
 find_package(maeparser)
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${maeparser_INCLUDE_DIRS})


### PR DESCRIPTION
Since we are adding maeparser as a library, we need to update the project's dependencies.