### PR TITLE
Reduce number of arguments passed by value

### DIFF
--- a/CoordgenFragmentBuilder.cpp
+++ b/CoordgenFragmentBuilder.cpp
@@ -6,10 +6,10 @@
 #include "CoordgenFragmentBuilder.h"
 #include "CoordgenMinimizer.h"
 
-#include "sketcherMinimizerFragment.h"
 #include "sketcherMinimizer.h"
-#include <numeric>
+#include "sketcherMinimizerFragment.h"
 #include <algorithm>
+#include <numeric>
 using namespace std;
 
 const int bondLength = BONDLENGTH;
@@ -89,7 +89,7 @@ void CoordgenFragmentBuilder::rotateMainFragment(
 }
 
 bool CoordgenFragmentBuilder::findTemplate(
-    const vector<sketcherMinimizerRing*> rings) const
+    const vector<sketcherMinimizerRing*>& rings) const
 {
     vector<sketcherMinimizerAtom*> allAtoms =
         rings[0]->_atoms[0]->fragment->getAtoms();
@@ -151,7 +151,7 @@ bool CoordgenFragmentBuilder::findTemplate(
 }
 
 sketcherMinimizerRing* CoordgenFragmentBuilder::findCentralRingOfSystem(
-    const vector<sketcherMinimizerRing*> rings) const
+    const vector<sketcherMinimizerRing*>& rings) const
 {
     sketcherMinimizerRing* highest = nullptr;
     size_t high_score = 0;
@@ -213,7 +213,7 @@ void CoordgenFragmentBuilder::generateCoordinatesCentralRings(
 }
 
 float CoordgenFragmentBuilder::newScorePlanarity(
-    const vector<sketcherMinimizerRing*> rings)
+    const vector<sketcherMinimizerRing*>& rings)
     const // if score > 1000 then it is not planar
 {
     float score = 0.f;
@@ -298,7 +298,7 @@ CoordgenFragmentBuilder::getSharedAtomsWithAlreadyDrawnRing(
 }
 
 vector<sketcherMinimizerAtom*> CoordgenFragmentBuilder::orderChainOfAtoms(
-    const vector<sketcherMinimizerAtom*> atoms,
+    const vector<sketcherMinimizerAtom*>& atoms,
     sketcherMinimizerAtom* startAtom)
 {
     vector<sketcherMinimizerAtom*> orderedAtoms;
@@ -436,7 +436,7 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
                 coords2[i] =
                     sketcherMinimizerPointF(coords2[i].x(), -coords2[i].y());
             }
-            map<sketcherMinimizerAtom *, sketcherMinimizerPointF> map1, map2;
+            map<sketcherMinimizerAtom*, sketcherMinimizerPointF> map1, map2;
             for (unsigned int i = 0; i < atoms.size(); i++) {
                 map1[atoms[i]] = coords[i];
                 map2[atoms[i]] = coords2[i];
@@ -524,7 +524,7 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
 
 vector<sketcherMinimizerPointF>
 CoordgenFragmentBuilder::listOfCoordinatesFromListofRingAtoms(
-    const vector<sketcherMinimizerAtom*> atoms)
+    const vector<sketcherMinimizerAtom*>& atoms)
 {
     vector<sketcherMinimizerPointF> out;
     assert(atoms.size());
@@ -970,7 +970,7 @@ void CoordgenFragmentBuilder::initializeFusedRingInformation(
 }
 
 void CoordgenFragmentBuilder::simplifyRingSystem(
-    const vector<sketcherMinimizerRing*> allRings,
+    const vector<sketcherMinimizerRing*>& allRings,
     stack<sketcherMinimizerRing*>& sideRings,
     vector<sketcherMinimizerRing*>& centralRings) const
 {

--- a/CoordgenFragmentBuilder.cpp
+++ b/CoordgenFragmentBuilder.cpp
@@ -3,13 +3,15 @@
  Copyright Schrodinger, LLC. All rights reserved
  */
 
+#include <algorithm>
+#include <map>
+#include <numeric>
+
 #include "CoordgenFragmentBuilder.h"
 #include "CoordgenMinimizer.h"
-
 #include "sketcherMinimizer.h"
 #include "sketcherMinimizerFragment.h"
-#include <algorithm>
-#include <numeric>
+
 using namespace std;
 
 const int bondLength = BONDLENGTH;

--- a/CoordgenFragmentBuilder.h
+++ b/CoordgenFragmentBuilder.h
@@ -7,14 +7,14 @@
 #define COORDGEN_FRAGMENT_BUILDER_H
 
 #include <iostream>
-#include <vector>
-#include <stack>
-#include <queue>
 #include <map>
+#include <queue>
 #include <set>
+#include <stack>
+#include <vector>
 
-#include "CoordgenMacrocycleBuilder.h"
 #include "CoordgenConfig.hpp"
+#include "CoordgenMacrocycleBuilder.h"
 
 class sketcherMinimizerAtom;
 class sketcherMinimizerBond;
@@ -44,7 +44,7 @@ class EXPORT_COORDGEN CoordgenFragmentBuilder
      return a vector of atoms so that bound atoms are placed next to each other
      */
     static std::vector<sketcherMinimizerAtom*>
-    orderChainOfAtoms(const std::vector<sketcherMinimizerAtom*> atoms,
+    orderChainOfAtoms(const std::vector<sketcherMinimizerAtom*>& atoms,
                       sketcherMinimizerAtom* startAtom);
 
     /*
@@ -53,7 +53,7 @@ class EXPORT_COORDGEN CoordgenFragmentBuilder
      */
     static std::vector<sketcherMinimizerPointF>
     listOfCoordinatesFromListofRingAtoms(
-        const std::vector<sketcherMinimizerAtom*> atoms);
+        const std::vector<sketcherMinimizerAtom*>& atoms);
 
     /*
      set a flag that forces the macrocycle builder to skip expensive polyomino
@@ -98,12 +98,12 @@ class EXPORT_COORDGEN CoordgenFragmentBuilder
     void generateCoordinatesCentralRings(
         std::vector<sketcherMinimizerRing*> centralRings) const;
     sketcherMinimizerRing* findCentralRingOfSystem(
-        const std::vector<sketcherMinimizerRing*> rings) const;
+        const std::vector<sketcherMinimizerRing*>& rings) const;
 
     /*
      find a template to generate coordinates for a ring system
      */
-    bool findTemplate(const std::vector<sketcherMinimizerRing*> rings) const;
+    bool findTemplate(const std::vector<sketcherMinimizerRing*>& rings) const;
 
     /*
      generate coordinates for rings that have been stripped away from the core
@@ -145,7 +145,7 @@ class EXPORT_COORDGEN CoordgenFragmentBuilder
      share two atoms with other rings
      */
     void
-    simplifyRingSystem(const std::vector<sketcherMinimizerRing*> allRings,
+    simplifyRingSystem(const std::vector<sketcherMinimizerRing*>& allRings,
                        std::stack<sketcherMinimizerRing*>& sideRings,
                        std::vector<sketcherMinimizerRing*>& centralRings) const;
 
@@ -191,7 +191,7 @@ class EXPORT_COORDGEN CoordgenFragmentBuilder
 
     /* assign a score to the possibility of rings to be drawn on a plane */
     float
-    newScorePlanarity(const std::vector<sketcherMinimizerRing*> rings) const;
+    newScorePlanarity(const std::vector<sketcherMinimizerRing*>& rings) const;
 
     /* the macrocycle builder */
     CoordgenMacrocycleBuilder m_macrocycleBuilder;

--- a/CoordgenFragmentBuilder.h
+++ b/CoordgenFragmentBuilder.h
@@ -6,8 +6,6 @@
 #ifndef COORDGEN_FRAGMENT_BUILDER_H
 #define COORDGEN_FRAGMENT_BUILDER_H
 
-#include <iostream>
-#include <map>
 #include <queue>
 #include <set>
 #include <stack>

--- a/CoordgenFragmenter.cpp
+++ b/CoordgenFragmenter.cpp
@@ -4,15 +4,15 @@
  */
 
 #include "CoordgenFragmenter.h"
-#include "sketcherMinimizerMolecule.h"
 #include "sketcherMinimizerAtom.h"
 #include "sketcherMinimizerBond.h"
-#include "sketcherMinimizerRing.h"
 #include "sketcherMinimizerFragment.h"
+#include "sketcherMinimizerMolecule.h"
+#include "sketcherMinimizerRing.h"
 
 #include "sketcherMinimizerMaths.h"
-#include <queue>
 #include <algorithm>
+#include <queue>
 using namespace std;
 
 void CoordgenFragmenter::splitIntoFragments(sketcherMinimizerMolecule* molecule)
@@ -242,7 +242,7 @@ CoordgenFragmenter::getValueOfCheck(const sketcherMinimizerFragment* fragment,
 }
 
 sketcherMinimizerFragment* CoordgenFragmenter::findMainFragment(
-    vector<sketcherMinimizerFragment*> fragments)
+    const vector<sketcherMinimizerFragment*>& fragments)
 {
     sketcherMinimizerFragment* mainFragment =
         *(min_element(fragments.begin(), fragments.end(), hasPriority));
@@ -250,9 +250,9 @@ sketcherMinimizerFragment* CoordgenFragmenter::findMainFragment(
     return mainFragment;
 }
 
-sketcherMinimizerFragment*
-CoordgenFragmenter::considerChains(vector<sketcherMinimizerFragment*> fragments,
-                                   sketcherMinimizerFragment* mainFragment)
+sketcherMinimizerFragment* CoordgenFragmenter::considerChains(
+    const vector<sketcherMinimizerFragment*>& fragments,
+    sketcherMinimizerFragment* mainFragment)
 {
 
     foreach (sketcherMinimizerFragment* fragment, fragments) {
@@ -285,7 +285,7 @@ unsigned int CoordgenFragmenter::acceptableChainLength(
 }
 
 vector<sketcherMinimizerFragment*> CoordgenFragmenter::findLongestChain(
-    vector<sketcherMinimizerFragment*> fragments)
+    const vector<sketcherMinimizerFragment*>& fragments)
 {
     vector<sketcherMinimizerFragment*> longestChain;
     foreach (sketcherMinimizerFragment* fragment, fragments) {
@@ -342,7 +342,7 @@ vector<sketcherMinimizerFragment*> CoordgenFragmenter::findLongestChain(
 
 void CoordgenFragmenter::addParentRelationsToFragments(
     sketcherMinimizerFragment* mainFragment,
-    vector<sketcherMinimizerFragment*> fragments)
+    const vector<sketcherMinimizerFragment*>& fragments)
 {
     queue<sketcherMinimizerFragment*> fragmentsQueue;
     fragmentsQueue.push(mainFragment);

--- a/CoordgenFragmenter.h
+++ b/CoordgenFragmenter.h
@@ -114,14 +114,14 @@ class CoordgenFragmenter
      find the main fragment
      */
     static sketcherMinimizerFragment*
-    findMainFragment(std::vector<sketcherMinimizerFragment*> fragments);
+    findMainFragment(const std::vector<sketcherMinimizerFragment*>& fragments);
 
     /*
      if molecule has a long enough chain return the start of the chain as main
      fragment instead
      */
     static sketcherMinimizerFragment*
-    considerChains(std::vector<sketcherMinimizerFragment*> fragments,
+    considerChains(const std::vector<sketcherMinimizerFragment*>& fragments,
                    sketcherMinimizerFragment* mainFragment);
 
     /* empirical minimum length of zigzag chain of fragments
@@ -135,14 +135,14 @@ class CoordgenFragmenter
      find the longest chain of connected fragments
      */
     static std::vector<sketcherMinimizerFragment*>
-    findLongestChain(std::vector<sketcherMinimizerFragment*> fragments);
+    findLongestChain(const std::vector<sketcherMinimizerFragment*>& fragments);
 
     /*
      initialize parent-child info of bound fragments
      */
     static void addParentRelationsToFragments(
         sketcherMinimizerFragment* mainFragment,
-        std::vector<sketcherMinimizerFragment*> fragments);
+        const std::vector<sketcherMinimizerFragment*>& fragments);
 
     /*
      order the vector of fragments so that bound fragments are consecutive,

--- a/CoordgenMacrocycleBuilder.cpp
+++ b/CoordgenMacrocycleBuilder.cpp
@@ -6,9 +6,9 @@
 #include "CoordgenMacrocycleBuilder.h"
 #include "CoordgenMinimizer.h"
 #include "sketcherMinimizer.h"
-#include <queue>
-#include <algorithm>
 #include "sketcherMinimizerMaths.h"
+#include <algorithm>
+#include <queue>
 
 #define MAX_MACROCYCLES 40
 #define PATH_FAILED -1000
@@ -804,7 +804,7 @@ bool CoordgenMacrocycleBuilder::openCycleAndGenerateCoords(
 }
 
 vector<Polyomino>
-CoordgenMacrocycleBuilder::listOfEquivalents(vector<Polyomino> l) const
+CoordgenMacrocycleBuilder::listOfEquivalents(const vector<Polyomino>& l) const
 {
     vector<Polyomino> out;
     for (unsigned int i = 0; i < l.size(); i++) {
@@ -1210,7 +1210,7 @@ CoordgenMacrocycleBuilder::coordsOfVertex(vertexCoords& v) const
 }
 
 void CoordgenMacrocycleBuilder::writePolyominoCoordinates(
-    vector<vertexCoords>& path, vector<sketcherMinimizerAtom*> atoms,
+    vector<vertexCoords>& path, const vector<sketcherMinimizerAtom*>& atoms,
     int startI) const
 {
 

--- a/CoordgenMacrocycleBuilder.h
+++ b/CoordgenMacrocycleBuilder.h
@@ -6,10 +6,10 @@
 #ifndef COORDGEN_MACROCYCLE_BUILDER_H
 #define COORDGEN_MACROCYCLE_BUILDER_H
 
+#include "CoordgenConfig.hpp"
+#include <cstdlib>
 #include <iostream>
 #include <vector>
-#include <cstdlib>
-#include "CoordgenConfig.hpp"
 
 class sketcherMinimizerAtom;
 class sketcherMinimizerRing;
@@ -340,7 +340,8 @@ class EXPORT_COORDGEN CoordgenMacrocycleBuilder
      * hexagons with 3 neighbors */
     std::vector<Polyomino> listOfEquivalent(Polyomino p) const;
 
-    std::vector<Polyomino> listOfEquivalents(std::vector<Polyomino> l) const;
+    std::vector<Polyomino>
+    listOfEquivalents(const std::vector<Polyomino>& l) const;
 
     /* check that no ring constraints are violated */
     bool checkRingConstraints(std::vector<ringConstraint>& ringConstraints,
@@ -386,9 +387,10 @@ class EXPORT_COORDGEN CoordgenMacrocycleBuilder
                         int& bestStart, int& bestScore) const;
 
     /* write the coordinates of the given path */
-    void writePolyominoCoordinates(std::vector<vertexCoords>& path,
-                                   std::vector<sketcherMinimizerAtom*> atoms,
-                                   int startI) const;
+    void
+    writePolyominoCoordinates(std::vector<vertexCoords>& path,
+                              const std::vector<sketcherMinimizerAtom*>& atoms,
+                              int startI) const;
 
     /* return the coordinates of the given vertex */
     sketcherMinimizerPointF coordsOfVertex(vertexCoords& v) const;

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -4,21 +4,21 @@
  */
 
 #include "CoordgenMinimizer.h"
+#include "sketcherMinimizer.h" // should be removed at the end of refactoring
 #include "sketcherMinimizerAtom.h"
+#include "sketcherMinimizerBendInteraction.h"
 #include "sketcherMinimizerBond.h"
+#include "sketcherMinimizerClashInteraction.h"
+#include "sketcherMinimizerConstraintInteraction.h"
+#include "sketcherMinimizerEZConstrainInteraction.h"
+#include "sketcherMinimizerFragment.h"
+#include "sketcherMinimizerMaths.h"
 #include "sketcherMinimizerResidue.h"
 #include "sketcherMinimizerResidueInteraction.h"
-#include "sketcherMinimizerFragment.h"
 #include "sketcherMinimizerRing.h"
-#include "sketcherMinimizerClashInteraction.h"
-#include "sketcherMinimizerBendInteraction.h"
-#include "sketcherMinimizerEZConstrainInteraction.h"
 #include "sketcherMinimizerStretchInteraction.h"
-#include "sketcherMinimizerConstraintInteraction.h"
-#include "sketcherMinimizer.h" // should be removed at the end of refactoring
-#include <queue>
 #include <algorithm>
-#include "sketcherMinimizerMaths.h"
+#include <queue>
 
 using namespace std;
 static const float bondLength = BONDLENGTH;
@@ -206,8 +206,8 @@ void CoordgenMinimizer::addStretchInteractionsOfMolecule(
 
 /* return a set of all carbons part of a carbonyl group, i.e. doubly bonded to
  * an oxygen. */
-std::set<sketcherMinimizerAtom*>
-CoordgenMinimizer::getChetoCs(std::vector<sketcherMinimizerAtom*> allAtoms)
+std::set<sketcherMinimizerAtom*> CoordgenMinimizer::getChetoCs(
+    const std::vector<sketcherMinimizerAtom*>& allAtoms)
 {
     std::set<sketcherMinimizerAtom*> chetoCs;
     for (auto atom : allAtoms) {
@@ -229,8 +229,8 @@ CoordgenMinimizer::getChetoCs(std::vector<sketcherMinimizerAtom*> allAtoms)
 
 /* return a set of all amino nitrogens. Not chemically accurate, doesn't filter
  * out nitro Ns for instance. */
-std::set<sketcherMinimizerAtom*>
-CoordgenMinimizer::getAminoNs(std::vector<sketcherMinimizerAtom*> allAtoms)
+std::set<sketcherMinimizerAtom*> CoordgenMinimizer::getAminoNs(
+    const std::vector<sketcherMinimizerAtom*>& allAtoms)
 {
     std::set<sketcherMinimizerAtom*> aminoNs;
     for (auto atom : allAtoms) {
@@ -244,10 +244,10 @@ CoordgenMinimizer::getAminoNs(std::vector<sketcherMinimizerAtom*> allAtoms)
 /* return a set of all aminoacid alpha carbon, i.e. a carbon that is bound to a
  nitrogen
  and a cheto carbon. */
-std::set<sketcherMinimizerAtom*>
-CoordgenMinimizer::getAlphaCs(std::vector<sketcherMinimizerAtom*> allAtoms,
-                              std::set<sketcherMinimizerAtom*> chetoCs,
-                              std::set<sketcherMinimizerAtom*> aminoNs)
+std::set<sketcherMinimizerAtom*> CoordgenMinimizer::getAlphaCs(
+    const std::vector<sketcherMinimizerAtom*>& allAtoms,
+    const std::set<sketcherMinimizerAtom*>& chetoCs,
+    const std::set<sketcherMinimizerAtom*>& aminoNs)
 {
     std::set<sketcherMinimizerAtom*> alphaCs;
     for (auto atom : allAtoms) {
@@ -313,10 +313,10 @@ void CoordgenMinimizer::addPeptideBondInversionConstraintsOfMolecule(
  Useful to detect portions of a peptide backbone for instance. */
 void CoordgenMinimizer::getFourConsecutiveAtomsThatMatchSequence(
     std::vector<std::vector<sketcherMinimizerAtom*>>& consecutiveAtomsGroups,
-    std::set<sketcherMinimizerAtom*> firstSet,
-    std::set<sketcherMinimizerAtom*> secondSet,
-    std::set<sketcherMinimizerAtom*> thirdSet,
-    std::set<sketcherMinimizerAtom*> fourthSet) const
+    const std::set<sketcherMinimizerAtom*>& firstSet,
+    const std::set<sketcherMinimizerAtom*>& secondSet,
+    const std::set<sketcherMinimizerAtom*>& thirdSet,
+    const std::set<sketcherMinimizerAtom*>& fourthSet) const
 {
     for (auto firstAtom : firstSet) {
         for (auto secondAtom : firstAtom->neighbors) {
@@ -581,7 +581,7 @@ void CoordgenMinimizer::minimizeResidues()
 }
 
 void CoordgenMinimizer::minimizeProteinOnlyLID(
-    std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains)
+    const std::map<std::string, std::vector<sketcherMinimizerResidue*>>& chains)
 {
     setupInteractionsProteinOnly(chains);
     run();
@@ -619,7 +619,7 @@ void CoordgenMinimizer::setupInteractionsOnlyResidues()
 }
 
 void CoordgenMinimizer::setupInteractionsProteinOnly(
-    std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains)
+    const std::map<std::string, std::vector<sketcherMinimizerResidue*>>& chains)
 {
     clearInteractions();
     std::set<sketcherMinimizerBond*> interactions;
@@ -712,7 +712,7 @@ bool CoordgenMinimizer::findIntermolecularClashes(
 }
 
 bool CoordgenMinimizer::findIntermolecularClashes(
-    vector<sketcherMinimizerMolecule*> mols, float threshold)
+    const vector<sketcherMinimizerMolecule*>& mols, float threshold)
 {
     for (unsigned int i = 0; i < mols.size(); i++) {
         for (unsigned int j = i + 1; j < mols.size(); j++) {
@@ -973,7 +973,7 @@ bool CoordgenMinimizer::runExhaustiveSearch(sketcherMinimizerMolecule* molecule,
 
 void CoordgenMinimizer::runExhaustiveSearchLevel(
     sketcherMinimizerMolecule* molecule,
-    vector<CoordgenFragmentDOF*>::iterator iterator,
+    const vector<CoordgenFragmentDOF*>::iterator& iterator,
     vector<CoordgenFragmentDOF*>& dofs, float& bestResult, bool& abort,
     CoordgenDOFSolutions& solutions)
 {
@@ -1004,10 +1004,10 @@ void CoordgenMinimizer::runExhaustiveSearchLevel(
 }
 
 std::vector<std::vector<CoordgenFragmentDOF*>>
-CoordgenMinimizer::buildTuplesOfDofs(vector<CoordgenFragmentDOF*> dofs,
+CoordgenMinimizer::buildTuplesOfDofs(const vector<CoordgenFragmentDOF*>& dofs,
                                      unsigned int order) const
 {
-    std::vector<std::vector<CoordgenFragmentDOF *>> growingVector,
+    std::vector<std::vector<CoordgenFragmentDOF*>> growingVector,
         lastOrderVector;
     for (auto dof : dofs) {
         std::vector<CoordgenFragmentDOF*> tuple;
@@ -1111,7 +1111,7 @@ bool CoordgenMinimizer::runSearch(int tier, CoordgenDOFSolutions& solutions)
 }
 
 bool CoordgenMinimizer::runLocalSearch(sketcherMinimizerMolecule* molecule,
-                                       vector<CoordgenFragmentDOF*> dofs,
+                                       const vector<CoordgenFragmentDOF*>& dofs,
                                        int levels, float& clashE,
                                        CoordgenDOFSolutions& solutions)
 {
@@ -1133,40 +1133,6 @@ bool CoordgenMinimizer::runLocalSearch(sketcherMinimizerMolecule* molecule,
     return false;
 }
 
-/*
-
-bool CoordgenMinimizer::runLocalSearch(sketcherMinimizerMolecule* molecule,
-vector <CoordgenFragmentDOF*> dofs, float& clashE)
-{
-float bestResult = clashE;
-bool downhill = true;
-do {
-    downhill = false;
-    for (auto dof : dofs) {
-        for (int i = 1; i < dof->numberOfStates(); ++i)
-        {
-            dof->changeState();
-            buildMoleculeFromFragments(molecule);
-            float result = scoreClashes(molecule, true);
-            if (result < clashEnergyThreshold) {
-                dof->storeCurrentValueAsOptimal();
-                dof->setToOptimalValue();
-                clashE = result;
-                return true;
-            } else if (result < bestResult - SKETCHER_EPSILON) {
-                bestResult = result;
-                clashE = result;
-                downhill = true;
-                dof->storeCurrentValueAsOptimal();
-            }
-        }
-        dof->setToOptimalValue();
-    }
-} while (downhill);
-return false;
-}
-*/
-
 bool CoordgenMinimizer::flipFragments(sketcherMinimizerMolecule* molecule,
                                       float& clashE)
 {
@@ -1175,7 +1141,7 @@ bool CoordgenMinimizer::flipFragments(sketcherMinimizerMolecule* molecule,
         return true;
     if (bestResult < clashEnergyThreshold)
         return true;
-    vector<CoordgenFragmentDOF *> dofs, onlyFlipDofs;
+    vector<CoordgenFragmentDOF*> dofs, onlyFlipDofs;
     vector<sketcherMinimizerFragment*> fragments = molecule->getFragments();
     reverse(fragments.begin(), fragments.end());
     for (auto fragment : fragments) {
@@ -1199,7 +1165,7 @@ bool CoordgenMinimizer::flipFragments(sketcherMinimizerMolecule* molecule,
 
 bool CoordgenMinimizer::avoidClashesOfMolecule(
     sketcherMinimizerMolecule* molecule,
-    std::vector<sketcherMinimizerInteraction*> extraInteractions)
+    const std::vector<sketcherMinimizerInteraction*>& extraInteractions)
 {
     clearInteractions();
     addClashInteractionsOfMolecule(molecule, false);
@@ -1348,7 +1314,8 @@ void CoordgenMinimizer::avoidTerminalClashes(
     clashE = scoreClashes(molecule);
 }
 
-void CoordgenMinimizer::maybeMinimizeRings(vector<sketcherMinimizerRing*> rings)
+void CoordgenMinimizer::maybeMinimizeRings(
+    const vector<sketcherMinimizerRing*>& rings)
 {
     bool found = false;
     for (unsigned int rr = 0; rr < rings.size(); rr++) {
@@ -1403,7 +1370,7 @@ void CoordgenMinimizer::buildFromFragments(bool firstTime) const
 }
 
 bool CoordgenMinimizer::hasValid3DCoordinates(
-    vector<sketcherMinimizerAtom*> atoms)
+    const vector<sketcherMinimizerAtom*>& atoms)
 {
     foreach (sketcherMinimizerAtom* atom, atoms) {
         if (!atom->hasValid3DCoordinates()) {
@@ -1414,7 +1381,7 @@ bool CoordgenMinimizer::hasValid3DCoordinates(
 }
 
 void CoordgenMinimizer::fallbackOn3DCoordinates(
-    vector<sketcherMinimizerAtom*> atoms)
+    const vector<sketcherMinimizerAtom*>& atoms)
 {
     float scale = 35.f; // ratio between average bond length and 2d bond length
     /* TODO find best projection */
@@ -1425,7 +1392,7 @@ void CoordgenMinimizer::fallbackOn3DCoordinates(
 }
 
 bool CoordgenMinimizer::hasNaNCoordinates(
-    std::vector<sketcherMinimizerAtom*> atoms)
+    const std::vector<sketcherMinimizerAtom*>& atoms)
 {
     foreach (sketcherMinimizerAtom* a, atoms)
         if (a->coordinates.x() != a->coordinates.x() ||
@@ -1558,7 +1525,7 @@ std::vector<short unsigned int> CoordgenDOFSolutions::getCurrentSolution()
 }
 
 void CoordgenDOFSolutions::loadSolution(
-    std::vector<short unsigned int> solution)
+    const std::vector<short unsigned int>& solution)
 {
     assert(solution.size() == m_allDofs.size());
     for (unsigned int i = 0; i < solution.size(); ++i) {
@@ -1566,7 +1533,8 @@ void CoordgenDOFSolutions::loadSolution(
     }
 }
 
-bool CoordgenDOFSolutions::hasSolution(std::vector<short unsigned int> solution)
+bool CoordgenDOFSolutions::hasSolution(
+    const std::vector<short unsigned int>& solution)
 {
     return m_solutions.find(solution) != m_solutions.end();
 }

--- a/CoordgenMinimizer.h
+++ b/CoordgenMinimizer.h
@@ -6,11 +6,11 @@
 #ifndef COORDGEN_MINIMIZER_H
 #define COORDGEN_MINIMIZER_H
 
-#include <iostream>
-#include <vector>
-#include <set>
-#include <map>
 #include "CoordgenConfig.hpp"
+#include <iostream>
+#include <map>
+#include <set>
+#include <vector>
 
 class sketcherMinimizerInteraction;
 class sketcherMinimizerStretchInteraction;
@@ -37,7 +37,8 @@ class CoordgenDOFSolutions
     CoordgenDOFSolutions(const CoordgenMinimizer* minimizer,
                          sketcherMinimizerMolecule* molecule,
                          std::vector<CoordgenFragmentDOF*> allDofs)
-        : m_minimizer(minimizer), m_molecule(molecule), m_allDofs(allDofs)
+        : m_minimizer(minimizer), m_molecule(molecule),
+          m_allDofs(std::move(allDofs))
     {
     }
     /*
@@ -55,7 +56,7 @@ class CoordgenDOFSolutions
      load the given solution (i.e. set each degree of freedom in the molecule to
      the  given value)
      */
-    void loadSolution(std::vector<short unsigned int> solution);
+    void loadSolution(const std::vector<short unsigned int>& solution);
 
     /*
      return the best scoring solution that has been found so far
@@ -65,7 +66,7 @@ class CoordgenDOFSolutions
     /*
      check if the given solution has already been scored
      */
-    bool hasSolution(std::vector<short unsigned int> solution);
+    bool hasSolution(const std::vector<short unsigned int>& solution);
 
     std::vector<CoordgenFragmentDOF*> getAllDofs() { return m_allDofs; }
 
@@ -106,7 +107,8 @@ class EXPORT_COORDGEN CoordgenMinimizer
 
     /* solve clashes of residues in a protein-protein interaction LID */
     void minimizeProteinOnlyLID(
-        std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains);
+        const std::map<std::string, std::vector<sketcherMinimizerResidue*>>&
+            chains);
 
     /* setup constraints and run a force-field based minimization */
     void minimizeAll();
@@ -117,7 +119,8 @@ class EXPORT_COORDGEN CoordgenMinimizer
     /* setup constraints on residues in a protein-protein interaction scenario
      */
     void setupInteractionsProteinOnly(
-        std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains);
+        const std::map<std::string, std::vector<sketcherMinimizerResidue*>>&
+            chains);
 
     /* setup all constraints */
     void setupInteractions(bool intrafragmentClashes = false);
@@ -137,8 +140,8 @@ class EXPORT_COORDGEN CoordgenMinimizer
                                    float threshold);
 
     /* add a list of intermolecular clash constraints between given molecules */
-    bool findIntermolecularClashes(std::vector<sketcherMinimizerMolecule*> mols,
-                                   float threshold);
+    bool findIntermolecularClashes(
+        const std::vector<sketcherMinimizerMolecule*>& mols, float threshold);
 
     /* run a minimization of the molecules rings constraining their shape to
      * regular polygons */
@@ -183,7 +186,7 @@ class EXPORT_COORDGEN CoordgenMinimizer
      */
     bool avoidClashesOfMolecule(
         sketcherMinimizerMolecule* molecule,
-        std::vector<sketcherMinimizerInteraction*> extraInteractions =
+        const std::vector<sketcherMinimizerInteraction*>& extraInteractions =
             std::vector<sketcherMinimizerInteraction*>());
 
     /*
@@ -196,8 +199,9 @@ class EXPORT_COORDGEN CoordgenMinimizer
      of freedom
      */
     bool runLocalSearch(sketcherMinimizerMolecule* molecule,
-                        std::vector<CoordgenFragmentDOF*> dofs, int levels,
-                        float& clashE, CoordgenDOFSolutions& solutions);
+                        const std::vector<CoordgenFragmentDOF*>& dofs,
+                        int levels, float& clashE,
+                        CoordgenDOFSolutions& solutions);
 
     /*
      iteratively grow the pool of solutions by mutating the best scoring one by
@@ -221,7 +225,7 @@ class EXPORT_COORDGEN CoordgenMinimizer
     /* build a list of tuples of the given order representing all combinations
      * of dofs */
     std::vector<std::vector<CoordgenFragmentDOF*>>
-    buildTuplesOfDofs(std::vector<CoordgenFragmentDOF*> dofs,
+    buildTuplesOfDofs(const std::vector<CoordgenFragmentDOF*>& dofs,
                       unsigned int order) const;
 
     /*
@@ -233,7 +237,7 @@ class EXPORT_COORDGEN CoordgenMinimizer
 
     void runExhaustiveSearchLevel(
         sketcherMinimizerMolecule* molecule,
-        std::vector<CoordgenFragmentDOF*>::iterator iterator,
+        const std::vector<CoordgenFragmentDOF*>::iterator& iterator,
         std::vector<CoordgenFragmentDOF*>& dofs, float& bestResult, bool& abort,
         CoordgenDOFSolutions& solutions);
 
@@ -252,7 +256,8 @@ class EXPORT_COORDGEN CoordgenMinimizer
      check if the ring system cannot be drown with regular polygons and needs a
      FF based minimization
      */
-    static void maybeMinimizeRings(std::vector<sketcherMinimizerRing*> rings);
+    static void
+    maybeMinimizeRings(const std::vector<sketcherMinimizerRing*>& rings);
 
     /*
      avoid clashes of terminal atoms of the same fragment without running a
@@ -275,17 +280,17 @@ class EXPORT_COORDGEN CoordgenMinimizer
 
     /* find a list of carbons from the backbone C=O of a peptide */
     std::set<sketcherMinimizerAtom*>
-    getChetoCs(std::vector<sketcherMinimizerAtom*> allAtoms);
+    getChetoCs(const std::vector<sketcherMinimizerAtom*>& allAtoms);
 
     /* find a list of nitrogens from the backbon NH of a peptide */
     std::set<sketcherMinimizerAtom*>
-    getAminoNs(std::vector<sketcherMinimizerAtom*> allAtoms);
+    getAminoNs(const std::vector<sketcherMinimizerAtom*>& allAtoms);
 
     /* find a list of alpha carbons of a peptide */
     std::set<sketcherMinimizerAtom*>
-    getAlphaCs(std::vector<sketcherMinimizerAtom*> allAtoms,
-               std::set<sketcherMinimizerAtom*> chetoCs,
-               std::set<sketcherMinimizerAtom*> aminoNs);
+    getAlphaCs(const std::vector<sketcherMinimizerAtom*>& allAtoms,
+               const std::set<sketcherMinimizerAtom*>& chetoCs,
+               const std::set<sketcherMinimizerAtom*>& aminoNs);
 
     /* check the atom for clashes with other atoms */
     static void checkForClashes(sketcherMinimizerAtom* a);
@@ -293,19 +298,20 @@ class EXPORT_COORDGEN CoordgenMinimizer
     /*
      return true if atoms have NaN coordinates
      */
-    static bool hasNaNCoordinates(std::vector<sketcherMinimizerAtom*> atoms);
+    static bool
+    hasNaNCoordinates(const std::vector<sketcherMinimizerAtom*>& atoms);
     bool hasNaNCoordinates();
 
     /*
      return true if the atom has valid 3d coordinates
      */
     static bool
-    hasValid3DCoordinates(std::vector<sketcherMinimizerAtom*> atoms);
+    hasValid3DCoordinates(const std::vector<sketcherMinimizerAtom*>& atoms);
 
     /* use 3d coordinates in 2d (e.g. when a reasonable 2d structure cannot be
      * found) */
     static void
-    fallbackOn3DCoordinates(std::vector<sketcherMinimizerAtom*> atoms);
+    fallbackOn3DCoordinates(const std::vector<sketcherMinimizerAtom*>& atoms);
 
     /*
      add the given constraint to the minimizer
@@ -367,10 +373,10 @@ class EXPORT_COORDGEN CoordgenMinimizer
     void getFourConsecutiveAtomsThatMatchSequence(
         std::vector<std::vector<sketcherMinimizerAtom*>>&
             consecutiveAtomsGroups,
-        std::set<sketcherMinimizerAtom*> firstSet,
-        std::set<sketcherMinimizerAtom*> secondSet,
-        std::set<sketcherMinimizerAtom*> thirdSet,
-        std::set<sketcherMinimizerAtom*> fourthSet) const;
+        const std::set<sketcherMinimizerAtom*>& firstSet,
+        const std::set<sketcherMinimizerAtom*>& secondSet,
+        const std::set<sketcherMinimizerAtom*>& thirdSet,
+        const std::set<sketcherMinimizerAtom*>& fourthSet) const;
 
     std::vector<sketcherMinimizerInteraction*> _interactions;
     std::vector<sketcherMinimizerStretchInteraction*> _stretchInteractions;

--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -303,73 +303,6 @@ void sketcherMinimizer::flagCrossAtoms()
     }
 }
 
-/*
-void sketcherMinimizer::exportCoordinates(ChmMol& molecule)
-{
-
-    foreach (sketcherMinimizerAtom* a, _referenceAtoms) {
-        a->setCoordinates(a->coordinates); // round the coordinates
-
-        // set NaN coordinates to (0);
-        if (a->coordinates.x() != a->coordinates.x()) {
-            cerr << "coordgen warning: NaN coordinates" << endl;
-            a->coordinates.setX(0.f);
-        }
-        if (a->coordinates.y() != a->coordinates.y()) {
-            cerr << "coordgen warning: NaN coordinates" << endl;
-            a->coordinates.setY(0.f);
-        }
-    }
-
-    ChmAtoms as = molecule.getAtoms(true);
-    unsigned int i = 0;
-
-    while (as.hasNext()) {
-
-        ChmAtom& chma = as.next();
-        //   if (chma.isDummy ()) continue;
-        if (i < _referenceAtoms.size() && !_referenceAtoms[i]->hidden) {
-            sketcherMinimizerPointF& p = _referenceAtoms[i]->coordinates;
-            ChmPoint pt(p.x() / 35.f, p.y() / 35.f, 0.0f);
-            if (pt.isZero()) {
-                // apply gaussian random deviate to coordinates placed at origin
-                ChmPoint offset((float) m_random.nextGaussian(0.0, 1e-20),
-                                (float) m_random.nextGaussian(0.0, 1e-20), 0);
-                pt += offset;
-            }
-            chma.setCoords(pt);
-        }
-        i++;
-    }
-
-    unsigned int j = 0;
-    ChmBonds bs = molecule.getBonds(true);
-    while (bs.hasNext()) {
-        ChmBond& chmb = bs.next();
-        if (chmb.atom1().isDummy() && !chmb.atom1().isWildcard())
-            continue;
-        if (chmb.atom2().isDummy() && !chmb.atom2().isWildcard())
-            continue;
-
-        if (chmb.isHidden()) {
-            chmb.setBondDirectionHint(ChmBond::directionNone);
-            continue; // do not increment j
-        }
-        const bool stereoBonds = _referenceBonds[j]->hasStereochemistryDisplay;
-        if (stereoBonds) {
-            if (_referenceBonds[j]->isWedge) {
-                chmb.setBondDirectionHint(ChmBond::directionUp);
-            } else {
-                chmb.setBondDirectionHint(ChmBond::directionDown);
-            }
-        } else {
-            chmb.setBondDirectionHint(ChmBond::directionNone);
-        }
-        j++;
-    }
-}
-*/
-
 void sketcherMinimizer::clear()
 {
     for (unsigned int i = 0; i < _referenceAtoms.size(); i++) {
@@ -403,140 +336,6 @@ void sketcherMinimizer::clear()
 
     _molecules.clear();
 }
-
-/*
-void sketcherMinimizer::initializeFromMolecule(ChmMol& mol)
-{
-    sketcherMinimizerMolecule* minMol = new sketcherMinimizerMolecule;
-    ChmAtoms as = mol.getAtoms(true);
-    unsigned int i = 0;
-    while (as.hasNext()) {
-        ChmAtom& chma = as.next();
-        sketcherMinimizerAtom* min_at = new sketcherMinimizerAtom;
-        min_at->_generalUseN = i;
-        min_at->_generalUseN2 = i; // generalUseN will be changed by initialise,
-                                   // we need a second counter to assign atom
-                                   // chirality
-        min_at->m_chmN = chma.getMolIndex();
-
-        i++;
-
-        min_at->charge = chma.getFormalCharge();
-        min_at->atomicNumber = chma.getAtomicNumber();
-        min_at->fixed = chma.isFixed();
-
-        min_at->constrained = chma.isConstrained();
-        min_at->coordinates =
-            sketcherMinimizerPointF(chma.getX() * 35.f, chma.getY() * 35.f);
-        min_at->templateCoordinates = min_at->coordinates;
-
-        min_at->hidden = chma.isHidden();
-        if (chma.isDummy() && !chma.isWildcard())
-            min_at->hidden = true;
-
-        min_at->molecule = minMol;
-        minMol->_atoms.push_back(min_at);
-    }
-
-    ChmBonds bs = mol.getBonds(true);
-
-    while (bs.hasNext()) {
-        ChmBond& chmb = bs.next();
-        // do not create sketcher bond to any hidden atoms
-        // this means that bond vectors will be out of sequence
-        if (chmb.atom1().isHidden() || chmb.atom2().isHidden())
-            continue;
-        if ((chmb.atom1().isDummy() && !chmb.atom1().isWildcard()) ||
-            (chmb.atom2().isDummy() && !chmb.atom2().isWildcard()))
-            continue;
-        sketcherMinimizerBond* min_bo = new sketcherMinimizerBond;
-        min_bo->startAtom = minMol->_atoms[chmb.atom1().getMolIndex()];
-        min_bo->endAtom = minMol->_atoms[chmb.atom2().getMolIndex()];
-        int order = chmb.getOrder();
-        if (chmb.isAromatic())
-            order -= 4;
-        min_bo->bondOrder = order;
-        minMol->_bonds.push_back(min_bo);
-    }
-
-    vector<pair<ATOM_INDEX_TYPE, ATOM_INDEX_TYPE>> zobs =
-        mol.getZeroOrderBonds();
-    const unsigned int zbsz = (int) zobs.size();
-    unsigned int atomsize = (int) as.size();
-    if (minMol->_atoms.size() < atomsize)
-        atomsize = (int) minMol->_atoms.size();
-    for (unsigned int i = 0; i < zbsz; i++) {
-        pair<ATOM_INDEX_TYPE, ATOM_INDEX_TYPE>& pr = zobs[i];
-        const unsigned int i1 = pr.first;
-        const unsigned int i2 = pr.second;
-        if (i1 >= atomsize || i2 >= atomsize)
-            continue;
-        ChmAtom& atom1 = as[i1];
-        ChmAtom& atom2 = as[i2];
-        if (atom1.isHidden() || atom2.isHidden())
-            continue;
-        if ((atom1.isDummy() && !atom1.isWildcard()) ||
-            (atom2.isDummy() && !atom2.isWildcard()))
-            continue;
-        sketcherMinimizerBond* min_bo = new sketcherMinimizerBond;
-        min_bo->startAtom = minMol->_atoms[i1];
-        min_bo->endAtom = minMol->_atoms[i2];
-        min_bo->bondOrder = 0;
-        minMol->_bonds.push_back(min_bo);
-    }
-
-    sketcherMinimizerMolecule::assignBondsAndNeighbors(minMol->_atoms,
-                                                       minMol->_bonds);
-
-    foreach (sketcherMinimizerBond* b, minMol->_bonds) {
-        if (b->bondOrder == 2) {
-
-            sketcherMinimizerAtom* startA = b->startAtomCIPFirstNeighbor();
-            sketcherMinimizerAtom* endA = b->endAtomCIPFirstNeighbor();
-            if (startA && endA) {
-                ChmBond chb =
-                    mol.getBond(mol.getAtom(b->startAtom->_generalUseN2),
-                                mol.getAtom(b->endAtom->_generalUseN2));
-
-                if (chb.getStereo() == BondCis) {
-                    int i1 = -1, i2 = -1;
-                    chb.getCis(i1, i2);
-                    bool isZ = true;
-                    if (!(i1 == startA->_generalUseN2 ||
-                          i1 == endA->_generalUseN2))
-                        isZ = !isZ;
-                    if (!(i2 == startA->_generalUseN2 ||
-                          i2 == endA->_generalUseN2))
-                        isZ = !isZ;
-                    b->isZ = isZ;
-                    //   cerr << "translating it to "<<isZ<<endl;
-                } else if (chb.getStereo() == BondTrans) {
-                    int i1 = -1, i2 = -1;
-                    chb.getTrans(i1, i2);
-                    bool isZ = false;
-                    if (!(i1 == startA->_generalUseN2 ||
-                          i1 == endA->_generalUseN2))
-                        isZ = !isZ;
-                    if (!(i2 == startA->_generalUseN2 ||
-                          i2 == endA->_generalUseN2))
-                        isZ = !isZ;
-                    b->isZ = isZ;
-                } else {
-                    b->m_ignoreZE = true;
-                }
-            }
-        }
-    }
-    initialize(minMol);
-    for (unsigned int j = 0; j < minMol->_atoms.size(); j++) {
-        sketcherMinimizerAtom* a = minMol->_atoms[j];
-
-        ChmAtom atom = mol.getAtom(a->_generalUseN2);
-        ChmChiralityInfo info = atom.getChiralityInfo();
-        a->setStereochemistryFromChmChiralityInfo(info);
-    }
-}
-*/
 
 void sketcherMinimizer::splitIntoMolecules(
     sketcherMinimizerMolecule* mol, vector<sketcherMinimizerMolecule*>& mols)
@@ -740,7 +539,7 @@ void sketcherMinimizer::assignPseudoZ()
 }
 
 void sketcherMinimizer::maybeFlipPeptides(
-    std::vector<sketcherMinimizerAtom*> atoms, float& scoreX)
+    const std::vector<sketcherMinimizerAtom*>& atoms, float& scoreX)
 {
     auto chetoCs = m_minimizer.getChetoCs(atoms);
     auto aminoNs = m_minimizer.getAminoNs(atoms);
@@ -939,7 +738,7 @@ void sketcherMinimizer::addToVector(float weight, float angle,
 /* if a peptide chain is present rotate the molecule so it's horizontal */
 void sketcherMinimizer::addBestRotationInfoForPeptides(
     vector<pair<float, float>>& angles,
-    std::vector<sketcherMinimizerAtom*> atoms)
+    const std::vector<sketcherMinimizerAtom*>& atoms)
 {
     auto chetoCs = m_minimizer.getChetoCs(atoms);
     auto aminoNs = m_minimizer.getAminoNs(atoms);
@@ -1166,7 +965,7 @@ void sketcherMinimizer::findFragments()
 }
 
 void sketcherMinimizer::placeResiduesProteinOnlyModeCircleStyle(
-    std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains)
+    const std::map<std::string, std::vector<sketcherMinimizerResidue*>>& chains)
 {
     size_t totalResiduesNumber = _residues.size() + chains.size();
 
@@ -1201,7 +1000,7 @@ void sketcherMinimizer::placeResiduesProteinOnlyModeCircleStyle(
 
 std::map<std::string, sketcherMinimizerPointF>
 sketcherMinimizer::computeChainsStartingPositionsMetaMol(
-    std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains)
+    const std::map<std::string, std::vector<sketcherMinimizerResidue*>>& chains)
 {
     map<std::string, sketcherMinimizerAtom*> molMap;
 
@@ -1270,7 +1069,7 @@ sketcherMinimizer::computeChainsStartingPositionsMetaMol(
 }
 
 void sketcherMinimizer::shortenInteractions(
-    std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains)
+    const std::map<std::string, std::vector<sketcherMinimizerResidue*>>& chains)
 {
     for (auto chain : chains) {
         for (auto res : chain.second) {
@@ -1285,7 +1084,7 @@ void sketcherMinimizer::shortenInteractions(
 }
 
 std::vector<sketcherMinimizerResidue*> sketcherMinimizer::orderResiduesOfChains(
-    std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains)
+    const std::map<std::string, std::vector<sketcherMinimizerResidue*>>& chains)
 {
     std::vector<sketcherMinimizerResidue*> vec;
     for (auto chain : chains) {
@@ -1293,11 +1092,12 @@ std::vector<sketcherMinimizerResidue*> sketcherMinimizer::orderResiduesOfChains(
             vec.push_back(res);
         }
     }
-    sort(vec.begin(), vec.end(), [](const sketcherMinimizerResidue* firstRes,
-                                    const sketcherMinimizerResidue* secondRes) {
-        return firstRes->residueInteractions.size() >
-               secondRes->residueInteractions.size();
-    });
+    sort(vec.begin(), vec.end(),
+         [](const sketcherMinimizerResidue* firstRes,
+            const sketcherMinimizerResidue* secondRes) {
+             return firstRes->residueInteractions.size() >
+                    secondRes->residueInteractions.size();
+         });
     std::set<sketcherMinimizerResidue*> visitedResidues;
     std::queue<sketcherMinimizerResidue*> residueQueue;
     std::vector<sketcherMinimizerResidue*> finalVec;
@@ -1325,7 +1125,7 @@ std::vector<sketcherMinimizerResidue*> sketcherMinimizer::orderResiduesOfChains(
 }
 
 void sketcherMinimizer::placeResiduesProteinOnlyModeLIDStyle(
-    std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains)
+    const std::map<std::string, std::vector<sketcherMinimizerResidue*>>& chains)
 {
     auto positions = computeChainsStartingPositionsMetaMol(chains);
     sketcherMinimizerPointF p;
@@ -1398,12 +1198,12 @@ void sketcherMinimizer::placeResiduesInCrowns()
                  interactionsOfSecond += res->residueInteractions.size();
              }
              float interactionScaling = 3.f;
-             float score1 =
-                 firstSSE.size() +
-                 interactionScaling * interactionsOfFirst / firstSSE.size();
-             float score2 =
-                 secondSSE.size() +
-                 interactionScaling * interactionsOfSecond / secondSSE.size();
+             float score1 = firstSSE.size() + interactionScaling *
+                                                  interactionsOfFirst /
+                                                  firstSSE.size();
+             float score2 = secondSSE.size() + interactionScaling *
+                                                   interactionsOfSecond /
+                                                   secondSSE.size();
              return score1 > score2;
          });
     bool needOtherShape = true;
@@ -1435,7 +1235,8 @@ bool sketcherMinimizer::fillShape(
 /* assign a penalty for the stretching of bonds between residues in the same
  * SSE */
 float sketcherMinimizer::scoreSSEBondStretch(
-    sketcherMinimizerPointF coordinates1, sketcherMinimizerPointF coordinates2)
+    const sketcherMinimizerPointF& coordinates1,
+    const sketcherMinimizerPointF& coordinates2)
 {
     const float stretchPenalty = 400.f;
     auto squaredLength = (coordinates2 - coordinates1).squareLength();
@@ -1444,7 +1245,7 @@ float sketcherMinimizer::scoreSSEBondStretch(
 
 float sketcherMinimizer::getResidueDistance(
     float startF, float increment, sketcherMinimizerResidue* resToConsider,
-    vector<sketcherMinimizerResidue*> SSE)
+    const vector<sketcherMinimizerResidue*>& SSE)
 {
     float totalF = startF;
     sketcherMinimizerResidue* lastRes = nullptr;
@@ -1469,7 +1270,7 @@ float sketcherMinimizer::getResidueDistance(
 /* return a score for the placing on the SSE starting at startingPosition and
  * separated by increment */
 float sketcherMinimizer::scoreSSEPosition(
-    vector<sketcherMinimizerResidue*> SSE,
+    const vector<sketcherMinimizerResidue*>& SSE,
     const vector<sketcherMinimizerPointF>& shape, int shapeN,
     vector<bool>& penalties, float startingPosition, float increment)
 {
@@ -1509,7 +1310,7 @@ float sketcherMinimizer::scoreSSEPosition(
     return score;
 }
 
-void sketcherMinimizer::placeSSE(vector<sketcherMinimizerResidue*> SSE,
+void sketcherMinimizer::placeSSE(const vector<sketcherMinimizerResidue*>& SSE,
                                  const vector<sketcherMinimizerPointF>& shape,
                                  int shapeN, vector<bool>& penalties,
                                  set<sketcherMinimizerResidue*>& outliers,
@@ -1579,7 +1380,8 @@ void sketcherMinimizer::placeSSE(vector<sketcherMinimizerResidue*> SSE,
 }
 
 void sketcherMinimizer::markSolution(
-    pair<float, float> solution, vector<sketcherMinimizerResidue*> SSE,
+    const pair<float, float>& solution,
+    const vector<sketcherMinimizerResidue*>& SSE,
     const vector<sketcherMinimizerPointF>& shape, vector<bool>& penalties,
     set<sketcherMinimizerResidue*>& outliers)
 {
@@ -1616,8 +1418,8 @@ void sketcherMinimizer::markSolution(
     }
 }
 
-int sketcherMinimizer::getShapeIndex(vector<sketcherMinimizerPointF> shape,
-                                     float floatPosition)
+int sketcherMinimizer::getShapeIndex(
+    const vector<sketcherMinimizerPointF>& shape, float floatPosition)
 {
     float normalizedF = floatPosition;
     while (normalizedF < 0) {
@@ -1632,7 +1434,7 @@ int sketcherMinimizer::getShapeIndex(vector<sketcherMinimizerPointF> shape,
 
 vector<vector<sketcherMinimizerResidue*>>
 sketcherMinimizer::groupResiduesInSSEs(
-    vector<sketcherMinimizerResidue*> residues)
+    const vector<sketcherMinimizerResidue*>& residues)
 {
     // divide residues by chain
     map<string, vector<sketcherMinimizerResidue*>> chainsMap;
@@ -1756,10 +1558,11 @@ vector<sketcherMinimizerPointF> sketcherMinimizer::shapeAroundLigand(int crownN)
     ms.setThreshold(0);
     ms.run();
     auto result = ms.getOrderedCoordinatesPoints();
-    sort(result.begin(), result.end(), [](const vector<float>& firstContour,
-                                          const vector<float>& secondContour) {
-        return firstContour.size() > secondContour.size();
-    });
+    sort(result.begin(), result.end(),
+         [](const vector<float>& firstContour,
+            const vector<float>& secondContour) {
+             return firstContour.size() > secondContour.size();
+         });
     vector<sketcherMinimizerPointF> returnValue;
     if (result.size() > 0) {
         for (unsigned int i = 0; i < result.at(0).size(); i += 2) {
@@ -1811,7 +1614,8 @@ float sketcherMinimizer::scoreResiduePosition(
     return score;
 }
 
-void sketcherMinimizer::placeResidues(vector<sketcherMinimizerAtom*> atoms)
+void sketcherMinimizer::placeResidues(
+    const vector<sketcherMinimizerAtom*>& atoms)
 {
     if (!_residues.size()) {
         return;
@@ -1934,10 +1738,10 @@ sketcherMinimizer::exploreMolPosition(sketcherMinimizerMolecule* mol,
 }
 
 sketcherMinimizerPointF sketcherMinimizer::exploreGridAround(
-    sketcherMinimizerPointF centerOfGrid, unsigned int levels, float gridD,
-    float dx, float dy, float distanceFromAtoms, bool watermap,
+    const sketcherMinimizerPointF& centerOfGrid, unsigned int levels,
+    float gridD, float dx, float dy, float distanceFromAtoms, bool watermap,
     sketcherMinimizerResidue* residueForInteractions,
-    sketcherMinimizerPointF direction)
+    const sketcherMinimizerPointF& direction)
 {
     sketcherMinimizerPointF placeNextTo = centerOfGrid;
 
@@ -2781,8 +2585,8 @@ void sketcherMinimizer::initializeFragments()
 }
 
 bool sketcherMinimizer::alignWithParentDirectionConstrained(
-    sketcherMinimizerFragment* fragment, sketcherMinimizerPointF position,
-    float angle)
+    sketcherMinimizerFragment* fragment,
+    const sketcherMinimizerPointF& position, float angle)
 {
     vector<sketcherMinimizerPointF> templates, plainCoordinates,
         flippedCoordinates;
@@ -2873,8 +2677,8 @@ sketcherMinimizer::findDirectionsToAlignWith(
 }
 
 float sketcherMinimizer::testAlignment(
-    sketcherMinimizerPointF direction,
-    std::pair<sketcherMinimizerPointF, float> templat)
+    const sketcherMinimizerPointF& direction,
+    const std::pair<sketcherMinimizerPointF, float>& templat)
 {
     float dot = sketcherMinimizerMaths::dotProduct(direction, templat.first);
     if (dot < 0)
@@ -2888,7 +2692,8 @@ float sketcherMinimizer::testAlignment(
 
 sketcherMinimizerPointF sketcherMinimizer::scoreDirections(
     sketcherMinimizerFragment* fragment, float angle,
-    vector<std::pair<sketcherMinimizerPointF, float>> directions, bool& invert)
+    const vector<std::pair<sketcherMinimizerPointF, float>>& directions,
+    bool& invert)
 {
     float sine = sin(angle);
     float cosine = cos(angle);
@@ -2953,7 +2758,8 @@ bool sketcherMinimizer::alignWithParentDirectionUnconstrained(
 }
 
 void sketcherMinimizer::alignWithParentDirection(
-    sketcherMinimizerFragment* f, sketcherMinimizerPointF position, float angle)
+    sketcherMinimizerFragment* f, const sketcherMinimizerPointF& position,
+    float angle)
 {
     // deciding which "side" the fragment will be drawn, rotating 180° around
     // the axis of its bond to parent
@@ -3025,7 +2831,7 @@ sketcherMinimizerAtom*
 sketcherMinimizer::pickBestAtom(vector<sketcherMinimizerAtom*>& atoms)
 {
 
-    vector<sketcherMinimizerAtom *> candidates, oldCandidates;
+    vector<sketcherMinimizerAtom*> candidates, oldCandidates;
 
     {
         size_t biggestSize = atoms[0]->fragment->numberOfChildrenAtoms;
@@ -3092,7 +2898,7 @@ void sketcherMinimizer::constrainAllAtoms()
         a->constrained = true;
 }
 
-void sketcherMinimizer::constrainAtoms(vector<bool> constrained)
+void sketcherMinimizer::constrainAtoms(const vector<bool>& constrained)
 {
     if (constrained.size() == _referenceAtoms.size()) {
         for (unsigned int i = 0; i < constrained.size(); i++) {
@@ -3106,7 +2912,7 @@ void sketcherMinimizer::constrainAtoms(vector<bool> constrained)
     }
 }
 
-void sketcherMinimizer::fixAtoms(vector<bool> fixed)
+void sketcherMinimizer::fixAtoms(const vector<bool>& fixed)
 {
     if (fixed.size() == _referenceAtoms.size()) {
         for (unsigned int i = 0; i < fixed.size(); i++) {
@@ -3120,10 +2926,11 @@ void sketcherMinimizer::fixAtoms(vector<bool> fixed)
 }
 
 void sketcherMinimizer::findClosestAtomToResidues(
-    vector<sketcherMinimizerAtom*> atoms)
+    const vector<sketcherMinimizerAtom*>& catoms)
 {
-    if (!atoms.size())
-        atoms = _atoms;
+    const vector<sketcherMinimizerAtom*>& atoms =
+        catoms.empty() ? _atoms : catoms;
+
     foreach (sketcherMinimizerAtom* r, _residues) {
         float squareD = 9999999.f;
         sketcherMinimizerAtom* closestA = NULL;
@@ -3158,8 +2965,8 @@ void sketcherMinimizer::findClosestAtomToResidues(
     }
 }
 
-float sketcherMinimizer::RMSD(vector<sketcherMinimizerPointF> templates,
-                              vector<sketcherMinimizerPointF> points)
+float sketcherMinimizer::RMSD(const vector<sketcherMinimizerPointF>& templates,
+                              const vector<sketcherMinimizerPointF>& points)
 {
     assert(templates.size() == points.size());
     size_t counter = templates.size();
@@ -3176,9 +2983,9 @@ float sketcherMinimizer::RMSD(vector<sketcherMinimizerPointF> templates,
     return sqrt(total);
 }
 
-void sketcherMinimizer::alignmentMatrix(vector<sketcherMinimizerPointF> ref,
-                                        vector<sketcherMinimizerPointF> points,
-                                        float* m)
+void sketcherMinimizer::alignmentMatrix(
+    const vector<sketcherMinimizerPointF>& ref,
+    const vector<sketcherMinimizerPointF>& points, float* m)
 {
     float U[4];
     float Sig[4];
@@ -3299,8 +3106,8 @@ void sketcherMinimizer::svd(float* a, float* U, float* Sig, float* V)
     V[3] = roundToTwoDecimalDigits(V[3]);
 }
 
-bool sketcherMinimizer::compare(vector<sketcherMinimizerAtom*> atoms,
-                                vector<sketcherMinimizerBond*> bonds,
+bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
+                                const vector<sketcherMinimizerBond*>& bonds,
                                 sketcherMinimizerMolecule* templ,
                                 vector<unsigned int>& mapping)
 {
@@ -3532,7 +3339,7 @@ void sketcherMinimizer::checkIdentity(
 
 void sketcherMinimizer::setTemplateFileDir(string dir)
 {
-    sketcherMinimizer::m_templates.setTemplateDir(dir);
+    sketcherMinimizer::m_templates.setTemplateDir(std::move(dir));
 }
 
 static string getTempFileProjDir()
@@ -3659,8 +3466,8 @@ void sketcherMinimizer::loadTemplates()
     loaded = 1;
 }
 
-int sketcherMinimizer::morganScores(vector<sketcherMinimizerAtom*> atoms,
-                                    vector<sketcherMinimizerBond*> bonds,
+int sketcherMinimizer::morganScores(const vector<sketcherMinimizerAtom*>& atoms,
+                                    const vector<sketcherMinimizerBond*>& bonds,
                                     vector<int>& oldScores)
 {
     // assumes that atom[i]->_generalUseN = i

--- a/sketcherMinimizer.h
+++ b/sketcherMinimizer.h
@@ -68,9 +68,9 @@ class CoordgenTemplates
     {
         return m_templates;
     }
-    void setTemplateDir(std::string dir)
+    void setTemplateDir(std::string&& dir)
     {
-        m_templateDir = dir;
+        m_templateDir = std::move(dir);
         if (dir.back() != '/') {
             m_templateDir += "/";
         }
@@ -131,12 +131,12 @@ class EXPORT_COORDGEN sketcherMinimizer
 
     /* add info to choose the best angle so that, if present, peptide chains are
      * horizontal */
-    void
-    addBestRotationInfoForPeptides(std::vector<std::pair<float, float>>& angles,
-                                   std::vector<sketcherMinimizerAtom*> atoms);
+    void addBestRotationInfoForPeptides(
+        std::vector<std::pair<float, float>>& angles,
+        const std::vector<sketcherMinimizerAtom*>& atoms);
 
     /* if a peptide chain is present make sure that the N term is on the left */
-    void maybeFlipPeptides(std::vector<sketcherMinimizerAtom*> atoms,
+    void maybeFlipPeptides(const std::vector<sketcherMinimizerAtom*>& atoms,
                            float& scoreX);
 
     /* consider flipping the molecule horizontally and/or vertically */
@@ -194,21 +194,21 @@ class EXPORT_COORDGEN sketcherMinimizer
                    int shapeN);
 
     /* place a single strand of consecutive residues */
-    void placeSSE(std::vector<sketcherMinimizerResidue*> SSE,
+    void placeSSE(const std::vector<sketcherMinimizerResidue*>& SSE,
                   const std::vector<sketcherMinimizerPointF>& shape, int shapeN,
                   std::vector<bool>& penalties,
                   std::set<sketcherMinimizerResidue*>& outliers,
                   bool placeOnlyInteracting = false);
 
     /* score the position of the given strands */
-    float scoreSSEPosition(std::vector<sketcherMinimizerResidue*> SSE,
+    float scoreSSEPosition(const std::vector<sketcherMinimizerResidue*>& SSE,
                            const std::vector<sketcherMinimizerPointF>& shape,
                            int shapeN, std::vector<bool>& penalties, float f,
                            float increment);
 
     /* score the distance between the two given points of connected residues */
-    float scoreSSEBondStretch(sketcherMinimizerPointF coordinates1,
-                              sketcherMinimizerPointF coordinates2);
+    float scoreSSEBondStretch(const sketcherMinimizerPointF& coordinates1,
+                              const sketcherMinimizerPointF& coordinates2);
 
     /* return the position of res, which is part of SSE, given that the first
      * residue of SSE is placed at startF and consecutive residues are placed
@@ -217,18 +217,18 @@ class EXPORT_COORDGEN sketcherMinimizer
      * curve and 1.0 is again the starting point */
     float getResidueDistance(float startF, float increment,
                              sketcherMinimizerResidue* res,
-                             std::vector<sketcherMinimizerResidue*> SSE);
+                             const std::vector<sketcherMinimizerResidue*>& SSE);
 
     /* return the vector index corresponding to floatPosition */
-    int getShapeIndex(std::vector<sketcherMinimizerPointF> shape,
+    int getShapeIndex(const std::vector<sketcherMinimizerPointF>& shape,
                       float floatPosition);
 
     /* solution represent the placement chosen for residues in SSE. Mark the
      * corresponding sections of the crown to prevent other residues to be
      * placed
      * there */
-    void markSolution(std::pair<float, float> solution,
-                      std::vector<sketcherMinimizerResidue*> SSE,
+    void markSolution(const std::pair<float, float>& solution,
+                      const std::vector<sketcherMinimizerResidue*>& SSE,
                       const std::vector<sketcherMinimizerPointF>& shape,
                       std::vector<bool>& penalties,
                       std::set<sketcherMinimizerResidue*>& outliers);
@@ -239,7 +239,7 @@ class EXPORT_COORDGEN sketcherMinimizer
 
     /* group residues in strands of consecutive residues */
     std::vector<std::vector<sketcherMinimizerResidue*>>
-    groupResiduesInSSEs(std::vector<sketcherMinimizerResidue*> residues);
+    groupResiduesInSSEs(const std::vector<sketcherMinimizerResidue*>& residues);
 
     /* score the position of given residues */
     float
@@ -249,7 +249,7 @@ class EXPORT_COORDGEN sketcherMinimizer
                          sketcherMinimizerResidue* residue);
 
     /* assign coordinates to residues */
-    void placeResidues(std::vector<sketcherMinimizerAtom*> atoms =
+    void placeResidues(const std::vector<sketcherMinimizerAtom*>& atoms =
                            std::vector<sketcherMinimizerAtom*>(0));
 
     /* assign coordinates to residues in the context of a protein-protein
@@ -259,38 +259,44 @@ class EXPORT_COORDGEN sketcherMinimizer
     /* assign coordinates to residues in a protein-protein interaction
      diagram shaped as a circle */
     void placeResiduesProteinOnlyModeCircleStyle(
-        std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains);
+        const std::map<std::string, std::vector<sketcherMinimizerResidue*>>&
+            chains);
 
     /* assign coordinates to residues in a protein-protein interaction
      diagram shaped as a LID */
     void placeResiduesProteinOnlyModeLIDStyle(
-        std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains);
+        const std::map<std::string, std::vector<sketcherMinimizerResidue*>>&
+            chains);
 
     /* order residues for drawing, so that residues interacting together are
      * drawn one after the other and residues with more interactions are drawn
      * first */
     std::vector<sketcherMinimizerResidue*> orderResiduesOfChains(
-        std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains);
+        const std::map<std::string, std::vector<sketcherMinimizerResidue*>>&
+            chains);
 
     /* find center position for each chain of residues using a meta-molecule
      * approach, building a molecule where each atom represents a chain and each
      * bond connects two interacting chains */
     std::map<std::string, sketcherMinimizerPointF>
     computeChainsStartingPositionsMetaMol(
-        std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains);
+        const std::map<std::string, std::vector<sketcherMinimizerResidue*>>&
+            chains);
 
     /* place interacting residues closer to each other, so they end up at the
      * periphery of the chain */
     void shortenInteractions(
-        std::map<std::string, std::vector<sketcherMinimizerResidue*>> chains);
+        const std::map<std::string, std::vector<sketcherMinimizerResidue*>>&
+            chains);
 
     /* explore positions in a grid around the current one to ease clashes */
     sketcherMinimizerPointF exploreGridAround(
-        sketcherMinimizerPointF centerOfGrid, unsigned int levels, float gridD,
-        float dx = 0.f, float dy = 0.f, float distanceFromAtoms = -1.f,
-        bool watermap = false,
+        const sketcherMinimizerPointF& centerOfGrid, unsigned int levels,
+        float gridD, float dx = 0.f, float dy = 0.f,
+        float distanceFromAtoms = -1.f, bool watermap = false,
         sketcherMinimizerResidue* residueForInteractions = NULL,
-        sketcherMinimizerPointF direction = sketcherMinimizerPointF(0, 1));
+        const sketcherMinimizerPointF& direction = sketcherMinimizerPointF(0,
+                                                                           1));
 
     sketcherMinimizerPointF exploreMolPosition(sketcherMinimizerMolecule* mol,
                                                unsigned int levels, float gridD,
@@ -304,26 +310,28 @@ class EXPORT_COORDGEN sketcherMinimizer
     /* return a score of the alignment between direction and templat.first,
      * weight on the angle between the two and templat.second */
     static float
-    testAlignment(sketcherMinimizerPointF direction,
-                  std::pair<sketcherMinimizerPointF, float> templat);
+    testAlignment(const sketcherMinimizerPointF& direction,
+                  const std::pair<sketcherMinimizerPointF, float>& templat);
 
     /* find the best alignment of a fragment to its parent and set invert in
      * case the fragment needs to be flipped */
     static sketcherMinimizerPointF scoreDirections(
         sketcherMinimizerFragment* fragment, float angle,
-        std::vector<std::pair<sketcherMinimizerPointF, float>> directions,
+        const std::vector<std::pair<sketcherMinimizerPointF, float>>&
+            directions,
         bool& invert);
 
     /* align the fragment to its parent */
-    static void alignWithParentDirection(sketcherMinimizerFragment* f,
-                                         sketcherMinimizerPointF position,
-                                         float angle);
+    static void
+    alignWithParentDirection(sketcherMinimizerFragment* f,
+                             const sketcherMinimizerPointF& position,
+                             float angle);
 
     /* align the fragment to its parent in the case of constrained coordinates
      */
     static bool
     alignWithParentDirectionConstrained(sketcherMinimizerFragment* fragment,
-                                        sketcherMinimizerPointF position,
+                                        const sketcherMinimizerPointF& position,
                                         float angle);
 
     /* align the fragment to its parent in the case of unconstrained coordinates
@@ -372,11 +380,11 @@ class EXPORT_COORDGEN sketcherMinimizer
     void constrainAllAtoms();
 
     /* constrain coordinates on atoms corresponding to true */
-    void constrainAtoms(std::vector<bool> constrained);
+    void constrainAtoms(const std::vector<bool>& constrained);
 
     /* fix cooordinates (i.e. guarantee they will not change) on atoms marked as
      * true */
-    void fixAtoms(std::vector<bool> fixed);
+    void fixAtoms(const std::vector<bool>& fixed);
 
     /* set a flag to enable/disable the scoring of interactions with residues */
     void setScoreResidueInteractions(bool b);
@@ -401,21 +409,23 @@ class EXPORT_COORDGEN sketcherMinimizer
 
     /* for each residue, find the closest atom among atoms, or all atoms
      if none are given */
-    void findClosestAtomToResidues(std::vector<sketcherMinimizerAtom*> atoms =
-                                       std::vector<sketcherMinimizerAtom*>(0));
+    void
+    findClosestAtomToResidues(const std::vector<sketcherMinimizerAtom*>& atoms =
+                                  std::vector<sketcherMinimizerAtom*>(0));
 
     /* calculate root mean square deviation between templates and points */
-    static float RMSD(std::vector<sketcherMinimizerPointF> templates,
-                      std::vector<sketcherMinimizerPointF> points);
+    static float RMSD(const std::vector<sketcherMinimizerPointF>& templates,
+                      const std::vector<sketcherMinimizerPointF>& points);
 
     /* singular value decomposition for 2x2 matrices.
      used for 2D alignment. */
     static void svd(float* a, float* U, float* Sig, float* V);
 
     /* set m to a rotation matrix to align ref to points */
-    static void alignmentMatrix(std::vector<sketcherMinimizerPointF> ref,
-                                std::vector<sketcherMinimizerPointF> points,
-                                float* m);
+    static void
+    alignmentMatrix(const std::vector<sketcherMinimizerPointF>& ref,
+                    const std::vector<sketcherMinimizerPointF>& points,
+                    float* m);
 
     static void
     checkIdentity(std::vector<unsigned int> solution, int newSol,
@@ -429,14 +439,14 @@ class EXPORT_COORDGEN sketcherMinimizer
 
     /* compare atoms and bonds to template and map which atom is which in case
      * of a positive match */
-    static bool compare(std::vector<sketcherMinimizerAtom*> atoms,
-                        std::vector<sketcherMinimizerBond*> bonds,
+    static bool compare(const std::vector<sketcherMinimizerAtom*>& atoms,
+                        const std::vector<sketcherMinimizerBond*>& bonds,
                         sketcherMinimizerMolecule* templ,
                         std::vector<unsigned int>& mapping);
 
     /* calculate morgan scores for the given input */
-    static int morganScores(std::vector<sketcherMinimizerAtom*> atoms,
-                            std::vector<sketcherMinimizerBond*> bonds,
+    static int morganScores(const std::vector<sketcherMinimizerAtom*>& atoms,
+                            const std::vector<sketcherMinimizerBond*>& bonds,
                             std::vector<int>& scores);
 
     std::string m_chainHint;

--- a/sketcherMinimizerAtom.cpp
+++ b/sketcherMinimizerAtom.cpp
@@ -734,7 +734,7 @@ bool sketcherMinimizerAtom::matchCIPSequence(vector<int>& v1, vector<int>& v2)
 
 void sketcherMinimizerAtom::setCoordinates(sketcherMinimizerPointF coords)
 {
-    coordinates = coords;
+    coordinates = std::move(coords);
     coordinates.round();
     coordinatesSet = true;
 }
@@ -913,13 +913,13 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
 
     vector<CIPAtom> AN1, AN2;
 
-    map<sketcherMinimizerAtom *, int> score1,
+    map<sketcherMinimizerAtom*, int> score1,
         score2; // used to keep track if a parent atom has been found to have
                 // priority over another
-    map<sketcherMinimizerAtom *, vector<int>> medals1,
+    map<sketcherMinimizerAtom*, vector<int>> medals1,
         medals2; // marks if an atom is a parent of the atoms being evaluated in
                  // the current iteration
-    map<sketcherMinimizerAtom *, int> visited1,
+    map<sketcherMinimizerAtom*, int> visited1,
         visited2; // marks at which iteration this atom was evaluated
 
     visited1[center] = 1;
@@ -927,11 +927,11 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
     visited1[at1] = 2;
     visited2[at2] = 2;
 
-    vector<pair<int, sketcherMinimizerAtom *>> v1, v2;
+    vector<pair<int, sketcherMinimizerAtom*>> v1, v2;
     v1.push_back(pair<int, sketcherMinimizerAtom*>(at1->atomicNumber, at1));
     v2.push_back(pair<int, sketcherMinimizerAtom*>(at2->atomicNumber, at2));
 
-    vector<sketcherMinimizerAtom *> parents1, parents2;
+    vector<sketcherMinimizerAtom*> parents1, parents2;
     parents1.push_back(center);
     parents1.push_back(at1);
     parents2.push_back(center);
@@ -1036,7 +1036,7 @@ vector<CIPAtom> sketcherMinimizerAtom::expandOneLevel(vector<CIPAtom>& oldV)
                               (*visited)[a] + 1) // closing a ring to an atom
                                                  // already visited in a
                                                  // previous cycle
-                         );
+                        );
                     theseAts.push_back(pair<int, sketcherMinimizerAtom*>(
                         neigh->atomicNumber,
                         ghost ? ((sketcherMinimizerAtom*) NULL)
@@ -1431,7 +1431,7 @@ bool sketcherMinimizerAtom::canBeChiral() const
 /* get a vector that points out towards the most free region of space around the
  * atom. Used to determined where an arrow to the atom will point from */
 sketcherMinimizerPointF sketcherMinimizerAtom::getSingleAdditionVector(
-    vector<sketcherMinimizerAtom*> ats)
+    const vector<sketcherMinimizerAtom*>& ats)
 {
     sketcherMinimizerPointF out(0.f, 0.f);
     int n = 0;

--- a/sketcherMinimizerAtom.h
+++ b/sketcherMinimizerAtom.h
@@ -10,11 +10,11 @@
 #define sketcherMINIMIZERATOM_H
 
 // #include <sketcherMinimizerPointF>
-#include <vector>
-#include <map>
-#include <iostream>
 #include "CoordgenConfig.hpp"
 #include "sketcherMinimizerMaths.h"
+#include <iostream>
+#include <map>
+#include <vector>
 
 static const int COORDINATES_LIMIT = 10000000;
 static const int INVALID_COORDINATES = COORDINATES_LIMIT + 1;
@@ -54,13 +54,10 @@ struct CIPAtom {
             std::map<sketcherMinimizerAtom*, int>* visits
 
             )
+        : theseAtoms(std::move(us)), parent(dad),
+          allParents(std::move(allPars)), scores(scors), visited(visits),
+          medals(meds)
     {
-        theseAtoms = us;
-        parent = dad;
-        scores = scors;
-        medals = meds;
-        visited = visits;
-        allParents = allPars;
     }
     bool operator<(const CIPAtom& rhs) const;
     bool operator==(const CIPAtom& rhs) const;
@@ -252,7 +249,7 @@ class EXPORT_COORDGEN sketcherMinimizerAtom
     sketcherMinimizerPointF getSingleAdditionVector() const;
 
     static sketcherMinimizerPointF
-    getSingleAdditionVector(std::vector<sketcherMinimizerAtom*> ats);
+    getSingleAdditionVector(const std::vector<sketcherMinimizerAtom*>& ats);
 
     /* return true if the atom  has valid 3d coordinates */
     bool hasValid3DCoordinates() const;

--- a/sketcherMinimizerBond.h
+++ b/sketcherMinimizerBond.h
@@ -9,9 +9,9 @@
 #ifndef sketcherMINIMIZERBOND_H
 #define sketcherMINIMIZERBOND_H
 
+#include "CoordgenConfig.hpp"
 #include <cstddef>
 #include <vector>
-#include "CoordgenConfig.hpp"
 
 class sketcherMinimizerRing;
 class sketcherMinimizerAtom;

--- a/sketcherMinimizerConstraintInteraction.h
+++ b/sketcherMinimizerConstraintInteraction.h
@@ -19,7 +19,7 @@ class sketcherMinimizerConstraintInteraction
   public:
     sketcherMinimizerConstraintInteraction(sketcherMinimizerAtom* at1,
                                            sketcherMinimizerPointF position)
-        : sketcherMinimizerInteraction(at1, at1), origin(position)
+        : sketcherMinimizerInteraction(at1, at1), origin(std::move(position))
     {
         k = CONSTRAINT_SCALE;
     };

--- a/sketcherMinimizerFragment.cpp
+++ b/sketcherMinimizerFragment.cpp
@@ -30,9 +30,7 @@ CoordgenFragmentDOF::CoordgenFragmentDOF(sketcherMinimizerFragment* fragment)
 {
 }
 
-CoordgenFragmentDOF::~CoordgenFragmentDOF()
-{
-}
+CoordgenFragmentDOF::~CoordgenFragmentDOF() {}
 
 short unsigned int CoordgenFragmentDOF::getCurrentState()
 {
@@ -317,7 +315,7 @@ float CoordgenInvertBondDOF::getCurrentPenalty() const
 
 CoordgenFlipRingDOF::CoordgenFlipRingDOF(
     sketcherMinimizerRing* ring,
-    std::vector<sketcherMinimizerAtom*> fusionAtoms)
+    const std::vector<sketcherMinimizerAtom*>& fusionAtoms)
     : CoordgenFragmentDOF((*fusionAtoms.begin())->getFragment()),
       m_pivotAtom1(*(fusionAtoms.begin())),
       m_pivotAtom2(*(fusionAtoms.rbegin())),

--- a/sketcherMinimizerFragment.h
+++ b/sketcherMinimizerFragment.h
@@ -9,11 +9,11 @@
 #ifndef sketcherMINIMIZERFRAGMENT
 #define sketcherMINIMIZERFRAGMENT
 
-#include <vector>
-#include <map>
+#include "sketcherMinimizerMaths.h"
 #include <cassert>
 #include <iostream>
-#include "sketcherMinimizerMaths.h"
+#include <map>
+#include <vector>
 
 class sketcherMinimizerAtom;
 class sketcherMinimizerBond;
@@ -164,7 +164,7 @@ class CoordgenFlipRingDOF : public CoordgenFragmentDOF
 {
   public:
     CoordgenFlipRingDOF(sketcherMinimizerRing* ring,
-                        std::vector<sketcherMinimizerAtom*> fusionAtoms);
+                        const std::vector<sketcherMinimizerAtom*>& fusionAtoms);
     int numberOfStates() const;
     int tier() const;
     void apply() const;

--- a/sketcherMinimizerMaths.h
+++ b/sketcherMinimizerMaths.h
@@ -106,7 +106,8 @@ class sketcherMinimizerPointF
     }
 
     /* parallel component of this along the give axis */
-    sketcherMinimizerPointF parallelComponent(sketcherMinimizerPointF axis)
+    sketcherMinimizerPointF
+    parallelComponent(const sketcherMinimizerPointF& axis)
     {
         float dotProduct = x() * axis.x() + y() * axis.y();
         return axis * dotProduct / axis.squareLength();
@@ -209,10 +210,10 @@ class sketcherMinimizerPointF
 /* return true if the two segments intersect and if a result pointer was given,
  * set it to the intersection point */
 struct sketcherMinimizerMaths {
-    static bool intersectionOfSegments(sketcherMinimizerPointF s1p1,
-                                       sketcherMinimizerPointF s1p2,
-                                       sketcherMinimizerPointF s2p1,
-                                       sketcherMinimizerPointF s2p2,
+    static bool intersectionOfSegments(const sketcherMinimizerPointF& s1p1,
+                                       const sketcherMinimizerPointF& s1p2,
+                                       const sketcherMinimizerPointF& s2p1,
+                                       const sketcherMinimizerPointF& s2p2,
                                        sketcherMinimizerPointF* result = NULL)
     {
         /*
@@ -294,9 +295,9 @@ struct sketcherMinimizerMaths {
     }
 
     /* signed angle between p1p2 and p2p3 */
-    static float signedAngle(sketcherMinimizerPointF p1,
-                             sketcherMinimizerPointF p2,
-                             sketcherMinimizerPointF p3)
+    static float signedAngle(const sketcherMinimizerPointF& p1,
+                             const sketcherMinimizerPointF& p2,
+                             const sketcherMinimizerPointF& p3)
     {
         sketcherMinimizerPointF v1 = p1 - p2;
         sketcherMinimizerPointF v2 = p3 - p2;
@@ -306,9 +307,9 @@ struct sketcherMinimizerMaths {
     }
 
     /* unsigned angle between p1p2 and p2p3 */
-    static float unsignedAngle(sketcherMinimizerPointF p1,
-                               sketcherMinimizerPointF p2,
-                               sketcherMinimizerPointF p3)
+    static float unsignedAngle(const sketcherMinimizerPointF& p1,
+                               const sketcherMinimizerPointF& p2,
+                               const sketcherMinimizerPointF& p3)
     {
         float x1 = p1.x();
         float y1 = p1.y();
@@ -334,18 +335,18 @@ struct sketcherMinimizerMaths {
     }
 
     /* return true if the two points are very close in space */
-    static bool pointsCoincide(sketcherMinimizerPointF p1,
-                               sketcherMinimizerPointF p2)
+    static bool pointsCoincide(const sketcherMinimizerPointF& p1,
+                               const sketcherMinimizerPointF& p2)
     {
         return ((p1 - p2).squareLength() < SKETCHER_EPSILON * SKETCHER_EPSILON);
     }
 
     /* return true if p1 and p2 are in the same semiplane defined by the given
      * segment */
-    static bool sameSide(const sketcherMinimizerPointF p1,
-                         const sketcherMinimizerPointF p2,
-                         const sketcherMinimizerPointF lineP1,
-                         const sketcherMinimizerPointF lineP2)
+    static bool sameSide(const sketcherMinimizerPointF& p1,
+                         const sketcherMinimizerPointF& p2,
+                         const sketcherMinimizerPointF& lineP1,
+                         const sketcherMinimizerPointF& lineP2)
     {
         float x = lineP2.x() - lineP1.x();
         float y = lineP2.y() - lineP1.y();
@@ -368,8 +369,9 @@ struct sketcherMinimizerMaths {
 
     /* return the projection of p on the line defined by the given segment */
     static sketcherMinimizerPointF
-    projectPointOnLine(sketcherMinimizerPointF p, sketcherMinimizerPointF sp1,
-                       sketcherMinimizerPointF sp2)
+    projectPointOnLine(const sketcherMinimizerPointF& p,
+                       const sketcherMinimizerPointF& sp1,
+                       const sketcherMinimizerPointF& sp2)
     {
         sketcherMinimizerPointF l1 = p - sp1;
         sketcherMinimizerPointF l3 = sp2 - sp1;
@@ -383,10 +385,10 @@ struct sketcherMinimizerMaths {
     }
 
     /* squared distance of the given point from the given segment */
-    static float squaredDistancePointSegment(sketcherMinimizerPointF p,
-                                             sketcherMinimizerPointF sp1,
-                                             sketcherMinimizerPointF sp2,
-                                             float* returnT = NULL)
+    static float squaredDistancePointSegment(const sketcherMinimizerPointF& p,
+                                             const sketcherMinimizerPointF& sp1,
+                                             const sketcherMinimizerPointF& sp2,
+                                             float* returnT = nullptr)
     {
 
         sketcherMinimizerPointF l1 = p - sp1;
@@ -426,17 +428,17 @@ struct sketcherMinimizerMaths {
         return squaredistance;
     }
 
-    static float squaredDistance(sketcherMinimizerPointF p1,
-                                 sketcherMinimizerPointF p2)
+    static float squaredDistance(const sketcherMinimizerPointF& p1,
+                                 const sketcherMinimizerPointF& p2)
     {
         return (p1.x() - p2.x()) * (p1.x() - p2.x()) +
                (p1.y() - p2.y()) * (p1.y() - p2.y());
     }
 
-    static std::vector<float> tridiagonalSolve(std::vector<float> a,
-                                               std::vector<float> b,
-                                               std::vector<float> c,
-                                               std::vector<float> rhs)
+    static std::vector<float> tridiagonalSolve(const std::vector<float>& a,
+                                               const std::vector<float>& b,
+                                               const std::vector<float>& c,
+                                               const std::vector<float>& rhs)
     {
         assert(a.size() == b.size() && a.size() == c.size() &&
                a.size() == rhs.size());
@@ -461,10 +463,11 @@ struct sketcherMinimizerMaths {
     }
 
     /* used by ClosedBezierControlPoints */
-    static std::vector<float> cyclicSolve(std::vector<float> a,
-                                          std::vector<float> b,
-                                          std::vector<float> c, float alpha,
-                                          float beta, std::vector<float> rhs)
+    static std::vector<float> cyclicSolve(const std::vector<float>& a,
+                                          const std::vector<float>& b,
+                                          const std::vector<float>& c,
+                                          float alpha, float beta,
+                                          const std::vector<float>& rhs)
     {
         assert(a.size() == b.size() && a.size() == c.size());
         unsigned int n = (unsigned int) b.size();
@@ -501,9 +504,10 @@ struct sketcherMinimizerMaths {
     }
 
     static sketcherMinimizerPointF
-    pointOnCubicBezier(sketcherMinimizerPointF p1, sketcherMinimizerPointF cp1,
-                       sketcherMinimizerPointF cp2, sketcherMinimizerPointF p2,
-                       float t)
+    pointOnCubicBezier(const sketcherMinimizerPointF& p1,
+                       const sketcherMinimizerPointF& cp1,
+                       const sketcherMinimizerPointF& cp2,
+                       const sketcherMinimizerPointF& p2, float t)
     {
         // using Casteljiau's algorithm
         auto v1 = (1 - t) * p1 + t * cp1;
@@ -517,7 +521,7 @@ struct sketcherMinimizerMaths {
     /* find control points to a closed Bezier curve that passes through the
      * given points */
     static void ClosedBezierControlPoints(
-        std::vector<sketcherMinimizerPointF> knots,
+        std::vector<sketcherMinimizerPointF>& knots,
         std::vector<sketcherMinimizerPointF>& firstControlPoints,
         std::vector<sketcherMinimizerPointF>& secondControlPoints)
     {
@@ -567,9 +571,9 @@ struct sketcherMinimizerMaths {
 
     /* return the mirror image of the given point wrt the given segment */
     static sketcherMinimizerPointF
-    mirrorPoint(sketcherMinimizerPointF point,
-                sketcherMinimizerPointF segmentPoint1,
-                sketcherMinimizerPointF segmentPoint2)
+    mirrorPoint(const sketcherMinimizerPointF& point,
+                const sketcherMinimizerPointF& segmentPoint1,
+                const sketcherMinimizerPointF& segmentPoint2)
     {
         sketcherMinimizerPointF segmentV = segmentPoint2 - segmentPoint1;
         sketcherMinimizerPointF v2 = point - segmentPoint1;
@@ -580,16 +584,16 @@ struct sketcherMinimizerMaths {
     }
 
     /* dot product of two vectors */
-    static float dotProduct(sketcherMinimizerPointF a,
-                            sketcherMinimizerPointF b)
+    static float dotProduct(const sketcherMinimizerPointF& a,
+                            const sketcherMinimizerPointF& b)
     {
 
         return (a.x() * b.x() + a.y() * b.y());
     }
 
     /* cross product of two vectors */
-    static float crossProduct(sketcherMinimizerPointF a,
-                              sketcherMinimizerPointF b)
+    static float crossProduct(const sketcherMinimizerPointF& a,
+                              const sketcherMinimizerPointF& b)
     {
 
         return (a.x() * b.y() - a.y() * b.x());
@@ -686,7 +690,7 @@ struct sketcherMinimizerMaths {
         return static_cast<float>(acos(dp / (l1 * l2)) * 180.f / M_PI);
     }
 
-    /* diheadral angle defined by 4 3d points */
+    /* dihedral angle defined by 4 3d points */
     static float dihedral3D(float x1, float y1, float z1, float x2, float y2,
                             float z2, float x3, float y3, float z3, float x4,
                             float y4, float z4)

--- a/sketcherMinimizerMaths.h
+++ b/sketcherMinimizerMaths.h
@@ -53,6 +53,7 @@ class sketcherMinimizerPointF
         : xp(p.x()), yp(p.y())
     {
     }
+
     sketcherMinimizerPointF(float xpos, float ypos) : xp(xpos), yp(ypos) {}
 
     sketcherMinimizerPointF& operator=(const sketcherMinimizerPointF& p)
@@ -210,11 +211,12 @@ class sketcherMinimizerPointF
 /* return true if the two segments intersect and if a result pointer was given,
  * set it to the intersection point */
 struct sketcherMinimizerMaths {
-    static bool intersectionOfSegments(const sketcherMinimizerPointF& s1p1,
-                                       const sketcherMinimizerPointF& s1p2,
-                                       const sketcherMinimizerPointF& s2p1,
-                                       const sketcherMinimizerPointF& s2p2,
-                                       sketcherMinimizerPointF* result = NULL)
+    static bool
+    intersectionOfSegments(const sketcherMinimizerPointF& s1p1,
+                           const sketcherMinimizerPointF& s1p2,
+                           const sketcherMinimizerPointF& s2p1,
+                           const sketcherMinimizerPointF& s2p2,
+                           sketcherMinimizerPointF* result = nullptr)
     {
         /*
                 Suppose the two line segments run from p to p + r and from q to
@@ -521,7 +523,7 @@ struct sketcherMinimizerMaths {
     /* find control points to a closed Bezier curve that passes through the
      * given points */
     static void ClosedBezierControlPoints(
-        std::vector<sketcherMinimizerPointF>& knots,
+        const std::vector<sketcherMinimizerPointF>& knots,
         std::vector<sketcherMinimizerPointF>& firstControlPoints,
         std::vector<sketcherMinimizerPointF>& secondControlPoints)
     {

--- a/sketcherMinimizerRing.cpp
+++ b/sketcherMinimizerRing.cpp
@@ -21,9 +21,7 @@ sketcherMinimizerRing::sketcherMinimizerRing()
     side = false;
 }
 
-sketcherMinimizerRing::~sketcherMinimizerRing()
-{
-}
+sketcherMinimizerRing::~sketcherMinimizerRing() {}
 
 sketcherMinimizerPointF sketcherMinimizerRing::findCenter()
 {
@@ -132,7 +130,7 @@ bool sketcherMinimizerRing::sameAs(sketcherMinimizerRing* ring)
     return true;
 }
 
-bool sketcherMinimizerRing::contains(sketcherMinimizerPointF p)
+bool sketcherMinimizerRing::contains(const sketcherMinimizerPointF& p)
 {
 
     int n = 0;

--- a/sketcherMinimizerRing.h
+++ b/sketcherMinimizerRing.h
@@ -6,10 +6,10 @@
  *
  */
 
-#include <vector>
-#include <iostream>
-#include "sketcherMinimizerMaths.h"
 #include "CoordgenConfig.hpp"
+#include "sketcherMinimizerMaths.h"
+#include <iostream>
+#include <vector>
 
 #ifndef sketcherMINIMIZERRING_H
 #define sketcherMINIMIZERRING_H
@@ -47,7 +47,7 @@ class EXPORT_COORDGEN sketcherMinimizerRing
     bool isBenzene();
 
     /* return true if the given point is inside the ring */
-    bool contains(sketcherMinimizerPointF p);
+    bool contains(const sketcherMinimizerPointF& p);
 
     /* return true if the given atom is part of the ring */
     bool containsAtom(const sketcherMinimizerAtom* a) const;


### PR DESCRIPTION
I noticed that we are passing a fair amount of function arguments by value (mostly `sketcherMinimizerPointF`, vectors of pointers, and a few maps), which introduces a great deal of copy operations that we could avoid.

I made most of these arguments passed by const ref, added a few `std::move`s, and deleted some blocks of commented code I noticed. clang-format also made some minor changes.

Checked that it builds, passes the test included in #35, and that RDKit and mmshare have no problem building after these changes.

