### PR TITLE
Export CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(example coordgen)
 enable_testing()
 
 install(TARGETS coordgen
-    EXPORT coordgenlibs-target
+    EXPORT coordgen-target
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib)
@@ -58,7 +58,7 @@ install(FILES
     sketcherMinimizerStretchInteraction.h
     DESTINATION include/coordgen)
 
-INSTALL(EXPORT coordgenlibs-target
+INSTALL(EXPORT coordgen-target
     FILE ${PROJECT_NAME}-config.cmake
     DESTINATION lib/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,10 @@ install(FILES
     sketcherMinimizerStretchInteraction.h
     DESTINATION include/coordgen)
 
+INSTALL(EXPORT coordgenlibs
+    FILE ${PROJECT_NAME}-config.cmake
+    DESTINATION lib/cmake)
+
 install(FILES
     templates.mae
     DESTINATION share/coordgen)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(example coordgen)
 enable_testing()
 
 install(TARGETS coordgen
+    EXPORT coordgenlibs-target
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib)
@@ -57,7 +58,7 @@ install(FILES
     sketcherMinimizerStretchInteraction.h
     DESTINATION include/coordgen)
 
-INSTALL(EXPORT coordgenlibs
+INSTALL(EXPORT coordgenlibs-target
     FILE ${PROJECT_NAME}-config.cmake
     DESTINATION lib/cmake)
 


### PR DESCRIPTION
This is to allow CMake to find coordgenlibs by using the "find_package" functionality.