### PR TITLE
Rename CMake target: coordgenlibs ==> coordgen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,21 +15,21 @@ find_package(Boost COMPONENTS iostreams REQUIRED)
 find_package(maeparser)
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${maeparser_INCLUDE_DIRS})
-add_library(coordgenlibs SHARED ${SOURCES})
-target_compile_definitions(coordgenlibs PRIVATE IN_COORDGEN)
-set_property(TARGET coordgenlibs PROPERTY CXX_VISIBILITY_PRESET "hidden")
-SET_TARGET_PROPERTIES(coordgenlibs
+add_library(coordgen SHARED ${SOURCES})
+target_compile_definitions(coordgen PRIVATE IN_COORDGEN)
+set_property(TARGET coordgen PROPERTY CXX_VISIBILITY_PRESET "hidden")
+SET_TARGET_PROPERTIES(coordgen
     PROPERTIES
         VERSION 1.1
         SOVERSION 1
 )
 add_executable(example example_dir/example.cpp)
 
-target_link_libraries(coordgenlibs maeparser)
-target_link_libraries(example coordgenlibs)
+target_link_libraries(coordgen maeparser)
+target_link_libraries(example coordgen)
 enable_testing()
 
-install(TARGETS coordgenlibs
+install(TARGETS coordgen
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib)


### PR DESCRIPTION
Rename the CMake target to be coherent with the project name and the include and share subdirectories and avoid the unfortunate "libcoordgenlibs.so" naming.