### PR TITLE
avoid setting bonds info when reading in atom stereochemistry

### DIFF
--- a/sketcherMinimizerAtom.cpp
+++ b/sketcherMinimizerAtom.cpp
@@ -712,7 +712,6 @@ bool sketcherMinimizerAtom::setAbsoluteStereoFromChiralityInfo()
     isRBool = !isRBool;
     isR = isRBool;
     hasStereochemistrySet = true;
-    writeStereoChemistry();
     return true;
 }
 


### PR DESCRIPTION
writeStereoChemistry() was setting bond direction flags (inaccurately cause at this stage atoms usually have no coordinates) that are not cleaned up and can end up messing the stereochemistry of the final molecule. (bond directions are set at a later stage) 