### PR TITLE
Speed up coordgen, especially for very slow molecules

### DIFF
--- a/CoordgenFragmentBuilder.cpp
+++ b/CoordgenFragmentBuilder.cpp
@@ -11,6 +11,7 @@
 #include "CoordgenMinimizer.h"
 #include "sketcherMinimizer.h"
 #include "sketcherMinimizerFragment.h"
+#include "sketcherMinimizerStretchInteraction.h"
 
 using namespace std;
 

--- a/CoordgenMacrocycleBuilder.cpp
+++ b/CoordgenMacrocycleBuilder.cpp
@@ -7,6 +7,7 @@
 #include "CoordgenMinimizer.h"
 #include "sketcherMinimizer.h"
 #include "sketcherMinimizerMaths.h"
+#include "sketcherMinimizerStretchInteraction.h"
 #include <algorithm>
 #include <queue>
 

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -1263,6 +1263,20 @@ bool CoordgenMinimizer::bondsClash(sketcherMinimizerBond* bond,
         bond->getEndAtom() == bond2->getEndAtom()) {
         return false;
     }
+    auto& start1 = bond->getStartAtom()->coordinates;
+    auto& start2 = bond2->getStartAtom()->coordinates;
+    auto& end1 = bond->getEndAtom()->coordinates;
+    auto& end2 = bond2->getEndAtom()->coordinates;
+    // coincidence and intersection calculations are expensive. Often bonds
+    // are nowhere near each other, so skip the remaining work if a bond is
+    // strictly to the left or right of another bond.
+    if (max(start1.x(), end1.x()) < min(start2.x(), end2.x()) ||
+        max(start1.y(), end1.y()) < min(start2.y(), end2.y()) ||
+        min(start1.x(), end1.x()) > max(start2.x(), end2.x()) ||
+        min(start1.y(), end1.y()) > max(start2.y(), end2.y())) {
+        return false;
+    }
+
     if (sketcherMinimizerMaths::pointsCoincide(
             bond->getStartAtom()->coordinates,
             bond2->getStartAtom()->coordinates) ||

--- a/sketcherMinimizer.h
+++ b/sketcherMinimizer.h
@@ -17,10 +17,6 @@
 #include "sketcherMinimizerResidue.h"
 #include "sketcherMinimizerResidueInteraction.h"
 
-#include "sketcherMinimizerBendInteraction.h"
-#include "sketcherMinimizerClashInteraction.h"
-#include "sketcherMinimizerStretchInteraction.h"
-
 #include "sketcherMinimizerFragment.h"
 #include "sketcherMinimizerMarchingSquares.h"
 #include "sketcherMinimizerMolecule.h"

--- a/sketcherMinimizerAtom.h
+++ b/sketcherMinimizerAtom.h
@@ -144,7 +144,7 @@ class EXPORT_COORDGEN sketcherMinimizerAtom
      * stereochemistry */
     bool hasNoStereoActiveBonds() const;
 
-    sketcherMinimizerPointF getCoordinates() const { return coordinates; }
+    const sketcherMinimizerPointF& getCoordinates() const { return coordinates; }
     int getAtomicNumber() const { return atomicNumber; }
 
     void setAtomicNumber(int number) { atomicNumber = number; }

--- a/sketcherMinimizerClashInteraction.h
+++ b/sketcherMinimizerClashInteraction.h
@@ -32,7 +32,7 @@ class sketcherMinimizerClashInteraction : public sketcherMinimizerInteraction
     /* calculate the energy of the clash */
     void energy(float& e) override
     {
-        float squaredDistance =
+        squaredDistance =
             sketcherMinimizerMaths::squaredDistancePointSegment(
                 atom2->coordinates, atom1->coordinates, atom3->coordinates);
         if (squaredDistance > restV)
@@ -49,15 +49,12 @@ class sketcherMinimizerClashInteraction : public sketcherMinimizerInteraction
         energy(totalE);
         if (skipForce)
             return;
+        if (squaredDistance > restV)
+            return;
+
         sketcherMinimizerPointF atomP = atom2->coordinates;
         sketcherMinimizerPointF bondP1 = atom1->coordinates;
         sketcherMinimizerPointF bondP2 = atom3->coordinates;
-
-        float squaredDistance =
-            sketcherMinimizerMaths::squaredDistancePointSegment(atomP, bondP1,
-                                                                bondP2);
-        if (squaredDistance > restV)
-            return;
 
         sketcherMinimizerPointF projection =
             sketcherMinimizerMaths::projectPointOnLine(atomP, bondP1, bondP2);
@@ -72,6 +69,8 @@ class sketcherMinimizerClashInteraction : public sketcherMinimizerInteraction
 
     float k2;
     sketcherMinimizerAtom* atom3;
+private:
+    float squaredDistance;
 };
 
 #endif // sketcherMINIMIZERCLASHINTERACTION


### PR DESCRIPTION
Improve coordgen performance: #39 
    
When detecting clashes, do a rough binning of atoms. If both
atoms for one bond are above both atoms of the other bond, they
can't be a clash. This saves clash calculations for things that
are obviously not clashes. It has an impact on big structures
that are partially templated. (overall 15% speedup, but 40%
improvement for the worst molecules in the test case.

coordgen is still slower than RDkit's native coordinate
generation, though.

Also adds a simple test that the coordinates generated don't
have crazy bond lengths. This would have caught my earlier
misunderstanding.
