### PR TITLE
Reduce compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - cd build
   - export CXX="g++-4.8"
   - export CMAKE_PREFIX_PATH=$TRAVIS_BUILD_DIR/installation/lib/cmake
-  - cmake ..
+  - cmake .. -DCOORDGEN_RIGOROUS_BUILD=ON
   - make
   - make test CTEST_OUTPUT_ON_FAILURE=1
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,22 @@ project(coordgen)
 
 # Options & Project configuration
 set(CMAKE_CXX_STANDARD 11)
+option(COORDGEN_RIGOROUS_BUILD "Abort the build if the compiler issues any warnings" OFF )
 option(COORDGEN_BUILD_TESTS "Whether test executables should be built" ON)
 option(COORDGEN_BUILD_EXAMPLE "Whether to build the sample executable" ON)
+
+if(MSVC)
+    # C4251 disables warnings for export STL containers as arguments (returning a vector of things)
+    add_definitions(/wd4251 /wd4275 /wd4996 /D_SCL_SECURE_NO_WARNINGS /D_CRT_SECURE_NO_WARNINGS)
+endif(MSVC)
+
+if(COORDGEN_RIGOROUS_BUILD)
+if(MSVC)
+    add_definitions(/WX)
+else(MSVC)
+    add_definitions(-Wall -Wextra -Werror)
+endif(MSVC)
+endif(COORDGEN_RIGOROUS_BUILD)
 
 # Dependencies
 find_package(Boost COMPONENTS iostreams REQUIRED)

--- a/CoordgenFragmenter.cpp
+++ b/CoordgenFragmenter.cpp
@@ -203,8 +203,8 @@ bool CoordgenFragmenter::hasPriority(const sketcherMinimizerFragment* fragment1,
     bool checkNoMore = false;
     int checkN = 0;
     while (!checkNoMore) {
-        int leftValue = getValueOfCheck(fragment1, checkN, checkNoMore);
-        int rightValue = getValueOfCheck(fragment2, checkN, checkNoMore);
+        size_t leftValue = getValueOfCheck(fragment1, checkN, checkNoMore);
+        size_t rightValue = getValueOfCheck(fragment2, checkN, checkNoMore);
         if (leftValue > rightValue)
             return true;
         if (leftValue < rightValue)
@@ -214,7 +214,7 @@ bool CoordgenFragmenter::hasPriority(const sketcherMinimizerFragment* fragment1,
     return false;
 }
 
-int CoordgenFragmenter::getValueOfCheck(
+size_t CoordgenFragmenter::getValueOfCheck(
     const sketcherMinimizerFragment* fragment, int checkN, bool& checkNoMore)
 {
     switch (checkN) {

--- a/CoordgenFragmenter.h
+++ b/CoordgenFragmenter.h
@@ -6,6 +6,7 @@
 #ifndef COORDGEN_FRAGMENTER_H
 #define COORDGEN_FRAGMENTER_H
 
+#include <cstddef>
 #include <vector>
 
 class sketcherMinimizerFragment;
@@ -107,7 +108,7 @@ class CoordgenFragmenter
     /*
      get the score of a particular descriptor for the given fragment (used to assign priorities)
      */
-    static int getValueOfCheck(const sketcherMinimizerFragment* fragment,
+    static size_t getValueOfCheck(const sketcherMinimizerFragment* fragment,
                                int checkN, bool& checkNoMore);
 
     /*

--- a/CoordgenMacrocycleBuilder.cpp
+++ b/CoordgenMacrocycleBuilder.cpp
@@ -74,7 +74,7 @@ void Polyomino::clear()
     m_list.clear();
 }
 
-int Polyomino::size() const
+size_t Polyomino::size() const
 {
     return m_list.size();
 }
@@ -286,11 +286,11 @@ void Polyomino::markOneVertexAsPentagon() // TO DO: should check if one vertex
                                           // only mark one vertex per polyomino
 {
     vector<vertexCoords> pathV = getPath();
-    int previousMultiplicity = hexagonsAtVertex(pathV[pathV.size() - 1]);
-    int thisMultiplicity = hexagonsAtVertex(pathV[0]);
-    int nextMultiplicity = 0;
-    for (unsigned int i = 0; i < pathV.size(); i++) {
-        int nextI = (i >= pathV.size() - 1) ? 0 : i + 1;
+    size_t previousMultiplicity = hexagonsAtVertex(pathV[pathV.size() - 1]);
+    size_t thisMultiplicity = hexagonsAtVertex(pathV[0]);
+    size_t nextMultiplicity = 0;
+    for (size_t i = 0; i < pathV.size(); i++) {
+        size_t nextI = (i >= pathV.size() - 1) ? 0 : i + 1;
         nextMultiplicity = hexagonsAtVertex(pathV[nextI]);
         if (previousMultiplicity == 2 && thisMultiplicity == 1 &&
             nextMultiplicity == 2) {
@@ -303,8 +303,8 @@ void Polyomino::markOneVertexAsPentagon() // TO DO: should check if one vertex
     previousMultiplicity = hexagonsAtVertex(pathV[pathV.size() - 1]);
     thisMultiplicity = hexagonsAtVertex(pathV[0]);
     nextMultiplicity = 0;
-    for (unsigned int i = 0; i < pathV.size(); i++) {
-        int nextI = (i >= pathV.size() - 1) ? 0 : i + 1;
+    for (size_t i = 0; i < pathV.size(); i++) {
+        size_t nextI = (i >= pathV.size() - 1) ? 0 : i + 1;
         nextMultiplicity = hexagonsAtVertex(pathV[nextI]);
         if (previousMultiplicity == 1 && thisMultiplicity == 2 &&
             nextMultiplicity == 1) {
@@ -324,7 +324,7 @@ void Polyomino::setPentagon(vertexCoords c) // the marked vertex and the
     pentagonVertices.push_back(c);
 }
 
-int Polyomino::hexagonsAtVertex(vertexCoords v) const
+size_t Polyomino::hexagonsAtVertex(vertexCoords v) const
 {
     return vertexNeighbors(v).size();
 }
@@ -619,11 +619,12 @@ vector<sketcherMinimizerPointF> CoordgenMacrocycleBuilder::newMacrocycle(
 {
     // TODO the coordinates should be built on the returned vector, never saved
     // to the atoms in atoms.
+    int natoms = static_cast<int>(atoms.size());
     Polyomino p;
-    p.buildWithVerticesN(atoms.size());
+    p.buildWithVerticesN(natoms);
     vector<Polyomino> pols;
     pols.push_back(p);
-    vector<Polyomino> squarePols = buildSquaredShapes(atoms.size());
+    vector<Polyomino> squarePols = buildSquaredShapes(natoms);
     for (unsigned int i = 0; i < squarePols.size(); i++) {
         assert(squarePols[i].getPath().size() == atoms.size());
     }
@@ -638,7 +639,7 @@ vector<sketcherMinimizerPointF> CoordgenMacrocycleBuilder::newMacrocycle(
     int bestStart = 0;
     int bestScore = PATH_FAILED;
     Polyomino chosenP = pols[0];
-    int acceptableScore = acceptableShapeScore(atoms.size());
+    int acceptableScore = acceptableShapeScore(natoms);
     int checkedMacrocycles = 0;
     if (!m_forceOpenMacrocycles) {
         do {
@@ -649,8 +650,9 @@ vector<sketcherMinimizerPointF> CoordgenMacrocycleBuilder::newMacrocycle(
                 startOfChosen = bestStart;
                 scoreOfChosen = bestScore;
                 chosenP = pols[bestP];
-                if (bestScore > acceptableScore)
+                if (bestScore > acceptableScore) {
                     break;
+                }
             }
             if (checkedMacrocycles > MAX_MACROCYCLES)
                 break;
@@ -692,9 +694,9 @@ sketcherMinimizerBond*
 CoordgenMacrocycleBuilder::findBondToOpen(sketcherMinimizerRing* ring) const
 {
     sketcherMinimizerBond* bestBond = NULL;
-    float bestScore = 0.f;
+    size_t bestScore = 0;
     foreach (sketcherMinimizerBond* bond, ring->_bonds) {
-        int score = 0.f;
+        size_t score = 0;
         if (ring->isMacrocycle()) {
             if (bond->getBondOrder() != 1)
                 continue;
@@ -821,14 +823,14 @@ vector<Polyomino> CoordgenMacrocycleBuilder::listOfEquivalent(
 {
     vector<Polyomino> out;
     vector<Hex*> l = p.m_list;
-    int pentagonVs = p.pentagonVertices.size();
+    size_t pentagonVs = p.pentagonVertices.size();
     for (unsigned int i = 0; i < l.size(); i++) {
         hexCoords c = l[i]->coords();
         if (p.isEquivalentWithout(c)) {
             Polyomino newP = p;
             newP.pentagonVertices.clear();
             newP.removeHex(c);
-            for (int i = 0; i < pentagonVs; i++) {
+            for (size_t i = 0; i < pentagonVs; i++) {
                 newP.markOneVertexAsPentagon();
             }
             out.push_back(newP);
@@ -904,8 +906,8 @@ CoordgenMacrocycleBuilder::getDoubleBondConstraints(
             }
             if (smallRingBond)
                 continue;
-            unsigned int previousI = (i + atoms.size() - 1) % atoms.size();
-            unsigned int followingI = (i + 2) % atoms.size();
+            int previousI = static_cast<int>((i + atoms.size() - 1) % atoms.size());
+            int followingI = (i + 2) % atoms.size();
 
             bool isTrans = !b->isZ; // is the atom trans in the ring? (isZ
                                     // stores the absolute chirality)
@@ -970,7 +972,7 @@ pathRestraints CoordgenMacrocycleBuilder::getPathRestraints(
             heteroAtoms.push_back(i);
         if (atoms[i]->neighbors.size() != 2) {
             int totN = 0;
-            unsigned int prevI = (i + atoms.size() - 1) % atoms.size();
+            unsigned int prevI = static_cast<int>((i + atoms.size() - 1) % atoms.size());
             unsigned int postI = (i + 1) % atoms.size();
             for (unsigned int j = 0; j < atoms[i]->neighbors.size(); j++) {
                 sketcherMinimizerAtom* n = atoms[i]->neighbors[j];
@@ -993,7 +995,7 @@ bool CoordgenMacrocycleBuilder::checkDoubleBoundConstraints(
     int& startI) const
 {
     for (unsigned int i = 0; i < dbConstraints.size(); i++) {
-        unsigned int counter =
+        size_t counter =
             (startI + dbConstraints[i].previousAtom) % vertices.size();
         sketcherMinimizerPointF p1 = coordsOfVertex(vertices[counter]);
         counter = (startI + dbConstraints[i].atom1) % vertices.size();
@@ -1119,7 +1121,8 @@ CoordgenMacrocycleBuilder::getVertexNeighborNs(Polyomino& p,
 {
     vector<int> out;
     for (unsigned int i = 0; i < path.size(); i++) {
-        out.push_back(p.hexagonsAtVertex(path[i]));
+        out.push_back(
+            static_cast<int>(p.hexagonsAtVertex(path[i])));
     }
     return out;
 }
@@ -1139,7 +1142,7 @@ int CoordgenMacrocycleBuilder::getLowestPeriod(
         if (!hasDifference)
             return period;
     }
-    return neighbors.size();
+    return static_cast<int>(neighbors.size());
 }
 
 bool CoordgenMacrocycleBuilder::matchPolyominoes(vector<Polyomino>& pols,
@@ -1202,8 +1205,8 @@ sketcherMinimizerPointF
 CoordgenMacrocycleBuilder::coordsOfVertex(vertexCoords& v) const
 {
     return sketcherMinimizerPointF(
-        BONDLENGTH * SQRT3HALF * v.x - BONDLENGTH * SQRT3HALF * v.z,
-        -BONDLENGTH * 0.5 * v.x + BONDLENGTH * v.y + -BONDLENGTH * 0.5 * v.z);
+        static_cast<float>(BONDLENGTH * SQRT3HALF * v.x - BONDLENGTH * SQRT3HALF * v.z),
+        static_cast<float>(-BONDLENGTH * 0.5 * v.x + BONDLENGTH * v.y + -BONDLENGTH * 0.5 * v.z));
 }
 
 void CoordgenMacrocycleBuilder::writePolyominoCoordinates(
@@ -1260,9 +1263,9 @@ CoordgenMacrocycleBuilder::buildSquaredShapes(int totVertices) const
             // we can build one with ragged borders and even number of y. We'll
             // only build the ones alternating rows with length x, x+1, because
             // the x, x-1 one is equivant
-            int xandy = (totVertices) / 4;
+            int xandy = totVertices / 4;
             int mid = xandy / 2; // truncate
-            for (int i = 1; i < mid; i++) {
+            for (int i = 1; i < mid; ++i) {
                 int i2 = xandy - i;
                 if ((i2 % 2) == 0 && i > 1) {
                     Polyomino p;
@@ -1330,8 +1333,9 @@ CoordgenMacrocycleBuilder::buildSquaredShapes(int totVertices) const
 
 int CoordgenMacrocycleBuilder::acceptableShapeScore(int numberOfAtoms) const
 {
-    if (numberOfAtoms < 10)
+    if (numberOfAtoms < 10) {
         return 0;
-    else
+    } else {
         return numberOfAtoms * SUBSTITUTED_ATOM_RESTRAINT / 2;
+    }
 }

--- a/CoordgenMacrocycleBuilder.h
+++ b/CoordgenMacrocycleBuilder.h
@@ -164,7 +164,7 @@ class EXPORT_COORDGEN
     bool isTheSameAs(Polyomino& p) const;
 
     /*returns the number of hexagons in the polyomino*/
-    int size() const;
+    size_t size() const;
 
     /*empties the polyomino*/
     void clear();
@@ -193,8 +193,7 @@ class EXPORT_COORDGEN
     vertexCoords findOuterVertex() const;
 
     /* number of Hexs present at the given vertex*/
-    int hexagonsAtVertex(
-        vertexCoords v) const;
+    size_t hexagonsAtVertex(vertexCoords v) const;
 
 
     /*build a round-ish polyomino with the given number of vertices*/
@@ -386,7 +385,7 @@ class EXPORT_COORDGEN CoordgenMacrocycleBuilder
 
     /*return lowest period after which there is a rotation symmetry*/
     int getLowestPeriod(std::vector<int>& neighbors)
-        const; 
+        const;
 
     /*explore the given polyominoes and score them*/
     bool matchPolyominoes(std::vector<Polyomino>& pols, pathConstraints& pc,

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -26,7 +26,7 @@ static const float clashEnergyThreshold = 10;
 
 #define SAME_SIDE_DPR_PENALTY 100
 #define SAME_SIDE_DPR_PENALTY_2 50
-static const float FORCE_MULTIPLIER = 0.3;
+static const float FORCE_MULTIPLIER = 0.3f;
 
 static const float STANDARD_CROSSING_BOND_PENALTY = 2500.f;
 static const float TERMINAL_BOND_CROSSING_MULTIPLIER = 0.5f;
@@ -79,7 +79,7 @@ void CoordgenMinimizer::run()
 
 bool CoordgenMinimizer::applyForces(float maxd)
 {
-    float delta = 0.001; // minimum squared displacement
+    float delta = 0.001f; // minimum squared displacement
     float distance = 0.f;
     for (unsigned int i = 0; i < _atoms.size(); i++) {
         sketcherMinimizerAtom* atom = _atoms[i];
@@ -165,12 +165,12 @@ void CoordgenMinimizer::addClashInteractionsOfMolecule(
                     //                }
                     sketcherMinimizerClashInteraction* interaction =
                         new sketcherMinimizerClashInteraction(at1, at2, at3);
-                    float restVK = 0.8;
+                    float restVK = 0.8f;
                     if (at2->atomicNumber == 6 && at2->charge == 0)
-                        restVK -= 0.1;
+                        restVK -= 0.1f;
                     if (at1->atomicNumber == 6 && at1->charge == 0 &&
                         at3->atomicNumber == 6 && at3->charge == 0)
-                        restVK -= 0.1;
+                        restVK -= 0.1f;
 
                     interaction->restV =
                         (bondLength * restVK) * (bondLength * restVK);
@@ -193,7 +193,7 @@ void CoordgenMinimizer::addStretchInteractionsOfMolecule(
         sketcherMinimizerAtom* at2 = bo->endAtom;
         sketcherMinimizerStretchInteraction* interaction =
             new sketcherMinimizerStretchInteraction(at1, at2);
-        interaction->k *= 0.1;
+        interaction->k *= 0.1f;
         interaction->restV = bondLength;
         if (at1->rigid && at2->rigid) {
             sketcherMinimizerPointF v = at2->coordinates - at1->coordinates;
@@ -370,10 +370,10 @@ void CoordgenMinimizer::addChiralInversionConstraintsOfMolecule(
             vector<sketcherMinimizerAtom*> atoms =
                 CoordgenFragmentBuilder::orderRingAtoms(ring);
             for (unsigned int i = 0; i < atoms.size(); i++) {
-                int size = atoms.size();
-                int a1 = (i - 1 + size) % size;
-                int a11 = (i - 2 + size) % size;
-                int a2 = (i + 1) % size;
+                size_t size = atoms.size();
+                size_t a1 = (i - 1 + size) % size;
+                size_t a11 = (i - 2 + size) % size;
+                size_t a2 = (i + 1) % size;
 
                 sketcherMinimizerBond* bond =
                     sketcherMinimizer::getBond(atoms[a1], atoms[i]);
@@ -398,7 +398,7 @@ void CoordgenMinimizer::addBendInteractionsOfMolecule(
         vector<sketcherMinimizerBendInteraction*> interactions;
         vector<sketcherMinimizerBendInteraction*> ringInteractions;
         vector<sketcherMinimizerBendInteraction*> nonRingInteractions;
-        int nbonds = at->neighbors.size();
+        int nbonds = static_cast<int>(at->neighbors.size());
         bool invertedMacrocycleBond = false;
         if (nbonds > 1) {
             // order bonds so that they appear in clockwise order.
@@ -434,14 +434,14 @@ void CoordgenMinimizer::addBendInteractionsOfMolecule(
                             if (r->fusedWith[i]->isMacrocycle())
                                 continue;
                             if (r->fusionAtoms[i].size() > 2) {
-                                extraAtoms += r->fusedWith[i]->_atoms.size() -
-                                              r->fusionAtoms[i].size();
+                                extraAtoms += static_cast<int>(r->fusedWith[i]->_atoms.size() -
+                                              r->fusionAtoms[i].size());
                             }
                         }
                         interaction->isRing = true;
                         interaction->k *= 10;
-                        interaction->restV =
-                            180 - (360 / (r->size() + extraAtoms));
+                        interaction->restV = static_cast<float>(
+                            180. - (360. / (r->size() + extraAtoms)));
                         ringInteractions.push_back(interaction);
                     } else {
                         if (nbonds == 3) {
@@ -542,7 +542,7 @@ void CoordgenMinimizer::addBendInteractionsOfMolecule(
             } else if (nonRingInteractions.size() > 4) {
                 foreach (sketcherMinimizerBendInteraction* i,
                          nonRingInteractions) {
-                    i->restV = 360 / nonRingInteractions.size();
+                    i->restV = static_cast<float>(360 / nonRingInteractions.size());
                 }
             }
         }
@@ -608,7 +608,7 @@ void CoordgenMinimizer::addInteractionsOfMolecule(
 
 void CoordgenMinimizer::setupInteractionsOnlyResidues()
 {
-    const float CLASH_DISTANCE = bondLength * 1.5;
+    const float CLASH_DISTANCE = bondLength * 1.5f;
     for (auto res : _residues) {
         for (auto res2 : _residues) {
             if (res2 >= res) {
@@ -830,9 +830,9 @@ float CoordgenMinimizer::scoreCrossBonds(sketcherMinimizerMolecule* molecule,
                             r->residueInteractions[ri2]->endAtom;
                         if (sketcherMinimizerMaths::intersectionOfSegments(
                                 a1->coordinates +
-                                    a1->getSingleAdditionVector() * 0.2,
+                                    a1->getSingleAdditionVector() * 0.2f,
                                 a2->coordinates +
-                                    a2->getSingleAdditionVector() * 0.2,
+                                    a2->getSingleAdditionVector() * 0.2f,
                                 a1->coordinates, a2->coordinates)) {
                             out += 15.f;
                         }
@@ -1046,7 +1046,7 @@ bool CoordgenMinimizer::growSolutions(
 {
     std::map<std::vector<short unsigned int>, float> oldGrowingSolutions =
         growingSolutions;
-    int bestScoreForRun = bestScore;
+    float bestScoreForRun = bestScore;
     std::vector<std::pair<float, std::vector<short unsigned int>>>
         bestSolutions;
     for (auto solution : growingSolutions) {
@@ -1056,7 +1056,7 @@ bool CoordgenMinimizer::growSolutions(
     }
     sort(bestSolutions.begin(), bestSolutions.end());
     growingSolutions.clear();
-    int maxN = 6 * getPrecision();
+    int maxN = static_cast<int>(6 * getPrecision());
     if (maxN < 1)
         maxN = 1;
     int n = 0;
@@ -1266,22 +1266,22 @@ void CoordgenMinimizer::avoidInternalClashes(
             if (sketcherMinimizer::getBond(a, a2))
                 continue;
             float dx = a2->coordinates.x() - a->coordinates.x();
-            if (dx > bondLength * 0.5)
+            if (dx > bondLength * 0.5f)
                 continue;
-            if (dx < -bondLength * 0.5)
+            if (dx < -bondLength * 0.5f)
                 continue;
             float dy = a2->coordinates.y() - a->coordinates.y();
-            if (dy > bondLength * 0.5)
+            if (dy > bondLength * 0.5f)
                 continue;
-            if (dy < -bondLength * 0.5)
+            if (dy < -bondLength * 0.5f)
                 continue;
             float squareD = dx * dx + dy * dy;
-            if (squareD > bondLength * 0.5 * bondLength * 0.5)
+            if (squareD > bondLength * 0.5f * bondLength * 0.5f)
                 continue;
 
             sketcherMinimizerPointF vec =
                 a->coordinates - a->neighbors[0]->coordinates;
-            vec *= 0.3;
+            vec *= 0.3f;
             a->coordinates -= vec;
             if (a2->neighbors.size() == 1) {
                 a2->coordinates += vec;
@@ -1454,27 +1454,27 @@ void CoordgenMinimizer::checkForClashes(sketcherMinimizerAtom* a)
     vector<sketcherMinimizerPointF> coordsVect;
     coordsVect.push_back(oldCoordinates);
     coordsVect.push_back(oldCoordinates +
-                         sketcherMinimizerPointF(bondLength * 0.25, 0.f));
+                         sketcherMinimizerPointF(bondLength * 0.25f, 0.f));
     coordsVect.push_back(oldCoordinates +
-                         sketcherMinimizerPointF(-bondLength * 0.25, 0.f));
+                         sketcherMinimizerPointF(-bondLength * 0.25f, 0.f));
     coordsVect.push_back(oldCoordinates +
-                         sketcherMinimizerPointF(0.f, bondLength * 0.25));
+                         sketcherMinimizerPointF(0.f, bondLength * 0.25f));
     coordsVect.push_back(oldCoordinates +
-                         sketcherMinimizerPointF(0.f, -bondLength * 0.25));
+                         sketcherMinimizerPointF(0.f, -bondLength * 0.25f));
     coordsVect.push_back(oldCoordinates +
-                         sketcherMinimizerPointF(bondLength * 0.25 * 0.7071,
-                                                 -bondLength * 0.25 * 0.7071));
+                         sketcherMinimizerPointF(bondLength * 0.25f * 0.7071f,
+                                                 -bondLength * 0.25f * 0.7071f));
     coordsVect.push_back(oldCoordinates +
-                         sketcherMinimizerPointF(-bondLength * 0.25 * 0.7071,
-                                                 -bondLength * 0.25 * 0.7071));
+                         sketcherMinimizerPointF(-bondLength * 0.25f * 0.7071f,
+                                                 -bondLength * 0.25f * 0.7071f));
     coordsVect.push_back(oldCoordinates +
-                         sketcherMinimizerPointF(-bondLength * 0.25 * 0.7071,
-                                                 bondLength * 0.25 * 0.7071));
+                         sketcherMinimizerPointF(-bondLength * 0.25f * 0.7071f,
+                                                 bondLength * 0.25f * 0.7071f));
     coordsVect.push_back(oldCoordinates +
-                         sketcherMinimizerPointF(bondLength * 0.25 * 0.7071,
-                                                 bondLength * 0.25 * 0.7071));
-    float bestE = 999999;
-    float bestI = 0;
+                         sketcherMinimizerPointF(bondLength * 0.25f * 0.7071f,
+                                                 bondLength * 0.25f * 0.7071f));
+    float bestE = 999999.f;
+    int bestI = 0;
     for (unsigned int i = 0; i < coordsVect.size(); i++) {
         a->coordinates = coordsVect[i];
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ before_build:
   - cmake .. -G "Visual Studio 12 Win64" ^
       -DBOOST_ROOT="%BOOST_ROOT_DIR%" ^
       -DBOOST_LIBRARYDIR="%BOOST_LIBRARY_PATH%" ^
-      -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%" ^
+      -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
   - cmake --build . --target install --config Release
   - mkdir %APPVEYOR_BUILD_FOLDER%\build
   - cd %APPVEYOR_BUILD_FOLDER%\build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ before_build:
   - cmake .. -G "Visual Studio 12 Win64" ^
       -DBOOST_ROOT="%BOOST_ROOT_DIR%" ^
       -DBOOST_LIBRARYDIR="%BOOST_LIBRARY_PATH%" ^
-      -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
+      -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%" ^
   - cmake --build . --target install --config Release
   - mkdir %APPVEYOR_BUILD_FOLDER%\build
   - cd %APPVEYOR_BUILD_FOLDER%\build
@@ -34,7 +34,8 @@ before_build:
       -DBOOST_ROOT="%BOOST_ROOT_DIR%" ^
       -DBOOST_LIBRARYDIR="%BOOST_LIBRARY_PATH%" ^
       -DCMAKE_PREFIX_PATH="%CMAKE_PREFIX_PATH%" ^
-      -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
+      -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%" ^
+      -DCOORDGEN_RIGOROUS_BUILD=ON
 
 test_script:
   - set PATH=%PATH%;%BOOST_LIBRARY_PATH%;%INSTALL_PREFIX%\bin

--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -10,19 +10,18 @@
 #include "sketcherMinimizer.h"
 #include "sketcherMinimizerMaths.h"
 
-#include "sketcherMinimizerStretchInteraction.h"
-#include "sketcherMinimizerBendInteraction.h"
-#include "sketcherMinimizerClashInteraction.h"
-#include <queue>
-#include <stack>
-#include <algorithm>
 #include "CoordgenFragmenter.h"
 #include "CoordgenMacrocycleBuilder.h"
 #include "maeparser/Reader.hpp"
+#include "sketcherMinimizerBendInteraction.h"
+#include "sketcherMinimizerClashInteraction.h"
+#include "sketcherMinimizerStretchInteraction.h"
+#include <algorithm>
 #include <cstdio>
+#include <queue>
+#include <stack>
 
 using namespace std;
-
 
 #define RESIDUE_CLASH_DISTANCE_SQUARED 2.0 * 2.0
 
@@ -33,9 +32,9 @@ using namespace std;
 const int bondLength = BONDLENGTH;
 
 static const unsigned int MINIMUM_LIGAND_ATOMS = 8;
-static const float SCORE_MULTIPLIER_FOR_DOUBLE_BONDS = 0.82;
-static const float SCORE_MULTIPLIER_FOR_SINGLE_BONDED_HETEROATOMS = 0.9;
-static const float SCORE_MULTIPLIER_FOR_FRAGMENTS = 0.1;
+static const float SCORE_MULTIPLIER_FOR_DOUBLE_BONDS = 0.82f;
+static const float SCORE_MULTIPLIER_FOR_SINGLE_BONDED_HETEROATOMS = 0.9f;
+static const float SCORE_MULTIPLIER_FOR_FRAGMENTS = 0.1f;
 const int MAX_NUMBER_OF_RINGS = 40;
 
 sketcherMinimizer::sketcherMinimizer(float precision)
@@ -283,7 +282,6 @@ bool sketcherMinimizer::runGenerateCoordinates()
     return cleanPose;
 }
 
-
 void sketcherMinimizer::flagCrossAtoms()
 {
     foreach (sketcherMinimizerAtom* at, _atoms)
@@ -405,7 +403,6 @@ void sketcherMinimizer::clear()
 
     _molecules.clear();
 }
-
 
 /*
 void sketcherMinimizer::initializeFromMolecule(ChmMol& mol)
@@ -817,7 +814,7 @@ void sketcherMinimizer::maybeFlip()
                 sketcherMinimizerPointF center(0.f, 0.f);
                 sketcherMinimizerPointF weightedCenter(0.f, 0.f);
 
-                int totalN = 0;
+                size_t totalN = 0;
                 int totalRings = 0;
                 foreach (sketcherMinimizerRing* r, rings) {
                     if (r->_atoms.size() < 4)
@@ -862,17 +859,17 @@ void sketcherMinimizer::maybeFlip()
                 maxy = y;
         }
 
-        float meanx = (maxx + minx) * 0.5;
-        float meany = (maxy + miny) * 0.5;
+        float meanx = (maxx + minx) * 0.5f;
+        float meany = (maxy + miny) * 0.5f;
 
         if (meanx - cent.x() > SKETCHER_EPSILON)
-            scoreX -= 0.5;
+            scoreX -= 0.5f;
         else if (meanx - cent.x() < -SKETCHER_EPSILON)
-            scoreX += 0.5;
+            scoreX += 0.5f;
         if (meany - cent.y() > SKETCHER_EPSILON)
-            scoreY += 0.5;
+            scoreY += 0.5f;
         else if (meany - cent.y() < -SKETCHER_EPSILON)
-            scoreY -= 0.5;
+            scoreY -= 0.5f;
 
         foreach (sketcherMinimizerBond* b, mol->_bonds) {
             if (b->bondOrder == 2) {
@@ -918,7 +915,7 @@ void sketcherMinimizer::addToVector(float weight, float angle,
 {
     angle = roundToTwoDecimalDigits(angle);
     while (angle <= 0)
-        angle += M_PI;
+        angle += static_cast<float>(M_PI);
     for (unsigned int i = 0; i < angles.size(); i++) {
         if (angles[i].second < angle - SKETCHER_EPSILON) {
             if (i == angles.size() - 1) {
@@ -977,7 +974,7 @@ void sketcherMinimizer::bestRotation()
         float lastAngle;
         unsigned int i = 0, j = 0;
         float weight = 1.f;
-        float increment = M_PI / 6;
+        float increment = static_cast<float>(M_PI / 6);
         foreach (sketcherMinimizerAtom* a, mol->_atoms) {
             if (a->rings.size())
                 continue;
@@ -1016,8 +1013,9 @@ void sketcherMinimizer::bestRotation()
             angle = atan2(-p.y(), p.x());
             angle = roundToTwoDecimalDigits(angle);
 
-            while (angle <= 0)
-                angle += M_PI;
+            while (angle <= 0) {
+                angle += static_cast<float>(M_PI);
+            }
             lastAngle = angle;
             for (unsigned int i = 0; i < 6; i++) {
                 if (i == 1 || i == 5)
@@ -1037,7 +1035,7 @@ void sketcherMinimizer::bestRotation()
                 addToVector(weight, lastAngle, angles);
                 lastAngle += increment;
                 if (lastAngle > M_PI)
-                    lastAngle -= M_PI;
+                    lastAngle -= static_cast<float>(M_PI);
             }
         }
 
@@ -1046,7 +1044,7 @@ void sketcherMinimizer::bestRotation()
             vector<sketcherMinimizerRing*> rings = f->getRings();
             vector<sketcherMinimizerRing*> inPlaneRings = rings;
 
-            int ringsN = inPlaneRings.size();
+            size_t ringsN = inPlaneRings.size();
             if (ringsN == 2) {
 
                 sketcherMinimizerRing* r1 = inPlaneRings[0];
@@ -1108,7 +1106,8 @@ void sketcherMinimizer::bestRotation()
                             //  if (p.x () != p.x () || p.y () != p.y ()) p =
                             //  sketcherMinimizerPointF (50.f, 0.f);
                             sketcherMinimizerPointF rotatedP(p.y(), p.x());
-                            angle = atan2(-p.y(), p.x()) - M_PI * 0.5;
+                            angle = static_cast<float>(atan2(-p.y(), p.x()) -
+                                                       M_PI * 0.5);
                             weight = 25.f;
                             addToVector(weight, angle, angles);
                         }
@@ -1169,12 +1168,13 @@ void sketcherMinimizer::findFragments()
 void sketcherMinimizer::placeResiduesProteinOnlyModeCircleStyle(
     std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains)
 {
-    int totalResiduesNumber = _residues.size() + chains.size();
+    size_t totalResiduesNumber = _residues.size() + chains.size();
 
-    float angle = 2.f * M_PI / totalResiduesNumber;
-    const float residueRadius = 30;
-    const float circumference = totalResiduesNumber * residueRadius * 2;
-    const float radius = circumference * 0.5 / M_PI;
+    float angle = static_cast<float>(2.f * M_PI / totalResiduesNumber);
+    const float residueRadius = 30.f;
+    const float circumference =
+        static_cast<float>(totalResiduesNumber * residueRadius * 2);
+    const float radius = static_cast<float>(circumference * 0.5 / M_PI);
     int i = 0;
     for (auto chain : chains) {
         ++i; // gap between chains
@@ -1284,7 +1284,6 @@ void sketcherMinimizer::shortenInteractions(
     }
 }
 
-
 std::vector<sketcherMinimizerResidue*> sketcherMinimizer::orderResiduesOfChains(
     std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains)
 {
@@ -1294,11 +1293,12 @@ std::vector<sketcherMinimizerResidue*> sketcherMinimizer::orderResiduesOfChains(
             vec.push_back(res);
         }
     }
-    sort(vec.begin(), vec.end(), [](const sketcherMinimizerResidue* firstRes,
-                                    const sketcherMinimizerResidue* secondRes) {
-        return firstRes->residueInteractions.size() >
-               secondRes->residueInteractions.size();
-    });
+    sort(vec.begin(), vec.end(),
+         [](const sketcherMinimizerResidue* firstRes,
+            const sketcherMinimizerResidue* secondRes) {
+             return firstRes->residueInteractions.size() >
+                    secondRes->residueInteractions.size();
+         });
     std::set<sketcherMinimizerResidue*> visitedResidues;
     std::queue<sketcherMinimizerResidue*> residueQueue;
     std::vector<sketcherMinimizerResidue*> finalVec;
@@ -1400,12 +1400,12 @@ void sketcherMinimizer::placeResiduesInCrowns()
                  interactionsOfSecond += res->residueInteractions.size();
              }
              float interactionScaling = 3.f;
-             float score1 =
-                 firstSSE.size() +
-                 interactionScaling * interactionsOfFirst / firstSSE.size();
-             float score2 =
-                 secondSSE.size() +
-                 interactionScaling * interactionsOfSecond / secondSSE.size();
+             float score1 = firstSSE.size() + interactionScaling *
+                                                  interactionsOfFirst /
+                                                  firstSSE.size();
+             float score2 = secondSSE.size() + interactionScaling *
+                                                   interactionsOfSecond /
+                                                   secondSSE.size();
              return score1 > score2;
          });
     bool needOtherShape = true;
@@ -1445,7 +1445,6 @@ float sketcherMinimizer::scoreSSEBondStretch(
     return squaredLength * stretchPenalty;
 }
 
-
 float sketcherMinimizer::getResidueDistance(
     float startF, float increment, sketcherMinimizerResidue* resToConsider,
     vector<sketcherMinimizerResidue*> SSE)
@@ -1454,12 +1453,13 @@ float sketcherMinimizer::getResidueDistance(
     sketcherMinimizerResidue* lastRes = nullptr;
     for (auto res : SSE) {
         if (lastRes) {
-            float result = res->resnum - lastRes->resnum;
+            float result = static_cast<float>(res->resnum - lastRes->resnum);
             /*if the gap is more than 1, make the distance a bit smaller for
              * aesthetic reasons*/
-            result = 1 + (result - 1) * 0.8;
-            if (result < 1.f)
+            result = static_cast<float>(1 + (result - 1) * 0.8);
+            if (result < 1.f) {
                 result = 1.f;
+            }
             totalF += increment * result;
         }
         if (res == resToConsider)
@@ -1582,7 +1582,6 @@ void sketcherMinimizer::placeSSE(vector<sketcherMinimizerResidue*> SSE,
     }
 }
 
-
 void sketcherMinimizer::markSolution(
     pair<float, float> solution, vector<sketcherMinimizerResidue*> SSE,
     const vector<sketcherMinimizerPointF>& shape, vector<bool>& penalties,
@@ -1625,11 +1624,13 @@ int sketcherMinimizer::getShapeIndex(vector<sketcherMinimizerPointF> shape,
                                      float floatPosition)
 {
     float normalizedF = floatPosition;
-    while (normalizedF < 0)
+    while (normalizedF < 0) {
         normalizedF += 1.f;
-    while (normalizedF >= 1.f)
+    }
+    while (normalizedF >= 1.f) {
         normalizedF -= 1.f;
-    int counter = shape.size() * normalizedF;
+    }
+    int counter = static_cast<int>(shape.size() * normalizedF);
     return counter;
 }
 
@@ -1759,10 +1760,11 @@ vector<sketcherMinimizerPointF> sketcherMinimizer::shapeAroundLigand(int crownN)
     ms.setThreshold(0);
     ms.run();
     auto result = ms.getOrderedCoordinatesPoints();
-    sort(result.begin(), result.end(), [](const vector<float>& firstContour,
-                                          const vector<float>& secondContour) {
-        return firstContour.size() > secondContour.size();
-    });
+    sort(result.begin(), result.end(),
+         [](const vector<float>& firstContour,
+            const vector<float>& secondContour) {
+             return firstContour.size() > secondContour.size();
+         });
     vector<sketcherMinimizerPointF> returnValue;
     if (result.size() > 0) {
         for (unsigned int i = 0; i < result.at(0).size(); i += 2) {
@@ -1775,7 +1777,7 @@ vector<sketcherMinimizerPointF> sketcherMinimizer::shapeAroundLigand(int crownN)
 
 float sketcherMinimizer::scoreResiduePosition(
     int index, const vector<sketcherMinimizerPointF>& shape, int shapeN,
-    vector<bool>& , sketcherMinimizerResidue* residue)
+    vector<bool>&, sketcherMinimizerResidue* residue)
 {
     auto position = shape.at(index);
     float distancePenalty = 0.01f;
@@ -2155,7 +2157,7 @@ void sketcherMinimizer::rotateMoleculesWithProximityRelations(
             sketcherMinimizerPointF p3 = direction;
             float rotationAngle = sketcherMinimizerMaths::signedAngle(
                 p1, sketcherMinimizerPointF(0, 0), p3);
-            rotationAngle *= -M_PI / 180.f;
+            rotationAngle *= static_cast<float>(-M_PI / 180.f);
             float s = sin(rotationAngle);
             float c = cos(rotationAngle);
 
@@ -2190,7 +2192,7 @@ void sketcherMinimizer::translateMoleculesWithProximityRelations(
     vector<sketcherMinimizerMolecule*>& proximityMols,
     map<sketcherMinimizerMolecule*, sketcherMinimizerAtom*>& molMap,
     map<sketcherMinimizerMolecule*, sketcherMinimizerPointF>& templateCenters,
-    vector<proximityData>& )
+    vector<proximityData>&)
 {
 
     // placing
@@ -2501,10 +2503,9 @@ void sketcherMinimizer::placeMolResidueLigandStyle(
         sketcherMinimizerPointF startingPos = parentV + parentAdditionV;
         startingPos = exploreGridAround(startingPos, 15, 10);
 
-        float angle = sketcherMinimizerMaths::signedAngle(
-                          startingPos - parentV, sketcherMinimizerPointF(0, 0),
-                          -additionV) /
-                      180 * M_PI;
+        float signedAngle = sketcherMinimizerMaths::signedAngle(
+            startingPos - parentV, sketcherMinimizerPointF(0, 0), -additionV);
+        float angle = static_cast<float>(signedAngle / 180 * M_PI);
         float s = sin(angle);
         float c = cos(angle);
 
@@ -2621,11 +2622,10 @@ void sketcherMinimizer::arrangeMultipleMolecules()
             placeMoleculesWithProximityRelations(proximityMols);
         } else {
             int maxI = 0;
-            maxI = 0;
-            int maxSize = _molecules[0]->_atoms.size();
+            size_t maxSize = _molecules[0]->_atoms.size();
             for (unsigned int i = 0; i < _molecules.size(); i++) {
                 sketcherMinimizerMolecule* m = _molecules[i];
-                int size = m->_atoms.size();
+                size_t size = m->_atoms.size();
                 if (size > maxSize) {
                     maxI = i;
                     maxSize = size;
@@ -2779,7 +2779,6 @@ void sketcherMinimizer::initializeFragments()
     foreach (sketcherMinimizerFragment* f, _fragments) {
         m_fragmentBuilder.initializeCoordinates(f);
     }
-
 
     foreach (sketcherMinimizerFragment* indf, _independentFragments) {
         assignLongestChainFromHere(indf); // recursively assign it to children
@@ -2985,9 +2984,9 @@ void sketcherMinimizer::alignWithParentDirection(
 void sketcherMinimizer::assignNumberOfChildrenAtomsFromHere(
     sketcherMinimizerFragment* f)
 {
-    float cumulatedNumberOfAtoms = 0;
+    size_t cumulatedNumberOfAtoms = 0;
     float cumulatedNumberOfAtomsRanks = 0;
-    float childrenAtoms = 0;
+    size_t childrenAtoms = 0;
     foreach (sketcherMinimizerFragment* child, f->_children) {
         assignNumberOfChildrenAtomsFromHere(child);
         cumulatedNumberOfAtoms += child->numberOfChildrenAtoms;
@@ -2996,7 +2995,7 @@ void sketcherMinimizer::assignNumberOfChildrenAtomsFromHere(
     }
     f->numberOfChildrenAtoms = cumulatedNumberOfAtoms + childrenAtoms;
     f->numberOfChildrenAtomsRank =
-        0.01f * cumulatedNumberOfAtomsRanks + childrenAtoms;
+        static_cast<float>(0.01f * cumulatedNumberOfAtomsRanks + childrenAtoms);
 }
 
 void sketcherMinimizer::assignLongestChainFromHere(sketcherMinimizerFragment* f)
@@ -3031,56 +3030,62 @@ sketcherMinimizerAtom*
 sketcherMinimizer::pickBestAtom(vector<sketcherMinimizerAtom*>& atoms)
 {
 
-    vector<sketcherMinimizerAtom *> candidates, oldCandidates;
+    vector<sketcherMinimizerAtom*> candidates, oldCandidates;
 
-    int biggestSize = atoms[0]->fragment->numberOfChildrenAtoms;
-    foreach (sketcherMinimizerAtom* a, atoms) {
-        int size = a->fragment->numberOfChildrenAtoms;
-        if (size == biggestSize) {
-            candidates.push_back(a);
-        } else if (size > biggestSize) {
-            biggestSize = size;
-            candidates.clear();
-            candidates.push_back(a);
+    {
+        size_t biggestSize = atoms[0]->fragment->numberOfChildrenAtoms;
+        foreach (sketcherMinimizerAtom* a, atoms) {
+            size_t size = a->fragment->numberOfChildrenAtoms;
+            if (size == biggestSize) {
+                candidates.push_back(a);
+            } else if (size > biggestSize) {
+                biggestSize = size;
+                candidates.clear();
+                candidates.push_back(a);
+            }
         }
+        if (candidates.size() == 1)
+            return candidates[0];
+        oldCandidates = candidates;
+        candidates.clear();
     }
-    if (candidates.size() == 1)
-        return candidates[0];
-    oldCandidates = candidates;
-    candidates.clear();
 
-    biggestSize = oldCandidates[0]->fragment->numberOfChildrenAtomsRank;
-    foreach (sketcherMinimizerAtom* a, oldCandidates) {
-        int size = a->fragment->numberOfChildrenAtomsRank;
-        if (size == biggestSize) {
-            candidates.push_back(a);
-        } else if (size > biggestSize) {
-            biggestSize = size;
-            candidates.clear();
-            candidates.push_back(a);
+    {
+        float biggestSize =
+            oldCandidates[0]->fragment->numberOfChildrenAtomsRank;
+        foreach (sketcherMinimizerAtom* a, oldCandidates) {
+            float size = a->fragment->numberOfChildrenAtomsRank;
+            if (size == biggestSize) {
+                candidates.push_back(a);
+            } else if (size > biggestSize) {
+                biggestSize = size;
+                candidates.clear();
+                candidates.push_back(a);
+            }
         }
+        if (candidates.size() == 1)
+            return candidates[0];
+        oldCandidates = candidates;
+        candidates.clear();
     }
-    if (candidates.size() == 1)
-        return candidates[0];
-    oldCandidates = candidates;
-    candidates.clear();
 
-    biggestSize = oldCandidates[0]->atomicNumber;
-    foreach (sketcherMinimizerAtom* a, oldCandidates) {
-        int size = a->atomicNumber;
-        if (size == biggestSize) {
-            candidates.push_back(a);
-        } else if (size > biggestSize) {
-            biggestSize = size;
-            candidates.clear();
-            candidates.push_back(a);
+    {
+        int biggestSize = oldCandidates[0]->atomicNumber;
+        foreach (sketcherMinimizerAtom* a, oldCandidates) {
+            int size = a->atomicNumber;
+            if (size == biggestSize) {
+                candidates.push_back(a);
+            } else if (size > biggestSize) {
+                biggestSize = size;
+                candidates.clear();
+                candidates.push_back(a);
+            }
         }
+        if (candidates.size() == 1)
+            return candidates[0];
+        oldCandidates = candidates;
+        candidates.clear();
     }
-    if (candidates.size() == 1)
-        return candidates[0];
-    oldCandidates = candidates;
-    candidates.clear();
-
     // give up
     return oldCandidates[0];
 }
@@ -3162,7 +3167,7 @@ float sketcherMinimizer::RMSD(vector<sketcherMinimizerPointF> templates,
                               vector<sketcherMinimizerPointF> points)
 {
     assert(templates.size() == points.size());
-    int counter = templates.size();
+    size_t counter = templates.size();
     float total = 0.f;
     for (unsigned int i = 0; i < templates.size(); i++) {
         //        cerr << templates[i].x () << ", "<< templates[i].y () << "
@@ -3170,8 +3175,9 @@ float sketcherMinimizer::RMSD(vector<sketcherMinimizerPointF> templates,
         sketcherMinimizerPointF diff = templates[i] - points[i];
         total += diff.x() * diff.x() + diff.y() * diff.y();
     }
-    if (counter > 0)
+    if (counter > 0) {
         total /= counter;
+    }
     return sqrt(total);
 }
 
@@ -3217,7 +3223,7 @@ void sketcherMinimizer::svd(float* a, float* U, float* Sig, float* V)
     Su[2] = a[2] * a1[0] + a[3] * a1[2];
     Su[3] = a[2] * a1[1] + a[3] * a1[3];
 
-    float phi = 0.5 * atan2(Su[1] + Su[2], Su[0] - Su[3]);
+    float phi = static_cast<float>(0.5 * atan2(Su[1] + Su[2], Su[0] - Su[3]));
     float cphi = cos(phi);
     cphi = roundToTwoDecimalDigits(cphi);
     float sphi = sin(phi);
@@ -3234,7 +3240,7 @@ void sketcherMinimizer::svd(float* a, float* U, float* Sig, float* V)
     Sw[2] = a1[2] * a[0] + a1[3] * a[2];
     Sw[3] = a1[2] * a[1] + a1[3] * a[3];
 
-    float theta = 0.5 * atan2(Sw[1] + Sw[2], Sw[0] - Sw[3]);
+    float theta = static_cast<float>(0.5 * atan2(Sw[1] + Sw[2], Sw[0] - Sw[3]));
     float ctheta = cos(theta);
     float stheta = sin(theta);
 
@@ -3245,12 +3251,12 @@ void sketcherMinimizer::svd(float* a, float* U, float* Sig, float* V)
     W[3] = ctheta;
 
     float SUsum = Su[0] + Su[3];
-    float SUdif = sqrt((Su[0] - Su[3]) * (Su[0] - Su[3]) + 4 * Su[1] * Su[2]);
+    float SUdif = sqrt((Su[0] - Su[3]) * (Su[0] - Su[3]) + 4.f * Su[1] * Su[2]);
 
-    Sig[0] = sqrt((SUsum + SUdif) * 0.5);
+    Sig[0] = sqrt((SUsum + SUdif) * 0.5f);
     Sig[1] = 0.f;
     Sig[2] = 0.f;
-    Sig[3] = sqrt((SUsum - SUdif) * 0.5);
+    Sig[3] = sqrt((SUsum - SUdif) * 0.5f);
 
     float U1[4];
     U1[0] = U[0];
@@ -3312,25 +3318,25 @@ bool sketcherMinimizer::compare(vector<sketcherMinimizerAtom*> atoms,
     if (molIter != templateIter)
         return false;
 
-    unsigned int size = atoms.size();
+    size_t size = atoms.size();
     vector<bool> matrix(size * size, false);
 
     vector<sketcherMinimizerPointF> templateCoordinates;
-    vector<vector<int>> molBonds;
-    vector<vector<int>> templateBonds;
+    vector<vector<size_t>> molBonds;
+    vector<vector<size_t>> templateBonds;
 
     //   vector < vector < int > > templateAllowedZChains; //for double bond
     //   chirality
-    vector<vector<int>> molCisTransChains;
+    vector<vector<size_t>> molCisTransChains;
     vector<bool> molIsCis;
 
     for (unsigned int ma = 0; ma < size; ma++) {
-        vector<int> vec;
+        vector<size_t> vec;
         molBonds.push_back(vec);
     }
 
     for (unsigned int ta = 0; ta < size; ta++) {
-        vector<int> vec;
+        vector<size_t> vec;
         templateBonds.push_back(vec);
     }
 
@@ -3399,7 +3405,7 @@ bool sketcherMinimizer::compare(vector<sketcherMinimizerAtom*> atoms,
                     isCis = !isCis;
                 if (endN != endA)
                     isCis = !isCis;
-                vector<int> chain;
+                vector<size_t> chain;
                 chain.push_back(startN->_generalUseN);
                 chain.push_back(b->startAtom->_generalUseN);
                 chain.push_back(b->endAtom->_generalUseN);
@@ -3412,8 +3418,8 @@ bool sketcherMinimizer::compare(vector<sketcherMinimizerAtom*> atoms,
     }
     // assuming that _generalUseN is set as the index of each atom
     for (unsigned int mb = 0; mb < bonds.size(); mb++) {
-        int in1 = bonds[mb]->startAtom->_generalUseN;
-        int in2 = bonds[mb]->endAtom->_generalUseN;
+        size_t in1 = bonds[mb]->startAtom->_generalUseN;
+        size_t in2 = bonds[mb]->endAtom->_generalUseN;
 
         if (in1 < in2) {
             molBonds[in2].push_back(in1);
@@ -3422,8 +3428,8 @@ bool sketcherMinimizer::compare(vector<sketcherMinimizerAtom*> atoms,
         }
     }
     for (unsigned int tb = 0; tb < templ->_bonds.size(); tb++) {
-        int in1 = templ->_bonds[tb]->startAtom->_generalUseN;
-        int in2 = templ->_bonds[tb]->endAtom->_generalUseN;
+        size_t in1 = templ->_bonds[tb]->startAtom->_generalUseN;
+        size_t in2 = templ->_bonds[tb]->endAtom->_generalUseN;
         if (in1 < in2) {
             templateBonds[in2].push_back(in1);
         } else {
@@ -3454,9 +3460,9 @@ bool sketcherMinimizer::compare(vector<sketcherMinimizerAtom*> atoms,
 void sketcherMinimizer::checkIdentity(
     vector<unsigned int> solution, int newSol, vector<bool>& matrix,
     vector<sketcherMinimizerPointF>& templateCoordinates,
-    vector<vector<int>>& molBonds, vector<vector<int>>& templateBonds,
-    vector<vector<int>>& molCisTransChains, vector<bool>& molIsCis,
-    unsigned int size, bool& found, vector<unsigned int>& mapping)
+    vector<vector<size_t>>& molBonds, vector<vector<size_t>>& templateBonds,
+    vector<vector<size_t>>& molCisTransChains, vector<bool>& molIsCis,
+    size_t size, bool& found, vector<unsigned int>& mapping)
 {
     solution.push_back(newSol);
     if (solution.size() == size) {
@@ -3501,10 +3507,10 @@ void sketcherMinimizer::checkIdentity(
                 for (unsigned int bi = 0; bi < molBonds[solution.size()].size();
                      bi++) {
                     check = false;
-                    int high = i;
-                    int low = solution[molBonds[solution.size()][bi]];
+                    size_t high = i;
+                    size_t low = solution[molBonds[solution.size()][bi]];
                     if (low > high) {
-                        int swap = low;
+                        size_t swap = low;
                         low = high;
                         high = swap;
                     }
@@ -3533,7 +3539,6 @@ void sketcherMinimizer::setTemplateFileDir(string dir)
     sketcherMinimizer::m_templates.setTemplateDir(dir);
 }
 
-
 static string getTempFileProjDir()
 {
     return sketcherMinimizer::m_templates.getTemplateDir();
@@ -3548,8 +3553,9 @@ static string getUserTemplateFileName()
 static void loadTemplate(const string& filename,
                          vector<sketcherMinimizerMolecule*>& templates)
 {
-    auto pFile = fopen (filename.c_str(), "r");
-    if (pFile == nullptr) return;
+    auto pFile = fopen(filename.c_str(), "r");
+    if (pFile == nullptr)
+        return;
     schrodinger::mae::Reader r(pFile);
     std::shared_ptr<schrodinger::mae::Block> b;
     while ((b = r.next("f_m_ct")) != nullptr) {
@@ -3559,21 +3565,23 @@ static void loadTemplate(const string& filename,
         {
             const auto atom_data = b->getIndexedBlock("m_atom");
             // All atoms are gauranteed to have these three field names:
-            const auto atomic_numbers = atom_data->getIntProperty("i_m_atomic_number");
+            const auto atomic_numbers =
+                atom_data->getIntProperty("i_m_atomic_number");
             const auto xs = atom_data->getRealProperty("r_m_x_coord");
             const auto ys = atom_data->getRealProperty("r_m_y_coord");
             const auto size = atomic_numbers->size();
 
             // atomic numbers, and x, y, and z coordinates
-            for (size_t i=0; i<size; ++i) {
+            for (size_t i = 0; i < size; ++i) {
                 auto atom = new sketcherMinimizerAtom();
-                atom->coordinates = sketcherMinimizerPointF (xs->at(i), ys->at(i));
+                atom->coordinates =
+                    sketcherMinimizerPointF(static_cast<float>(xs->at(i)),
+                                            static_cast<float>(ys->at(i)));
                 atom->atomicNumber = atomic_numbers->at(i);
                 atom->_generalUseN = atomCounter++;
                 molecule->_atoms.push_back(atom);
             }
         }
-
 
         // Bond data is in the m_bond indexed block
         {
@@ -3584,7 +3592,7 @@ static void loadTemplate(const string& filename,
             auto orders = bond_data->getIntProperty("i_m_order");
             const auto size = from_atoms->size();
 
-            for (size_t i=0; i<size; ++i) {
+            for (size_t i = 0; i < size; ++i) {
                 // Maestro atoms are 1 indexed!
                 const auto from_atom = from_atoms->at(i) - 1;
                 const auto to_atom = to_atoms->at(i) - 1;
@@ -3595,7 +3603,6 @@ static void loadTemplate(const string& filename,
                 bond->endAtom = molecule->_atoms.at(to_atom);
                 bond->bondOrder = order;
                 molecule->_bonds.push_back(bond);
-
             }
         }
 
@@ -3608,7 +3615,7 @@ static void loadTemplate(const string& filename,
         vector<int> ns;
         for (unsigned int i = 0; i < mol->_bonds.size(); i++) {
             sketcherMinimizerPointF v = mol->_bonds[i]->startAtom->coordinates -
-            mol->_bonds[i]->endAtom->coordinates;
+                                        mol->_bonds[i]->endAtom->coordinates;
             float dd = v.x() * v.x() + v.y() * v.y();
             bool found = false;
             for (unsigned int j = 0; j < dds.size(); j++) {
@@ -3638,11 +3645,6 @@ static void loadTemplate(const string& filename,
             }
         }
     }
-
-
-
-
-
 }
 
 void sketcherMinimizer::loadTemplates()
@@ -3650,7 +3652,7 @@ void sketcherMinimizer::loadTemplates()
     static int loaded = 0;
     if (loaded || m_templates.getTemplates().size())
         return;
-    string filename =getTempFileProjDir() + "templates.mae";
+    string filename = getTempFileProjDir() + "templates.mae";
 
     loadTemplate(filename, m_templates.getTemplates());
 
@@ -3672,9 +3674,9 @@ int sketcherMinimizer::morganScores(vector<sketcherMinimizerAtom*> atoms,
     vector<int> orderedScores;
     bool goOn = false;
     int n = 0;
-    int idx1, idx2;
-    int oldTies = atoms.size();
-    int newTies = oldTies;
+    size_t idx1, idx2;
+    size_t oldTies = atoms.size();
+    size_t newTies = oldTies;
     unsigned int i = 0, j = 0;
     do {
         n++;

--- a/sketcherMinimizer.h
+++ b/sketcherMinimizer.h
@@ -9,32 +9,31 @@
 #define sketcherMINIMIZER
 
 #include <map>
-#include <vector>
 #include <stack>
+#include <vector>
 
 #include "sketcherMinimizerAtom.h"
 #include "sketcherMinimizerBond.h"
 #include "sketcherMinimizerResidue.h"
 #include "sketcherMinimizerResidueInteraction.h"
 
-#include "sketcherMinimizerStretchInteraction.h"
-#include "sketcherMinimizerClashInteraction.h"
 #include "sketcherMinimizerBendInteraction.h"
+#include "sketcherMinimizerClashInteraction.h"
+#include "sketcherMinimizerStretchInteraction.h"
 
 #include "sketcherMinimizerFragment.h"
+#include "sketcherMinimizerMarchingSquares.h"
 #include "sketcherMinimizerMolecule.h"
 #include "sketcherMinimizerRing.h"
-#include "sketcherMinimizerMarchingSquares.h"
 #include <iostream>
 
-
+#include "CoordgenConfig.hpp"
 #include "CoordgenFragmentBuilder.h"
 #include "CoordgenMinimizer.h"
-#include "CoordgenConfig.hpp"
 
 static const float SKETCHER_STANDARD_PRECISION = 1.f;
-static const float SKETCHER_QUICK_PRECISION = 0.2;
-static const float SKETCHER_BEST_PRECISION = 3;
+static const float SKETCHER_QUICK_PRECISION = 0.2f;
+static const float SKETCHER_BEST_PRECISION = 3.f;
 
 class sketcherAtom;
 class sketcherBond;
@@ -47,9 +46,8 @@ typedef struct {
     std::vector<int> counters;
 } proximityData;
 
-
 /*class to handle templates of common difficult ring structures*/
-class  CoordgenTemplates
+class CoordgenTemplates
 {
   public:
     CoordgenTemplates() {}
@@ -77,17 +75,12 @@ class  CoordgenTemplates
             m_templateDir += "/";
         }
     }
-    std::string getTemplateDir()
-    {
-        return m_templateDir;
-    }
-
+    std::string getTemplateDir() { return m_templateDir; }
 
   private:
     std::vector<sketcherMinimizerMolecule*> m_templates;
     std::string m_templateDir = "";
 };
-
 
 /*main class. Creates 2d coordinates for molecular inputs*/
 class EXPORT_COORDGEN sketcherMinimizer
@@ -105,7 +98,8 @@ class EXPORT_COORDGEN sketcherMinimizer
     bool runGenerateCoordinates();
 
     /*
-     return true if the molecules structure is reasonable (e.g. reasonable amount of fused rings)
+     return true if the molecules structure is reasonable (e.g. reasonable
+     amount of fused rings)
      */
     bool structurePassSanityCheck() const;
 
@@ -119,10 +113,11 @@ class EXPORT_COORDGEN sketcherMinimizer
      */
     void initialize(sketcherMinimizerMolecule* minMol);
 
-    /*put atoms in a canonical order to reduce dependency from order in the input vector */
+    /*put atoms in a canonical order to reduce dependency from order in the
+     * input vector */
     static void canonicalOrdering(sketcherMinimizerMolecule* minMol);
 
-   // void initializeFromMolecule(ChmMol& mol);
+    // void initializeFromMolecule(ChmMol& mol);
 
     /*if mol contains separate molecules, split them into a vector*/
     void splitIntoMolecules(sketcherMinimizerMolecule* mol,
@@ -134,18 +129,17 @@ class EXPORT_COORDGEN sketcherMinimizer
     /*assign coordinates to all molecules and residues*/
     void minimizeAll();
 
-
     /*assign coordinates to given molecule*/
     void minimizeMolecule(sketcherMinimizerMolecule* molecule);
 
     /*find the best angle to rotate each molecule*/
     void bestRotation();
 
-    /*add info to choose the best angle so that, if present, peptide chains are horizontal*/
+    /*add info to choose the best angle so that, if present, peptide chains are
+     * horizontal*/
     void
     addBestRotationInfoForPeptides(std::vector<std::pair<float, float>>& angles,
                                    std::vector<sketcherMinimizerAtom*> atoms);
-
 
     /*if a peptide chain is present make sure that the N term is on the left*/
     void maybeFlipPeptides(std::vector<sketcherMinimizerAtom*> atoms,
@@ -154,7 +148,8 @@ class EXPORT_COORDGEN sketcherMinimizer
     /*consider flipping the molecule horizontaly and/or vertically*/
     void maybeFlip();
 
-    /*mark atoms with wedges as above or below the plane to correctly draw crossing bonds*/
+    /*mark atoms with wedges as above or below the plane to correctly draw
+     * crossing bonds*/
     void assignPseudoZ();
 
     /*write wedges and dashed bonds to mark stereochemistry*/
@@ -163,7 +158,8 @@ class EXPORT_COORDGEN sketcherMinimizer
     /*arrange multiple molecules next to each other*/
     void arrangeMultipleMolecules();
 
-    /*arrange molecules that have parts that interact with each other so that they are close*/
+    /*arrange molecules that have parts that interact with each other so that
+     * they are close*/
     void placeMoleculesWithProximityRelations(
         std::vector<sketcherMinimizerMolecule*> proximityMols);
 
@@ -221,18 +217,17 @@ class EXPORT_COORDGEN sketcherMinimizer
                               sketcherMinimizerPointF coordinates2);
 
     /*return the position of res, which is part of SSE, given that the
-     first residue of SSE is placed at startF and consecutive residues are placed
-     increment away from each other. All distances are expressed in floats, where
-     0.f is
-     an arbitrary starting point, 0.5 is the opposite side of the curve and 1.0 is
-     again
-     the starting point*/
+     first residue of SSE is placed at startF and consecutive residues are
+     placed increment away from each other. All distances are expressed in
+     floats, where 0.f is an arbitrary starting point, 0.5 is the opposite side
+     of the curve and 1.0 is again the starting point*/
     float getResidueDistance(float startF, float increment,
                              sketcherMinimizerResidue* res,
                              std::vector<sketcherMinimizerResidue*> SSE);
 
     /*return the vector index corresponding to floatPosition*/
-    int getShapeIndex(std::vector<sketcherMinimizerPointF> shape, float floatPosition);
+    int getShapeIndex(std::vector<sketcherMinimizerPointF> shape,
+                      float floatPosition);
 
     /*solution represent the placement chosen for residues in SSE. Mark the
      corresponding
@@ -266,12 +261,10 @@ class EXPORT_COORDGEN sketcherMinimizer
      interaction diagram*/
     void placeResiduesProteinOnlyMode();
 
-
     /*assign coordinates to residues in a protein-protein interaction
      diagram shaped as a circle*/
     void placeResiduesProteinOnlyModeCircleStyle(
         std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains);
-
 
     /*assign coordinates to residues in a protein-protein interaction
      diagram shaped as a LID*/
@@ -279,23 +272,21 @@ class EXPORT_COORDGEN sketcherMinimizer
         std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains);
 
     /*
-     order residues for drawing, so that residues interacting together are drawn one
-     after the other and
-     residues with more interactions are drawn first
+     order residues for drawing, so that residues interacting together are drawn
+     one after the other and residues with more interactions are drawn first
      */
     std::vector<sketcherMinimizerResidue*> orderResiduesOfChains(
         std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains);
 
-
-    /*find center position for each chain of residues using a meta-molecule approach,
-     building a molecule where each atom represents a chain and each bond connects
-     two interacting chains*/
+    /*find center position for each chain of residues using a meta-molecule
+     approach, building a molecule where each atom represents a chain and each
+     bond connects two interacting chains*/
     std::map<std::string, sketcherMinimizerPointF>
     computeChainsStartingPositionsMetaMol(
         std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains);
 
-    /*place interacting residues closer to each other, so they end up at the perifery
-     of the chain*/
+    /*place interacting residues closer to each other, so they end up at the
+     perifery of the chain*/
     void shortenInteractions(
         std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains);
 
@@ -311,22 +302,19 @@ class EXPORT_COORDGEN sketcherMinimizer
                                                unsigned int levels, float gridD,
                                                float distanceFromAtoms = -1.f);
 
-
     /*add given angle to a vector of angles, clustering them
      if a close angle is already in the vector*/
     void addToVector(float weight, float angle,
                      std::vector<std::pair<float, float>>& angles);
 
-
-    /*return a score of the alignment between direction and templat.first, weight on the
-     angle between the two and templat.second*/
+    /*return a score of the alignment between direction and templat.first,
+     weight on the angle between the two and templat.second*/
     static float
     testAlignment(sketcherMinimizerPointF direction,
                   std::pair<sketcherMinimizerPointF, float> templat);
 
-
-    /*find the best alignment of a fragment to its parent and set invert in case the fragment
-     needs to be flipped*/
+    /*find the best alignment of a fragment to its parent and set invert in case
+     the fragment needs to be flipped*/
     static sketcherMinimizerPointF scoreDirections(
         sketcherMinimizerFragment* fragment, float angle,
         std::vector<std::pair<sketcherMinimizerPointF, float>> directions,
@@ -343,7 +331,8 @@ class EXPORT_COORDGEN sketcherMinimizer
                                         sketcherMinimizerPointF position,
                                         float angle);
 
-    /*align the fragment to its parent in the case of unconstrained coordinates*/
+    /*align the fragment to its parent in the case of unconstrained
+     * coordinates*/
     static bool
     alignWithParentDirectionUnconstrained(sketcherMinimizerFragment* fragment,
                                           float angle);
@@ -352,12 +341,12 @@ class EXPORT_COORDGEN sketcherMinimizer
     static std::vector<sketcherMinimizerBond*>
     getAllTerminalBonds(sketcherMinimizerFragment* fragment);
 
-    /*return a list of vectors the given fragment can be aligned with and a score of 
-     the importance of each*/
+    /*return a list of vectors the given fragment can be aligned with and a
+     score of the importance of each*/
     static std::vector<std::pair<sketcherMinimizerPointF, float>>
     findDirectionsToAlignWith(sketcherMinimizerFragment* fragment);
 
-    std::vector<sketcherMinimizerAtom*> getAtoms() {return _atoms;}
+    std::vector<sketcherMinimizerAtom*> getAtoms() { return _atoms; }
 
     std::vector<sketcherMinimizerAtom*> _atoms;
     std::vector<sketcherMinimizerAtom*> _referenceAtoms;
@@ -376,7 +365,7 @@ class EXPORT_COORDGEN sketcherMinimizer
     void assignLongestChainFromHere(sketcherMinimizerFragment* f);
     void assignNumberOfChildrenAtomsFromHere(sketcherMinimizerFragment* f);
 
-//    void exportCoordinates(ChmMol& molecule);
+    //    void exportCoordinates(ChmMol& molecule);
 
     /*split molecules into rigid fragments*/
     void findFragments();
@@ -390,19 +379,19 @@ class EXPORT_COORDGEN sketcherMinimizer
     /*constrain coordinates on atoms corresponding to true*/
     void constrainAtoms(std::vector<bool> constrained);
 
-    /*fix cooordinates (i.e. guarantee they will not change) on atoms marked as true*/
+    /*fix cooordinates (i.e. guarantee they will not change) on atoms marked as
+     * true*/
     void fixAtoms(std::vector<bool> fixed);
 
     /*set a flag to enable/disable the scoring of interactions with residues*/
     void setScoreResidueInteractions(bool b);
 
     /*
-     pick one atom out of the vector. Arbitrary criteria such as atomic number and connectivity
-     are used
+     pick one atom out of the vector. Arbitrary criteria such as atomic number
+     and connectivity are used
      */
     static sketcherMinimizerAtom*
     pickBestAtom(std::vector<sketcherMinimizerAtom*>& atoms);
-
 
     /*if the three atoms share a ring, return it*/
     static sketcherMinimizerRing* sameRing(const sketcherMinimizerAtom* at1,
@@ -428,9 +417,7 @@ class EXPORT_COORDGEN sketcherMinimizer
 
     /* singular value decomposition for 2x2 matrices.
      used for 2D alignment.*/
-    static void svd(float* a, float* U, float* Sig,
-                    float* V);
-
+    static void svd(float* a, float* U, float* Sig, float* V);
 
     /*set m to a rotation matrix to align ref to points*/
     static void alignmentMatrix(std::vector<sketcherMinimizerPointF> ref,
@@ -441,14 +428,14 @@ class EXPORT_COORDGEN sketcherMinimizer
     checkIdentity(std::vector<unsigned int> solution, int newSol,
                   std::vector<bool>& matrix,
                   std::vector<sketcherMinimizerPointF>& templateCoordinates,
-                  std::vector<std::vector<int>>& molBonds,
-                  std::vector<std::vector<int>>& templateBonds,
-                  std::vector<std::vector<int>>& molCisTransChains,
-                  std::vector<bool>& molIsCis, unsigned int size, bool& found,
+                  std::vector<std::vector<size_t>>& molBonds,
+                  std::vector<std::vector<size_t>>& templateBonds,
+                  std::vector<std::vector<size_t>>& molCisTransChains,
+                  std::vector<bool>& molIsCis, size_t size, bool& found,
                   std::vector<unsigned int>& mapping);
 
-
-    /*compare atoms and bonds to template and map which atom is which in case of a positive match*/
+    /*compare atoms and bonds to template and map which atom is which in case of
+     * a positive match*/
     static bool compare(std::vector<sketcherMinimizerAtom*> atoms,
                         std::vector<sketcherMinimizerBond*> bonds,
                         sketcherMinimizerMolecule* templ,

--- a/sketcherMinimizerAtom.cpp
+++ b/sketcherMinimizerAtom.cpp
@@ -7,11 +7,12 @@
  */
 
 #include "sketcherMinimizerAtom.h"
-#include "sketcherMinimizerBond.h"
 #include "sketcherMinimizer.h"
+#include "sketcherMinimizerBond.h"
 #include "sketcherMinimizerMaths.h"
 
 #include <algorithm>
+#include <numeric>
 #include <queue>
 
 using namespace std;
@@ -26,7 +27,7 @@ bool CIPAtom::operator<(const CIPAtom& rhs) const
        algoirthm (scores) or in the present iteration (medals)
     */
     assert(allParents.size() == rhs.allParents.size());
-    for (unsigned int i = 0; i < allParents.size(); i++) {
+    for (size_t i = 0; i < allParents.size(); i++) {
 
         if (allParents[i]->atomicNumber > rhs.allParents[i]->atomicNumber)
             return true;
@@ -40,10 +41,10 @@ bool CIPAtom::operator<(const CIPAtom& rhs) const
 
         vector<int> meds = (*medals)[allParents[i]];
         vector<int> meds2 = (*rhs.medals)[rhs.allParents[i]];
-        unsigned int s =
+        size_t s =
             (meds.size() < meds2.size()) ? meds.size() : meds2.size();
 
-        for (unsigned int mm = 0; mm < s; mm++) {
+        for (size_t mm = 0; mm < s; mm++) {
             if (meds[mm] > meds2[mm])
                 return true;
             if (meds[mm] < meds2[mm])
@@ -54,10 +55,10 @@ bool CIPAtom::operator<(const CIPAtom& rhs) const
         if (meds2.size() > meds.size())
             return false;
     }
-    unsigned int siz = theseAtoms.size();
+    size_t siz = theseAtoms.size();
     if (rhs.theseAtoms.size() < siz)
         siz = rhs.theseAtoms.size();
-    for (unsigned int i = 0; i < siz; i++) {
+    for (size_t i = 0; i < siz; i++) {
         if (theseAtoms[i].first > rhs.theseAtoms[i].first)
             return true;
         if (theseAtoms[i].first < rhs.theseAtoms[i].first)
@@ -74,7 +75,7 @@ bool CIPAtom::operator<(const CIPAtom& rhs) const
 bool CIPAtom::operator==(const CIPAtom& rhs) const
 {
     assert(allParents.size() == rhs.allParents.size());
-    for (unsigned int i = 0; i < allParents.size(); i++) {
+    for (size_t i = 0; i < allParents.size(); i++) {
         if (allParents[i]->atomicNumber != rhs.allParents[i]->atomicNumber)
             return false;
         if ((*scores)[allParents[i]] != (*rhs.scores)[rhs.allParents[i]])
@@ -82,7 +83,7 @@ bool CIPAtom::operator==(const CIPAtom& rhs) const
     }
     if (theseAtoms.size() != rhs.theseAtoms.size())
         return false;
-    for (unsigned int i = 0; i < theseAtoms.size(); i++) {
+    for (size_t i = 0; i < theseAtoms.size(); i++) {
         if (theseAtoms[i].first != rhs.theseAtoms[i].first)
             return false;
     }
@@ -92,12 +93,12 @@ bool CIPAtom::operator==(const CIPAtom& rhs) const
 std::ostream& operator<<(std::ostream& os, const CIPAtom& a)
 {
 
-    for (unsigned int i = 0; i < a.allParents.size(); i++) {
+    for (size_t i = 0; i < a.allParents.size(); i++) {
         os << a.allParents[i]->atomicNumber << "("
            << (*a.scores)[a.allParents[i]] << ")";
         if ((*a.medals)[a.allParents[i]].size()) {
             cerr << "<";
-            for (unsigned int ii = 0; ii < (*a.medals)[a.allParents[i]].size();
+            for (size_t ii = 0; ii < (*a.medals)[a.allParents[i]].size();
                  ii++) {
                 cerr << (*a.medals)[a.allParents[i]][ii] << "|";
             }
@@ -106,7 +107,7 @@ std::ostream& operator<<(std::ostream& os, const CIPAtom& a)
         cerr << "   ";
     }
     os << "-";
-    for (unsigned int i = 0; i < a.theseAtoms.size(); i++) {
+    for (size_t i = 0; i < a.theseAtoms.size(); i++) {
         os << "    " << a.theseAtoms[i].first;
     }
     return os;
@@ -120,7 +121,7 @@ bool CIPAtom::isBetter(CIPAtom& rhs,
      scores stored in m
      */
     assert(allParents.size() == rhs.allParents.size());
-    for (unsigned int i = 0; i < allParents.size(); i++) {
+    for (size_t i = 0; i < allParents.size(); i++) {
 
         if ((*m)[allParents[i]] > (*m)[rhs.allParents[i]])
             return true;
@@ -139,10 +140,10 @@ bool CIPAtom::isBetter(CIPAtom& rhs,
 
         vector<int> meds = (*medals)[allParents[i]];
         vector<int> meds2 = (*rhs.medals)[rhs.allParents[i]];
-        unsigned int s =
+        size_t s =
             (meds.size() < meds2.size()) ? meds.size() : meds2.size();
 
-        for (unsigned int mm = 0; mm < s; mm++) {
+        for (size_t mm = 0; mm < s; mm++) {
             if (meds[mm] > meds2[mm])
                 return true;
             if (meds[mm] < meds2[mm])
@@ -153,10 +154,10 @@ bool CIPAtom::isBetter(CIPAtom& rhs,
         if (meds2.size() > meds.size())
             return false;
     }
-    unsigned int siz = theseAtoms.size();
+    size_t siz = theseAtoms.size();
     if (rhs.theseAtoms.size() < siz)
         siz = rhs.theseAtoms.size();
-    for (unsigned int i = 0; i < siz; i++) {
+    for (size_t i = 0; i < siz; i++) {
         if (theseAtoms[i].first > rhs.theseAtoms[i].first)
             return true;
         if (theseAtoms[i].first < rhs.theseAtoms[i].first)
@@ -170,16 +171,15 @@ bool CIPAtom::isBetter(CIPAtom& rhs,
     return false;
 }
 
-sketcherMinimizerAtom::~sketcherMinimizerAtom(){};
+sketcherMinimizerAtom::~sketcherMinimizerAtom() {}
 
 sketcherMinimizerAtom::sketcherMinimizerAtom()
-: crossLayout(false), fixed(false), constrained(false), rigid(false),
-isSharedAndInner(false), atomicNumber(6), charge(0), _valence(-10),
-_generalUseN(-1), _generalUseN2(-1), m_chmN(-1),
-_generalUseVisited(false), _generalUseVisited2(false),
-fragment(NULL), needsCheckForClashes(false), visited(false),
-coordinatesSet(false), isR(true), hasStereochemistrySet(false),
-_hasRingChirality(false)
+    : crossLayout(false), fixed(false), constrained(false), rigid(false),
+      isSharedAndInner(false), atomicNumber(6), charge(0), _valence(-10),
+      _generalUseN(-1), _generalUseN2(-1), m_chmN(-1),
+      _generalUseVisited(false), _generalUseVisited2(false), fragment(NULL),
+      needsCheckForClashes(false), visited(false), coordinatesSet(false),
+      isR(true), hasStereochemistrySet(false), _hasRingChirality(false)
 {
     hidden = false;
     m_pseudoZ = 0.f;
@@ -193,7 +193,7 @@ _hasRingChirality(false)
     m_clockwiseInvert = false;
     m_isStereogenic = false;
     m_ignoreRingChirality = false;
-};
+}
 
 sketcherMinimizerRing*
 sketcherMinimizerAtom::shareARing(const sketcherMinimizerAtom* atom1,
@@ -223,30 +223,31 @@ sketcherMinimizerAtom::shareARing(const sketcherMinimizerAtom* atom1,
     return NULL;
 }
 
-unsigned int sketcherMinimizerAtom::findHsNumber() const
+int sketcherMinimizerAtom::findHsNumber() const
 {
     int valence = _valence;
     if (valence == -10)
         valence = expectedValence(atomicNumber); // valence is not yet set
-    unsigned int nBondOrders = 0;
-    for (unsigned int i = 0; i < bonds.size(); i++)
+    int nBondOrders = 0;
+    for (size_t i = 0; i < bonds.size(); ++i) {
         nBondOrders += bonds[i]->bondOrder;
-    if (atomicNumber == 16) { // sulphite & sulphate
+    }
+    if (atomicNumber == 16) { // sulfite & sulfate
         int nOs = 0;
-        for (unsigned int i = 0; i < neighbors.size(); i++) {
+        for (size_t i = 0; i < neighbors.size(); ++i) {
             if (neighbors[i]->atomicNumber == 8 && bonds[i]->bondOrder == 2)
-                nOs++;
+                ++nOs;
         }
         if ((nOs) < 3)
             valence += nOs * 2;
     }
     if (atomicNumber == 15) { // P
         int nOs = 0;
-        for (unsigned int i = 0; i < neighbors.size(); i++) {
+        for (size_t i = 0; i < neighbors.size(); ++i) {
             if (neighbors[i]->atomicNumber == 8 && bonds[i]->bondOrder == 2)
-                nOs++;
+                ++nOs;
         }
-        if ((nOs) < 2)
+        if (nOs < 2)
             valence += nOs * 2;
     }
     int out = valence - nBondOrders + charge;
@@ -346,7 +347,7 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
 
     if (!hasStereochemistrySet)
         return;
-    int n = neighbors.size();
+    size_t n = neighbors.size();
     if (n != 3 && n != 4) {
         hasStereochemistrySet = false;
         return;
@@ -404,20 +405,8 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
             dummy = &dummyLP;
 
         bool four = true;
-        float totalAngle = 0;
-        for (unsigned int ai = 0; ai < angles.size(); ai++)
-            totalAngle += angles[ai];
+        float totalAngle = std::accumulate(angles.begin(), angles.end(), 0.f);
         angles.push_back(360.f - totalAngle);
-
-        if (angles.size() == 3) {
-            for (unsigned int i = 0; i < angles.size(); i++) {
-                if (angles[i] > 180.f) {
-                    int precI = i - 1;
-                    if (precI < 0)
-                        precI += angles.size();
-                }
-            }
-        }
 
         vector<sketcherMinimizerAtomPriority> atomPriorities,
             orderedAtomPriorities;
@@ -587,14 +576,15 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
 }
 
 sketcherMinimizerAtomChiralityInfo::sketcherMinimizerChirality
-     sketcherMinimizerAtom::getRelativeStereo(sketcherMinimizerAtom* lookingFrom,
-                                                                    sketcherMinimizerAtom* atom1,
-                                                                    sketcherMinimizerAtom* atom2)
+sketcherMinimizerAtom::getRelativeStereo(sketcherMinimizerAtom* lookingFrom,
+                                         sketcherMinimizerAtom* atom1,
+                                         sketcherMinimizerAtom* atom2)
 {
     readStereochemistry(); // to set m_RSPriorities
     auto RSpriorities = m_RSPriorities;
     if (RSpriorities.size() < 3) {
-        return sketcherMinimizerAtomChiralityInfo::unspecified;;
+        return sketcherMinimizerAtomChiralityInfo::unspecified;
+        ;
     }
     vector<int> priorities(4, 3);
 
@@ -610,8 +600,7 @@ sketcherMinimizerAtomChiralityInfo::sketcherMinimizerChirality
             priorities[1] = RSpriorities[nn];
         } else if (n == lookingFrom) {
             priorities[3] = RSpriorities[nn];
-        }
-        else {
+        } else {
             priorities[2] = RSpriorities[nn];
         }
     }
@@ -624,30 +613,30 @@ sketcherMinimizerAtomChiralityInfo::sketcherMinimizerChirality
      atom2 (priority 1)
      atom3 (priority 2)
      atomLookingFrom (priority 3 -lowest)
-     which is the opposite of the CIP rules, where the the lowest priority atom is AWAY from the observer.
-     This is the reason why we return CCW for R and CW for S.
+     which is the opposite of the CIP rules, where the the lowest priority atom
+     is AWAY from the observer. This is the reason why we return CCW for R and
+     CW for S.
      */
     bool match = sketcherMinimizerAtom::matchCIPSequence(priorities, can);
     bool isClockWise = (match ? !isR : isR);
-    if (isClockWise) return sketcherMinimizerAtomChiralityInfo::clockwise;
+    if (isClockWise)
+        return sketcherMinimizerAtomChiralityInfo::clockwise;
     return sketcherMinimizerAtomChiralityInfo::counterClockwise;
 }
-
 
 bool sketcherMinimizerAtom::setAbsoluteStereoFromChiralityInfo()
 {
     auto info = m_chiralityInfo;
     if (info.direction == sketcherMinimizerAtomChiralityInfo::unspecified)
-    return true;
+        return true;
     readStereochemistry(); // to set m_RSPriorities
     auto RSpriorities = m_RSPriorities;
     ;
     if (RSpriorities.size() < 3) {
         cerr << "CHMMol-> sketcher stereo error: wrong number for RSpriorities"
-        << endl;
+             << endl;
         return false;
     }
-
 
     vector<int> priorities(4, 5);
 
@@ -665,8 +654,8 @@ bool sketcherMinimizerAtom::setAbsoluteStereoFromChiralityInfo()
         } else {
             if (at3) {
                 cerr << "CHMMol-> sketcher stereo error: more than 1 atom not "
-                "matching"
-                << endl;
+                        "matching"
+                     << endl;
                 return false;
 
             } else {
@@ -694,7 +683,7 @@ bool sketcherMinimizerAtom::setAbsoluteStereoFromChiralityInfo()
     }
     if (addingHN > 1) {
         cerr << "CHMMol-> sketcher stereo error: more than 1 H on chiral center"
-        << endl;
+             << endl;
         return false;
     }
 
@@ -702,21 +691,19 @@ bool sketcherMinimizerAtom::setAbsoluteStereoFromChiralityInfo()
 
     vector<int> can(4);
     for (unsigned int i = 0; i < 4; i++)
-    can[i] = i;
+        can[i] = i;
     if (!sketcherMinimizerAtom::matchCIPSequence(priorities, can))
-    invert = !invert;
+        invert = !invert;
     bool isRBool = true;
     if (info.direction == sketcherMinimizerAtomChiralityInfo::clockwise)
-    isRBool = false;
+        isRBool = false;
     if (invert)
-    isRBool = !isRBool;
+        isRBool = !isRBool;
     isR = isRBool;
     hasStereochemistrySet = true;
     writeStereoChemistry();
     return true;
 }
-
-
 
 bool sketcherMinimizerAtom::matchCIPSequence(vector<int>& v1, vector<int>& v2)
 
@@ -747,7 +734,6 @@ bool sketcherMinimizerAtom::matchCIPSequence(vector<int>& v1, vector<int>& v2)
     }
     return true;
 }
-
 
 void sketcherMinimizerAtom::setCoordinates(sketcherMinimizerPointF coords)
 {
@@ -796,7 +782,7 @@ void sketcherMinimizerAtom::orderAtomPriorities(
                 }
             }
         }
-        weights[i] = counter;
+        weights[i] = static_cast<float>(counter);
         sketcherMinimizerBond* b = center->bondTo(atomPriorities[i].a);
         if (b) {
             if (b->bondOrder == 2)
@@ -804,7 +790,7 @@ void sketcherMinimizerAtom::orderAtomPriorities(
                     0.25; // so that =O get lower priority than -OH in phosphate
             if (center->atomicNumber == 16 && b->bondOrder == 2)
                 weights[i] += 2000; // forcing the wedge away from double bond
-                                    // in solphoxide
+                                    // in sulphoxide
 
             if (sketcherMinimizer::sameRing(b->startAtom, b->endAtom))
                 weights[i] +=
@@ -929,13 +915,13 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
 
     vector<CIPAtom> AN1, AN2;
 
-    map<sketcherMinimizerAtom *, int> score1,
+    map<sketcherMinimizerAtom*, int> score1,
         score2; // used to keep track if a parent atom has been found to have
                 // priority over another
-    map<sketcherMinimizerAtom *, vector<int>> medals1,
+    map<sketcherMinimizerAtom*, vector<int>> medals1,
         medals2; // marks if an atom is a parent of the atoms being evaluated in
                  // the current iteration
-    map<sketcherMinimizerAtom *, int> visited1,
+    map<sketcherMinimizerAtom*, int> visited1,
         visited2; // marks at which iteration this atom was evaluated
 
     visited1[center] = 1;
@@ -943,11 +929,11 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
     visited1[at1] = 2;
     visited2[at2] = 2;
 
-    vector<pair<int, sketcherMinimizerAtom *>> v1, v2;
+    vector<pair<int, sketcherMinimizerAtom*>> v1, v2;
     v1.push_back(pair<int, sketcherMinimizerAtom*>(at1->atomicNumber, at1));
     v2.push_back(pair<int, sketcherMinimizerAtom*>(at2->atomicNumber, at2));
 
-    vector<sketcherMinimizerAtom *> parents1, parents2;
+    vector<sketcherMinimizerAtom*> parents1, parents2;
     parents1.push_back(center);
     parents1.push_back(at1);
     parents2.push_back(center);
@@ -973,11 +959,11 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
         sketcherMinimizerAtom::finalizeScores(AN1);
         sketcherMinimizerAtom::finalizeScores(AN2);
 
-        unsigned int nn = AN1.size();
+        size_t nn = AN1.size();
         if (AN2.size() < nn)
             nn = AN2.size();
 
-        for (unsigned int i = 0; i < nn; i++) {
+        for (size_t i = 0; i < nn; ++i) {
             if (AN1[i] < AN2[i])
                 return at1;
             if (AN2[i] < AN1[i])
@@ -1052,7 +1038,7 @@ vector<CIPAtom> sketcherMinimizerAtom::expandOneLevel(vector<CIPAtom>& oldV)
                               (*visited)[a] + 1) // closing a ring to an atom
                                                  // already visited in a
                                                  // previous cycle
-                         );
+                        );
                     theseAts.push_back(pair<int, sketcherMinimizerAtom*>(
                         neigh->atomicNumber,
                         ghost ? ((sketcherMinimizerAtom*) NULL)
@@ -1238,9 +1224,12 @@ int sketcherMinimizerAtom::readStereochemistry(
         for (unsigned int i = 0; i < angles.size(); i++) {
             if (angles[i] > 180.f) {
                 semiplane = true;
-                int precI = i - 1;
-                if (precI < 0)
-                    precI += angles.size();
+                size_t precI;
+                if (i == 0) {
+                    precI = angles.size() - 1;
+                } else {
+                    precI = i - 1;
+                }
                 centralAtom = orderedNeighs[precI];
             }
         }
@@ -1310,7 +1299,7 @@ int sketcherMinimizerAtom::readStereochemistry(
     }
 
     int nOfHs = _implicitHs;
-    int totalSubstituentsN = neighbors.size() + nOfHs;
+    size_t totalSubstituentsN = neighbors.size() + nOfHs;
 
     if (orderedNeighs.size() == 3 && nOfHs == 1) {
         if (semiplane) {
@@ -1399,8 +1388,9 @@ int sketcherMinimizerAtom::readStereochemistry(
             int n = startIndex + i;
             if (n > 3)
                 n -= 4;
-            if (atomPriorities[n].priority != i)
-                outofPlaceAtoms++;
+            if (atomPriorities[n].priority != i) {
+                ++outofPlaceAtoms;
+            }
         }
         if (outofPlaceAtoms == 2)
             invert = !invert;

--- a/sketcherMinimizerAtom.h
+++ b/sketcherMinimizerAtom.h
@@ -29,7 +29,7 @@ class sketcherMinimizerMolecule;
 class sketcherMinimizerAtom;
 typedef struct {
     sketcherMinimizerAtom* a;
-    float priority;
+    unsigned int priority;
 } sketcherMinimizerAtomPriority;
 
 
@@ -97,7 +97,8 @@ class EXPORT_COORDGEN sketcherMinimizerAtom
     bool isSharedAndInner; // shared by two rings and needs to be drawn inside a
                            // ring
     bool hidden;
-    int atomicNumber, charge, _valence, _generalUseN, _generalUseN2;
+    int atomicNumber, charge, _valence;
+    size_t _generalUseN, _generalUseN2;
     int m_chmN; // idx of the corresponding ChmAtom if molecule comes from 3d
 
     bool _generalUseVisited, _generalUseVisited2;
@@ -196,7 +197,7 @@ class EXPORT_COORDGEN sketcherMinimizerAtom
 
     /*return all bonded atoms, ordered as they appear clockwise around this*/
     std::vector<sketcherMinimizerAtom*> clockwiseOrderedNeighbors() const;
-    unsigned int findHsNumber() const;
+    int findHsNumber() const;
 
     void writeStereoChemistry(); // assignes up-down bond flags based on isR and
                                  // hasStereochemistrySet

--- a/sketcherMinimizerBond.cpp
+++ b/sketcherMinimizerBond.cpp
@@ -59,29 +59,32 @@ sketcherMinimizerAtom* sketcherMinimizerBond::endAtomCIPFirstNeighbor() const
         return NULL;
 }
 
-void sketcherMinimizerBond::setAbsoluteStereoFromStereoInfo() {
+void sketcherMinimizerBond::setAbsoluteStereoFromStereoInfo()
+{
     if (isStereo() && m_stereo.atom1 != nullptr && m_stereo.atom2 != nullptr) {
         auto firstCIPNeighborStart = startAtomCIPFirstNeighbor();
         auto firstCIPNeighborEnd = endAtomCIPFirstNeighbor();
         if (firstCIPNeighborStart != nullptr && firstCIPNeighborEnd) {
             bool invert = false;
-            if (m_stereo.atom1 != firstCIPNeighborStart && m_stereo.atom1 != firstCIPNeighborEnd) {
+            if (m_stereo.atom1 != firstCIPNeighborStart &&
+                m_stereo.atom1 != firstCIPNeighborEnd) {
                 invert = !invert;
             }
-            if (m_stereo.atom2 != firstCIPNeighborStart && m_stereo.atom2 != firstCIPNeighborEnd) {
+            if (m_stereo.atom2 != firstCIPNeighborStart &&
+                m_stereo.atom2 != firstCIPNeighborEnd) {
                 invert = !invert;
             }
-            bool settingIsZ = (m_stereo.stereo == sketcherMinimizerBondStereoInfo::cis);
-            if (invert) settingIsZ = !settingIsZ;
+            bool settingIsZ =
+                (m_stereo.stereo == sketcherMinimizerBondStereoInfo::cis);
+            if (invert)
+                settingIsZ = !settingIsZ;
             isZ = settingIsZ;
-
         }
     }
     if (m_stereo.stereo == sketcherMinimizerBondStereoInfo::unspecified) {
         m_ignoreZE = true;
     }
 }
-
 
 bool sketcherMinimizerBond::checkStereoChemistry() const
 {
@@ -171,10 +174,10 @@ bool sketcherMinimizerBond::isStereo() const
 
 void sketcherMinimizerBond::flip()
 {
-    int totalAtomsNumber = getStartAtom()->getMolecule()->getAtoms().size();
+    size_t totalAtomsNumber = getStartAtom()->getMolecule()->getAtoms().size();
     vector<sketcherMinimizerAtom*> atoms =
         getStartAtom()->getSubmolecule(getEndAtom());
-    if (atoms.size() > totalAtomsNumber * 0.5) {
+    if (atoms.size() > totalAtomsNumber / 2) {
         atoms = getEndAtom()->getSubmolecule(getStartAtom());
     }
     vector<sketcherMinimizerBond*> allBonds =

--- a/sketcherMinimizerFragment.cpp
+++ b/sketcherMinimizerFragment.cpp
@@ -4,8 +4,8 @@
  */
 
 #include "sketcherMinimizerFragment.h"
-#include "sketcherMinimizerBond.h"
 #include "sketcherMinimizerAtom.h"
+#include "sketcherMinimizerBond.h"
 #include "sketcherMinimizerMaths.h"
 #include "sketcherMinimizerRing.h"
 
@@ -30,9 +30,7 @@ CoordgenFragmentDOF::CoordgenFragmentDOF(sketcherMinimizerFragment* fragment)
 {
 }
 
-CoordgenFragmentDOF::~CoordgenFragmentDOF()
-{
-}
+CoordgenFragmentDOF::~CoordgenFragmentDOF() {}
 
 short unsigned int CoordgenFragmentDOF::getCurrentState()
 {
@@ -133,7 +131,7 @@ int CoordgenScaleFragmentDOF::tier() const
 void CoordgenScaleFragmentDOF::apply() const
 {
     if (m_currentState != 0) {
-        float scale = pow(1.4, (m_currentState + 1) / 2);
+        float scale = static_cast<float>(pow(1.4, (m_currentState + 1) / 2));
         if (m_currentState % 2 == 0) {
             scale = 1 / scale;
         }
@@ -169,7 +167,7 @@ int CoordgenScaleAtomsDOF::tier() const
 void CoordgenScaleAtomsDOF::apply() const
 {
     if (m_currentState != 0) {
-        float scale = 0.4;
+        float scale = 0.4f;
         for (auto atom : m_atoms) {
             auto distance =
                 atom->getCoordinates() - m_pivotAtom->getCoordinates();
@@ -207,7 +205,7 @@ int CoordgenChangeParentBondLengthFragmentDOF::tier() const
 void CoordgenChangeParentBondLengthFragmentDOF::apply() const
 {
     if (m_currentState != 0) {
-        float scale = pow(1.6, (m_currentState + 1) / 2);
+        float scale = static_cast<float>(pow(1.6, (m_currentState + 1) / 2));
         if (m_currentState % 2 == 0) {
             scale = 1 / scale;
         }
@@ -247,7 +245,8 @@ int CoordgenRotateFragmentDOF::tier() const
 void CoordgenRotateFragmentDOF::apply() const
 {
     if (m_currentState != 0) {
-        float angle = M_PI / 180 * 15 * ((m_currentState + 1) / 2);
+        float angle =
+            static_cast<float>(M_PI / 180 * 15 * ((m_currentState + 1) / 2));
         if (m_currentState % 2 == 0) {
             angle = -angle;
         }
@@ -389,7 +388,7 @@ unsigned int sketcherMinimizerFragment::totalWeight() const
     for (unsigned int i = 0; i < m_atoms.size(); i++)
         n += m_atoms[i]->atomicNumber + m_atoms[i]->_implicitHs;
     return n;
-};
+}
 unsigned int sketcherMinimizerFragment::countDoubleBonds() const
 {
     int n = 0;
@@ -397,7 +396,7 @@ unsigned int sketcherMinimizerFragment::countDoubleBonds() const
         if (m_bonds[i]->bondOrder == 2)
             ++n;
     return n;
-};
+}
 unsigned int sketcherMinimizerFragment::countHeavyAtoms() const
 {
     int n = 0;
@@ -427,7 +426,6 @@ unsigned int sketcherMinimizerFragment::countFixedAtoms() const
     return n;
 }
 
-    
 void sketcherMinimizerFragment::addAtom(sketcherMinimizerAtom* atom)
 {
     m_atoms.push_back(atom);
@@ -507,4 +505,4 @@ void sketcherMinimizerFragment::setCoordinates(sketcherMinimizerPointF position,
         initialCoordinates.rotate(sine, cosine);
         atom->setCoordinates(initialCoordinates + position);
     }
-};
+}

--- a/sketcherMinimizerFragment.h
+++ b/sketcherMinimizerFragment.h
@@ -11,7 +11,7 @@
 
 #include <vector>
 #include <map>
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 #include "sketcherMinimizerMaths.h"
 
@@ -259,7 +259,7 @@ class sketcherMinimizerFragment
     bool isChain;
     sketcherMinimizerBond* _bondToParent;
     float longestChainFromHere;
-    int numberOfChildrenAtoms;
+    size_t numberOfChildrenAtoms;
     float numberOfChildrenAtomsRank;
 
     /*translate and rotate the fragment and set the resulting coordinates to every atom*/

--- a/sketcherMinimizerMarchingSquares.cpp
+++ b/sketcherMinimizerMarchingSquares.cpp
@@ -8,16 +8,13 @@
  */
 
 #include "sketcherMinimizerMarchingSquares.h"
-#include <assert.h>
-#include <iostream>
 #include "sketcherMinimizer.h"
-
+#include <cassert>
+#include <iostream>
 
 using namespace std;
 
-sketcherMinimizerMarchingSquares::sketcherMinimizerMarchingSquares()
-{
-}
+sketcherMinimizerMarchingSquares::sketcherMinimizerMarchingSquares() {}
 
 sketcherMinimizerMarchingSquares::~sketcherMinimizerMarchingSquares()
 {
@@ -42,8 +39,8 @@ void sketcherMinimizerMarchingSquares::initialize(float minx, float maxx,
     assert(dx > 0);
     assert(dy > 0);
 
-    m_XN = (dx / x_interval) + 2;
-    m_YN = (dy / y_interval) + 2;
+    m_XN = static_cast<unsigned int>((dx / x_interval) + 2);
+    m_YN = static_cast<unsigned int>((dy / y_interval) + 2);
     m_grid.clear();
     m_grid.resize(m_XN * m_YN, 0.f);
     m_lastRowPoints.resize(m_XN, NULL);
@@ -93,17 +90,15 @@ float sketcherMinimizerMarchingSquares::getThreshold() const
 {
     return m_threshold;
 }
-
-float sketcherMinimizerMarchingSquares::toRealx(float x) const
+template <typename T> float sketcherMinimizerMarchingSquares::toRealx(T x) const
 {
 
-    return m_left + (x * m_xinterval);
+    return m_left + (static_cast<float>(x) * m_xinterval);
 }
-
-float sketcherMinimizerMarchingSquares::toRealy(float y) const
+template <typename T> float sketcherMinimizerMarchingSquares::toRealy(T y) const
 {
 
-    return m_bottom + (y * m_yinterval);
+    return m_bottom + (static_cast<float>(y) * m_yinterval);
 }
 
 float sketcherMinimizerMarchingSquares::interpolate(float v1, float v2) const

--- a/sketcherMinimizerMarchingSquares.h
+++ b/sketcherMinimizerMarchingSquares.h
@@ -10,10 +10,9 @@
 #ifndef sketcherMINIMIZERMARCHINGSQUARES_H
 #define sketcherMINIMIZERMARCHINGSQUARES_H
 
+#include "CoordgenConfig.hpp"
 #include <cstddef>
 #include <vector>
-#include "CoordgenConfig.hpp"
-
 
 class sketcherMinimizerPointF;
 
@@ -55,8 +54,8 @@ class EXPORT_COORDGEN sketcherMinimizerMarchingSquares
     void setThreshold(float t);
     float getThreshold() const;
 
-    float toRealx(float x) const;
-    float toRealy(float y) const;
+    template <typename T> float toRealx(T x) const;
+    template <typename T> float toRealy(T y) const;
 
     unsigned int getXN() const { return m_XN; };
     unsigned int getYN() const { return m_YN; };
@@ -65,16 +64,16 @@ class EXPORT_COORDGEN sketcherMinimizerMarchingSquares
 
     std::vector<float>
 
-        /*call after run () is executed, returs the coordinates of all the
-           isovalue line points [x1, y1, x2, y2 .. xn, yn] in the order they
-           were created*/
-        getCoordinatesPoints() const;
+    /*call after run () is executed, returs the coordinates of all the
+       isovalue line points [x1, y1, x2, y2 .. xn, yn] in the order they
+       were created*/
+    getCoordinatesPoints() const;
     std::vector<std::vector<float>>
 
-        /*call after run () is executed. Returns a vector of isovalue closed
-           lines [x1, y1, x2, y2 .. xn, yn]. The points are ordered as they
-           appear along the line.*/
-        getOrderedCoordinatesPoints() const;
+    /*call after run () is executed. Returns a vector of isovalue closed
+       lines [x1, y1, x2, y2 .. xn, yn]. The points are ordered as they
+       appear along the line.*/
+    getOrderedCoordinatesPoints() const;
 
     inline std::vector<float> getRawData() const
     {

--- a/sketcherMinimizerMaths.h
+++ b/sketcherMinimizerMaths.h
@@ -10,11 +10,11 @@
 #ifndef sketcherMINIMIZERMATHS_H
 #define sketcherMINIMIZERMATHS_H
 
+#include <cassert>
 #include <cmath>
+#include <iostream>
 #include <math.h>
 #include <vector>
-#include <assert.h>
-#include <iostream>
 
 #define MACROCYCLE 9 // smallest MACROCYCLE
 
@@ -34,30 +34,42 @@
 
 inline float roundToTwoDecimalDigits(float f)
 {
-    return floor(f * 100 + 0.5) * 0.01;
+    return static_cast<float>(floor(f * 100 + 0.5) * 0.01);
 }
 
 inline float roundToPrecision(float f, int precision)
 {
-    return floor(f * pow(10.f, precision) + 0.5) * pow(0.1, precision);
+    return static_cast<float>(floor(f * pow(10.f, precision) + 0.5) *
+                              pow(0.1, precision));
 }
 
 /*class to represent a point or vector in 2d*/
 class sketcherMinimizerPointF
 {
   public:
-    sketcherMinimizerPointF() : xp(0.f), yp(0.f){};
+    sketcherMinimizerPointF() : xp(0.f), yp(0.f) {}
 
     sketcherMinimizerPointF(const sketcherMinimizerPointF& p)
-        : xp(p.x()), yp(p.y()){};
-    sketcherMinimizerPointF(float xpos, float ypos) : xp(xpos), yp(ypos){};
+        : xp(p.x()), yp(p.y())
+    {
+    }
+    sketcherMinimizerPointF(float xpos, float ypos) : xp(xpos), yp(ypos) {}
 
-    inline float x() const { return xp; };
-    inline float y() const { return yp; };
-    inline float& rx() { return xp; };
-    inline float& ry() { return yp; };
-    void setX(float x) { xp = x; };
-    void setY(float y) { yp = y; };
+    sketcherMinimizerPointF& operator=(const sketcherMinimizerPointF& p)
+    {
+        if (this != &p) {
+            xp = p.x();
+            yp = p.y();
+        }
+        return *this;
+    }
+
+    inline float x() const { return xp; }
+    inline float y() const { return yp; }
+    inline float& rx() { return xp; }
+    inline float& ry() { return yp; }
+    void setX(float x) { xp = x; }
+    void setY(float y) { yp = y; }
     float squareLength() const
     {
         float dd = x() * x() + y() * y();
@@ -72,7 +84,7 @@ class sketcherMinimizerPointF
             return sqrt(dd);
         else
             return 0;
-    };
+    }
 
     /*normalize the vector*/
     void normalize()
@@ -82,7 +94,7 @@ class sketcherMinimizerPointF
             xp /= q;
             yp /= q;
         }
-    };
+    }
 
     /*rotate the vector by the angle with given sine and cosine*/
     void rotate(float s, float c)
@@ -117,26 +129,25 @@ class sketcherMinimizerPointF
         xp += p.xp;
         yp += p.yp;
         return *this;
-    };
+    }
     sketcherMinimizerPointF& operator-=(const sketcherMinimizerPointF& p)
     {
         xp -= p.xp;
         yp -= p.yp;
         return *this;
-    };
-    sketcherMinimizerPointF& operator*=(float c)
+    }
+    template <typename T> sketcherMinimizerPointF& operator*=(T c)
     {
-        xp *= c;
-        yp *= c;
+        xp *= static_cast<float>(c);
+        yp *= static_cast<float>(c);
         return *this;
-    };
-    sketcherMinimizerPointF& operator/=(float c)
+    }
+    template <typename T> sketcherMinimizerPointF& operator/=(T c)
     {
-        xp /= c;
-        yp /= c;
+        xp /= static_cast<float>(c);
+        yp /= static_cast<float>(c);
         return *this;
-    };
-    ;
+    }
 
     // friend inline bool operator==(const sketcherMinimizerPointF &p1, const
     // sketcherMinimizerPointF &p2) ;
@@ -155,34 +166,38 @@ class sketcherMinimizerPointF
               const sketcherMinimizerPointF& p2)
     {
         return sketcherMinimizerPointF(p1.xp + p2.xp, p1.yp + p2.yp);
-    };
+    }
     friend inline const sketcherMinimizerPointF
     operator-(const sketcherMinimizerPointF& p1,
               const sketcherMinimizerPointF& p2)
     {
         return sketcherMinimizerPointF(p1.xp - p2.xp, p1.yp - p2.yp);
-    };
+    }
     friend inline const sketcherMinimizerPointF
     operator*(float c, const sketcherMinimizerPointF& p1)
     {
         return sketcherMinimizerPointF(p1.xp * c, p1.yp * c);
-    };
+    }
+    template <typename T>
     friend inline const sketcherMinimizerPointF
-    operator*(const sketcherMinimizerPointF& p1, float c)
+    operator*(const sketcherMinimizerPointF& p1, T c)
     {
-        return sketcherMinimizerPointF(p1.xp * c, p1.yp * c);
-    };
+        float cf = static_cast<float>(c);
+        return sketcherMinimizerPointF(p1.xp * cf, p1.yp * cf);
+    }
+    template <typename T>
     friend inline const sketcherMinimizerPointF
-    operator/(const sketcherMinimizerPointF& p1, float c)
+    operator/(const sketcherMinimizerPointF& p1, T c)
     {
-        return sketcherMinimizerPointF(p1.xp / c, p1.yp / c);
-    };
+        float cf = static_cast<float>(c);
+        return sketcherMinimizerPointF(p1.xp / cf, p1.yp / cf);
+    }
 
     friend inline const sketcherMinimizerPointF
     operator-(const sketcherMinimizerPointF& p1)
     {
         return sketcherMinimizerPointF(-p1.xp, -p1.yp);
-    };
+    }
     //     friend inline const sketcherMinimizerPointF operator/(const
     //     sketcherMinimizerPointF &, float);
 
@@ -191,8 +206,8 @@ class sketcherMinimizerPointF
     float yp;
 };
 
-/*return true if the two segments intersect and if a result pointer was given, set it to
- the intersection point*/
+/*return true if the two segments intersect and if a result pointer was given,
+ set it to the intersection point*/
 struct sketcherMinimizerMaths {
     static bool intersectionOfSegments(sketcherMinimizerPointF s1p1,
                                        sketcherMinimizerPointF s1p2,
@@ -260,7 +275,7 @@ struct sketcherMinimizerMaths {
         sketcherMinimizerPointF r = s1p2 - s1p1;
         sketcherMinimizerPointF q = s2p1;
         sketcherMinimizerPointF s = s2p2 - s2p1;
-        int rxs = crossProduct(r, s);
+        float rxs = crossProduct(r, s);
         if (rxs > -SKETCHER_EPSILON &&
             rxs < SKETCHER_EPSILON) { // parallel lines
             return false;
@@ -318,7 +333,6 @@ struct sketcherMinimizerMaths {
         return float((acos(cosine)) * 180 / M_PI);
     }
 
-
     /*return true if the two points are very close in space*/
     static bool pointsCoincide(sketcherMinimizerPointF p1,
                                sketcherMinimizerPointF p2)
@@ -326,7 +340,8 @@ struct sketcherMinimizerMaths {
         return ((p1 - p2).squareLength() < SKETCHER_EPSILON * SKETCHER_EPSILON);
     }
 
-    /*return true if p1 and p2 are in the same semiplane defined by the given segment*/
+    /*return true if p1 and p2 are in the same semiplane defined by the given
+     * segment*/
     static bool sameSide(const sketcherMinimizerPointF p1,
                          const sketcherMinimizerPointF p2,
                          const sketcherMinimizerPointF lineP1,
@@ -351,7 +366,6 @@ struct sketcherMinimizerMaths {
         }
     }
 
-
     /*return the projection of p on the line defined by the given segment*/
     static sketcherMinimizerPointF
     projectPointOnLine(sketcherMinimizerPointF p, sketcherMinimizerPointF sp1,
@@ -367,7 +381,6 @@ struct sketcherMinimizerMaths {
         float t = sketcherMinimizerMaths::dotProduct(l1, l3) / segmentl2;
         return sp1 + t * l3;
     }
-
 
     /*squared distance of the given point from the given segment*/
     static float squaredDistancePointSegment(sketcherMinimizerPointF p,
@@ -447,7 +460,6 @@ struct sketcherMinimizerMaths {
         return u;
     }
 
-
     /*used by ClosedBezierControlPoints*/
     static std::vector<float> cyclicSolve(std::vector<float> a,
                                           std::vector<float> b,
@@ -502,7 +514,8 @@ struct sketcherMinimizerMaths {
         return (1 - t) * v4 + t * v5;
     }
 
-    /*find control points to a closed bezier curve that passes through the given points*/
+    /*find control points to a closed bezier curve that passes through the given
+     * points*/
     static void ClosedBezierControlPoints(
         std::vector<sketcherMinimizerPointF> knots,
         std::vector<sketcherMinimizerPointF>& firstControlPoints,
@@ -593,7 +606,6 @@ struct sketcherMinimizerMaths {
 
         // assume that direction is normalized
 
-
         float targetdX = targetX - originX;
         float targetdY = targetY - originY;
         float targetdZ = targetZ - originZ;
@@ -627,7 +639,7 @@ struct sketcherMinimizerMaths {
         return result;
     }
 
-        /*length of a 3d vector*/
+    /*length of a 3d vector*/
     static float length3D(float x, float y, float z)
     {
         float m = x * x + y * y + z * z;
@@ -636,14 +648,14 @@ struct sketcherMinimizerMaths {
         return m;
     }
 
-        /*dot product of two 3d vectors*/
+    /*dot product of two 3d vectors*/
     static float dotProduct3D(float x1, float y1, float z1, float x2, float y2,
                               float z2)
     {
         return x1 * x2 + y1 * y2 + z1 * z2;
     }
 
-        /*cross product of two 3d vectors*/
+    /*cross product of two 3d vectors*/
     static void crossProduct3D(float x1, float y1, float z1, float x2, float y2,
                                float z2, float& xr, float& yr, float& zr)
 
@@ -658,10 +670,9 @@ struct sketcherMinimizerMaths {
         return length3D(x2 - x1, y2 - y1, z2 - z1);
     }
 
-        /*angle between two 3d vectors*/
-    static float angle3D(float x1, float y1, float z1,
-                         float x2, float y2, float z2,
-                         float x3, float y3, float z3)
+    /*angle between two 3d vectors*/
+    static float angle3D(float x1, float y1, float z1, float x2, float y2,
+                         float z2, float x3, float y3, float z3)
     {
         float xa = x1 - x2;
         float ya = y1 - y2;
@@ -672,14 +683,13 @@ struct sketcherMinimizerMaths {
         float l1 = length3D(xa, ya, za);
         float l2 = length3D(xb, yb, zb);
         float dp = dotProduct3D(xa, ya, za, xb, yb, zb);
-        return acos(dp / (l1 * l2)) * 180.f / M_PI;
+        return static_cast<float>(acos(dp / (l1 * l2)) * 180.f / M_PI);
     }
 
-        /*diheadral angle defined by 4 3d points*/
-    static float dihedral3D(float x1, float y1, float z1,
-                            float x2, float y2, float z2,
-                            float x3, float y3, float z3,
-                            float x4, float y4, float z4)
+    /*dihedral angle defined by 4 3d points*/
+    static float dihedral3D(float x1, float y1, float z1, float x2, float y2,
+                            float z2, float x3, float y3, float z3, float x4,
+                            float y4, float z4)
     {
         float xa, ya, za;
         crossProduct3D(x1 - x2, y1 - y2, z1 - z2, x3 - x2, y3 - y2, z3 - z2, xa,

--- a/sketcherMinimizerMolecule.cpp
+++ b/sketcherMinimizerMolecule.cpp
@@ -21,14 +21,14 @@ sketcherMinimizerMolecule::sketcherMinimizerMolecule()
 
       hasFixedFragments(false), hasConstrainedFragments(false),
       needToAlignNonRingAtoms(false), needToAlignWholeMolecule(false),
-      isPlaced(false), m_mainFragment(NULL), m_requireMinimization(false){};
+      isPlaced(false), m_mainFragment(NULL), m_requireMinimization(false){}
 
 sketcherMinimizerMolecule::~sketcherMinimizerMolecule()
 {
     for (auto ring : _rings) {
         delete ring;
     }
-};
+}
 
 
 sketcherMinimizerAtom* sketcherMinimizerMolecule::addNewAtom()

--- a/sketcherMinimizerRing.cpp
+++ b/sketcherMinimizerRing.cpp
@@ -21,9 +21,7 @@ sketcherMinimizerRing::sketcherMinimizerRing()
     side = false;
 }
 
-sketcherMinimizerRing::~sketcherMinimizerRing()
-{
-}
+sketcherMinimizerRing::~sketcherMinimizerRing() {}
 
 sketcherMinimizerPointF sketcherMinimizerRing::findCenter()
 {
@@ -60,7 +58,7 @@ bool sketcherMinimizerRing::isBenzene()
 bool sketcherMinimizerRing::isAromatic() // not chemically accurate, but good
                                          // enough for minimizer
 {
-    int bonds = _bonds.size();
+    size_t bonds = _bonds.size();
     int doubleBonds = 0;
     int NSOCount = 0;
     for (unsigned int i = 0; i < _bonds.size(); i++) {

--- a/sketcherMinimizerStretchInteraction.h
+++ b/sketcherMinimizerStretchInteraction.h
@@ -27,7 +27,7 @@ class sketcherMinimizerStretchInteraction : public sketcherMinimizerInteraction
         sketcherMinimizerPointF l = atom1->coordinates - atom2->coordinates;
         float m = l.length();
         float dr = restV - m;
-        float shortBondThreshold = restV * 0.4;
+        float shortBondThreshold = restV * 0.4f;
         float penaltyForVeryShortBonds = (shortBondThreshold - m);
         if (penaltyForVeryShortBonds < 0)
             penaltyForVeryShortBonds = 0;


### PR DESCRIPTION
This PR contains changes aimed at reducing the amount of compiler warnings generated at build.

Changes have been tested on different system configurations, including Mac, Linux and Windows. In all of these environments, compilation happens successfully, and no warnings are generated during compilation.

I also added and enabled a 'COORDGEN_RIGUROUS_BUILD' macro which enables "/WX" on Windows and "-Wall -Wextra -Werror" on Linux and Mac. On the windows side, the level of warnings reporting is not increased (/W4 or /Wall) because in those cases the compiler starts reporting warnings in boost.

The PR contains a lot of changes, most of them related to type casting, but also some which correct minor bugs (i.e. using a `float` variable to get an element of a vector, assigning `int` values to `float`s and vice versa).