### PR TITLE
CRDGEN-246 disable constraint interactions when avoiding clashes

### DIFF
--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -1209,7 +1209,6 @@ bool CoordgenMinimizer::avoidClashesOfMolecule(
     clearInteractions();
     addClashInteractionsOfMolecule(molecule, false);
     addPeptideBondInversionConstraintsOfMolecule(molecule);
-    addConstrainedInteractionsOfMolecule(molecule);
     foreach (sketcherMinimizerInteraction* interaction, extraInteractions) {
         _interactions.push_back(interaction);
         _extraInteractions.push_back(interaction);


### PR DESCRIPTION
these constraints were creating problems with clash minimization in the case of complicated constrained LID because they tend to take precedence over bond stretches and cause distorted images. Disabling them for now, I opened CRDGEN-247 to implement a better approach