### PR TITLE
Enable testing + small improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,35 @@
-set (CMAKE_CXX_STANDARD 11)
 cmake_minimum_required(VERSION 3.2)
 project(coordgen)
 
+# Options & Project configuration
+set(CMAKE_CXX_STANDARD 11)
+option(COORDGEN_BUILD_TESTS "Whether test executables should be built" ON)
+option(COORDGEN_BUILD_EXAMPLE "Whether to build the sample executable" ON)
 
-file(GLOB SOURCES "*.cpp")
+# Dependencies
 find_package(Boost COMPONENTS iostreams REQUIRED)
-find_package(maeparser)
+find_package(maeparser REQUIRED)
+
+# Source files & headers
+file(GLOB SOURCES "*.cpp")
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${maeparser_INCLUDE_DIRS})
+
+# Build Targets & Configuration -- coordgen library
 add_library(coordgen SHARED ${SOURCES})
 target_compile_definitions(coordgen PRIVATE IN_COORDGEN)
 set_property(TARGET coordgen PROPERTY CXX_VISIBILITY_PRESET "hidden")
-SET_TARGET_PROPERTIES(coordgen
+target_link_libraries(coordgen maeparser)
+
+set_target_properties(coordgen
     PROPERTIES
         VERSION 1.2.2
         SOVERSION 1
 )
-add_executable(example example_dir/example.cpp)
 
-target_link_libraries(coordgen maeparser)
-target_link_libraries(example coordgen)
-enable_testing()
-
+# Install configuration
 install(TARGETS coordgen
+    EXPORT coordgen-targets
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib)
@@ -53,3 +60,21 @@ install(FILES
 install(FILES
     templates.mae
     DESTINATION share/coordgen)
+
+install(EXPORT coordgen-targets
+    FILE ${PROJECT_NAME}-config.cmake
+    DESTINATION lib/cmake)
+
+# Example
+if(COORDGEN_BUILD_EXAMPLE)
+    add_subdirectory(example_dir)
+endif(COORDGEN_BUILD_EXAMPLE)
+
+# Tests
+if(COORDGEN_BUILD_TESTS)
+    include(CTest)
+    set(MEMORYCHECK_COMMAND_OPTIONS "--tool=memcheck --time-stamp=yes"
+        " --num-callers=20 --gen-suppressions=all --leak-check=full"
+        " --show-reachable=no --trace-children=yes")
+    add_subdirectory(test)
+endif(COORDGEN_BUILD_TESTS)

--- a/README.md
+++ b/README.md
@@ -11,5 +11,11 @@ Schrodinger intends to continue to contribute to this code as it still uses it i
 ### Documentation
 Examples and documentation will be added/improved over time
 
+### Usage example
+Code for a sample executable is provided in the `example_dir` directory. Building the example executable is enabled by default, but can be disabled by means of the `COORDGEN_BUILD_EXAMPLE` option.
+
 ### Automated Testing
-Automated testing is still primarily taking place inside Schrodinger's internal build system
+Automated testing is still primarily taking place inside Schrodinger's internal build system, although tests are incrementally being added to the `testing` directory. Building the tests is enabled by default, but can be disabled by means of the `COORDGEN_BUILD_TESTS` option.
+
+Memory debugging is, by default, configured to use `valgrind`. It can be run on the tests by passing `-DCMAKE_BUILD_TYPE=Debug` to cmake, to enable building the debugging symbols, and then using `ctest -T memcheck` inside the build directory.
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
-  BOOST_ROOT: c:/Libraries/boost
-  BOOST_LIBRARYDIR: c:/Libraries/boost/lib64-msvc-12.0
+  BOOST_ROOT_DIR: c:\Libraries\boost
+  BOOST_LIBRARYDIR: c:\Libraries\boost\lib64-msvc-12.0
   INSTALL_PREFIX : c:\installation
   CMAKE_PREFIX_PATH : c:\installation\lib\cmake
 
@@ -23,9 +23,13 @@ before_build:
   - git clone https://github.com/schrodinger/maeparser.git %APPVEYOR_BUILD_FOLDER%\maeparser
   - mkdir %APPVEYOR_BUILD_FOLDER%\maeparser\build
   - cd %APPVEYOR_BUILD_FOLDER%\maeparser\build
-  - cmake -G "Visual Studio 12 Win64" -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%" ..
+  - cmake -G "Visual Studio 12 Win64" -DBOOST_ROOT="%BOOST_ROOT_DIR%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%" ..
   - cmake --build . --target install
   - mkdir %APPVEYOR_BUILD_FOLDER%\build
   - cd %APPVEYOR_BUILD_FOLDER%\build
-  - cmake -G "Visual Studio 12 Win64" -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DCMAKE_PREFIX_PATH="%P\lib\cmake" -DCMAKE_INSTALL_PREFIX="INSTALL_PREFIX" ..
+  - cmake -G "Visual Studio 12 Win64" -DBOOST_ROOT="%BOOST_ROOT_DIR%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DCMAKE_PREFIX_PATH="%P\lib\cmake" -DCMAKE_INSTALL_PREFIX="INSTALL_PREFIX" ..
 
+test_script:
+  - set PATH=%PATH%;%BOOST_LIBRARYDIR%;%INSTALL_PREFIX%\lib
+  - cd %APPVEYOR_BUILD_FOLDER%\build
+  - ctest -j2 --output-on-failure

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   BOOST_ROOT_DIR: c:\Libraries\boost
-  BOOST_LIBRARYDIR: c:\Libraries\boost\lib64-msvc-12.0
+  BOOST_LIBRARY_PATH: c:\Libraries\boost\lib64-msvc-12.0
   INSTALL_PREFIX : c:\installation
   CMAKE_PREFIX_PATH : c:\installation\lib\cmake
 
@@ -16,20 +16,29 @@ install:
   # by default, all script lines are interpreted as batch
 
 build:
-  project: build\ALL_BUILD.vcxproj
+  project: build\INSTALL.vcxproj
   parallel: true
 
 before_build:
   - git clone https://github.com/schrodinger/maeparser.git %APPVEYOR_BUILD_FOLDER%\maeparser
   - mkdir %APPVEYOR_BUILD_FOLDER%\maeparser\build
   - cd %APPVEYOR_BUILD_FOLDER%\maeparser\build
-  - cmake -G "Visual Studio 12 Win64" -DBOOST_ROOT="%BOOST_ROOT_DIR%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%" ..
-  - cmake --build . --target install
+  - cmake .. -G "Visual Studio 12 Win64" ^
+      -DBOOST_ROOT="%BOOST_ROOT_DIR%" ^
+      -DBOOST_LIBRARYDIR="%BOOST_LIBRARY_PATH%" ^
+      -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
+  - cmake --build . --target install --config Release
   - mkdir %APPVEYOR_BUILD_FOLDER%\build
   - cd %APPVEYOR_BUILD_FOLDER%\build
-  - cmake -G "Visual Studio 12 Win64" -DBOOST_ROOT="%BOOST_ROOT_DIR%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DCMAKE_PREFIX_PATH="%P\lib\cmake" -DCMAKE_INSTALL_PREFIX="INSTALL_PREFIX" ..
+  - cmake .. -G "Visual Studio 12 Win64" ^
+      -DBOOST_ROOT="%BOOST_ROOT_DIR%" ^
+      -DBOOST_LIBRARYDIR="%BOOST_LIBRARY_PATH%" ^
+      -DCMAKE_PREFIX_PATH="%CMAKE_PREFIX_PATH%" ^
+      -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
 
 test_script:
-  - set PATH=%PATH%;%BOOST_LIBRARYDIR%;%INSTALL_PREFIX%\lib
+  - set PATH=%PATH%;%BOOST_LIBRARY_PATH%;%INSTALL_PREFIX%\bin
+  # For whatever reason, boost_iostreams depends on libbz2.dll (required for maeparser)
+  - copy %BOOST_LIBRARY_PATH%\boost_bzip2-vc120-mt-1_56.dll %INSTALL_PREFIX%\bin\libbz2.dll
   - cd %APPVEYOR_BUILD_FOLDER%\build
   - ctest -j2 --output-on-failure

--- a/example_dir/CMakeLists.txt
+++ b/example_dir/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(example example.cpp)
+target_link_libraries(example coordgen)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Use the example executable as a test
+add_test(example ${CMAKE_BINARY_DIR}/example_dir/example)


### PR DESCRIPTION
I have tidied up the CMakeLists.txt file and enabled testing, including a setup for using valgrind on tests.

Also:
- Made maeparser a "REQUIRED" dependency.
- Added a CMake export to the install (we don't need it, but might be useful for someone).
- Options to enable/disable building of example and/or tests.
- Updated Readme.
- Enabled testing on appveyor (they already were on travis); the appveyor script also required some fixing.