### PR TITLE
Remove "sudo:false" and automated apt workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
-sudo: false
-
 language: cpp
 
-# Travis' automated apt seems to be broken in bionic, so we need a workaround
 before_script:
-  - "if [ \"${DIST}\" == \"bionic\" ]; then sudo apt update && sudo apt install -y gcc-7 g++-7 libboost1.62-all-dev valgrind; fi"
   - git clone https://github.com/schrodinger/maeparser.git
   - mkdir maeparser/build
   - pushd maeparser/build
@@ -25,7 +21,7 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      env: CC="gcc-4.8" CXX="g++-4.8" DIST="trusty"
+      env: CC="gcc-4.8" CXX="g++-4.8"
       addons:
         apt:
           packages:
@@ -36,7 +32,7 @@ matrix:
 
     - os: linux
       dist: xenial
-      env: CC="gcc-5" CXX="g++-5" DIST="xenial"
+      env: CC="gcc-5" CXX="g++-5"
       addons:
         apt:
           packages:
@@ -47,5 +43,12 @@ matrix:
 
     - os: linux
       dist: bionic
-      env: CC="gcc-7" CXX="g++-7" DIST="bionic"
+      env: CC="gcc-7" CXX="g++-7"
+      addons:
+        apt:
+          packages:
+            - gcc-7
+            - g++-7
+            - libboost1.62-all-dev
+            - valgrind
 


### PR DESCRIPTION
`sudo: false` is long deprecated, and should be removed, and it seems that the workaround is no longer required (although the "unable to resolve host" are still there): either removing the `sudo` fixes it, or Travis fixed it since I last tried.