### PR TITLE
Please add SOVERSION to SONAME

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ include_directories(${maeparser_INCLUDE_DIRS})
 add_library(coordgenlibs SHARED ${SOURCES})
 target_compile_definitions(coordgenlibs PRIVATE IN_COORDGEN)
 set_property(TARGET coordgenlibs PROPERTY CXX_VISIBILITY_PRESET "hidden")
+SET_TARGET_PROPERTIES(coordgenlibs
+    PROPERTIES
+        VERSION 1.1
+        SOVERSION 1
+)
 add_executable(example example/example.cpp)
 
 target_link_libraries(coordgenlibs maeparser)


### PR DESCRIPTION
Dear coordgenlibs developers,

In analogy to https://github.com/schrodinger/maeparser/pull/23 against maeparser, please add an SOVERSION to your library. The SOVERSION version you specify (here I went to "1" to reflect the major version of your library, but 0 or 18 are just as fine, you may however want to coordinate your semantics [start with 0, major version, schroedinger major version, ...] with the maeparser folks) will affect the naming of the Debian(+Ubuntu) package of your software I am creating at the very moment at [https://salsa.debian.org/science-team/schroedinger-coordgenlibs/blob/master/debian/control](https://salsa.debian.org/science-team/schroedinger-coordgenlibs/blob/master/debian/control).

Kind regards,

Steffen Möller