### PR TITLE
Improve maeparser dependency handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,5 @@
 language: cpp
 
-before_script:
-  - git clone https://github.com/schrodinger/maeparser.git
-  - mkdir maeparser/build
-  - pushd maeparser/build
-  - cmake .. -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/installation -DCMAKE_BUILD_TYPE=Debug
-  - make install
-  - popd
-
 script:
   - mkdir build
   - cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(coordgen)
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # Options
 option(COORDGEN_RIGOROUS_BUILD "Abort the build if the compiler issues \
@@ -11,10 +11,9 @@ option(COORDGEN_BUILD_EXAMPLE "Whether to build the sample executable" ON)
 
 # Use the maeparser_DIR variable to tell CMake where to search for the
 # maeparser library.
-set(MAEPARSER_SOURCE_TAG "master" CACHE STRING "maeparser tag to build if \
+
+set(MAEPARSER_VERSION "master" CACHE STRING "maeparser tag to build if \
     a compiled library is not found")
-set(MAEPARSER_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE STRING
-    "directory in which to search for/download maeparser source code.")
 
 if(MSVC)
     # C4251 disables warnings for export STL containers as arguments
@@ -32,9 +31,15 @@ endif(MSVC)
 endif(COORDGEN_RIGOROUS_BUILD)
 
 # Dependencies
-include(CoordgenUtils)
 find_package(Boost COMPONENTS iostreams REQUIRED)
-find_maeparser("${maeparser_DIR}" "${MAEPARSER_SOURCE_TAG}")
+
+if(TARGET maeparser)
+    message(STATUS "Using externally defined maeparser target to "
+    "build coordgen")
+else()
+    include(CoordgenUtils)
+    find_or_clone_maeparser()
+endif()
 
 # Source files & headers
 file(GLOB SOURCES "*.cpp")
@@ -45,7 +50,7 @@ include_directories(${maeparser_INCLUDE_DIRS})
 add_library(coordgen SHARED ${SOURCES})
 target_compile_definitions(coordgen PRIVATE IN_COORDGEN)
 set_property(TARGET coordgen PROPERTY CXX_VISIBILITY_PRESET "hidden")
-target_link_libraries(coordgen maeparser)
+target_link_libraries(coordgen ${maeparser_LIBRARIES})
 
 set_target_properties(coordgen
     PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,8 @@ option(COORDGEN_BUILD_EXAMPLE "Whether to build the sample executable" ON)
 # maeparser library.
 set(MAEPARSER_SOURCE_TAG "master" CACHE STRING "maeparser tag to build if \
     a compiled library is not found")
-
+set(MAEPARSER_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE STRING
+    "directory in which to search for/download maeparser source code.")
 
 if(MSVC)
     # C4251 disables warnings for export STL containers as arguments

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,25 @@
 cmake_minimum_required(VERSION 3.2)
 project(coordgen)
-
-# Options & Project configuration
 set(CMAKE_CXX_STANDARD 11)
-option(COORDGEN_RIGOROUS_BUILD "Abort the build if the compiler issues any warnings" OFF )
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+
+# Options
+option(COORDGEN_RIGOROUS_BUILD "Abort the build if the compiler issues \
+       any warnings" OFF )
 option(COORDGEN_BUILD_TESTS "Whether test executables should be built" ON)
 option(COORDGEN_BUILD_EXAMPLE "Whether to build the sample executable" ON)
 
+# Use the maeparser_DIR variable to tell CMake where to search for the
+# maeparser library.
+set(MAEPARSER_SOURCE_TAG "master" CACHE STRING "maeparser tag to build if \
+    a compiled library is not found")
+
+
 if(MSVC)
-    # C4251 disables warnings for export STL containers as arguments (returning a vector of things)
-    add_definitions(/wd4251 /wd4275 /wd4996 /D_SCL_SECURE_NO_WARNINGS /D_CRT_SECURE_NO_WARNINGS)
+    # C4251 disables warnings for export STL containers as arguments
+    # (returning a vector of things)
+    add_definitions(/wd4251 /wd4275 /wd4996 /D_SCL_SECURE_NO_WARNINGS
+                    /D_CRT_SECURE_NO_WARNINGS)
 endif(MSVC)
 
 if(COORDGEN_RIGOROUS_BUILD)
@@ -21,8 +31,9 @@ endif(MSVC)
 endif(COORDGEN_RIGOROUS_BUILD)
 
 # Dependencies
+include(CoordgenUtils)
 find_package(Boost COMPONENTS iostreams REQUIRED)
-find_package(maeparser REQUIRED)
+find_maeparser("${maeparser_DIR}" "${MAEPARSER_SOURCE_TAG}")
 
 # Source files & headers
 file(GLOB SOURCES "*.cpp")

--- a/README.md
+++ b/README.md
@@ -38,31 +38,33 @@ In case **maeparser** is not available on your system, neither as a compiled lib
 
 1. Create a build directory inside the the one that contains Coordgen, and move into it:
 
-```bash
-mkdir build
-cd build
-```
+    ```bash
+    mkdir build
+    cd build
+    ```
 
-1. Run `cmake`, passing the path to the directory where the sources are located (just `..` if you created `build` inside the sources directory). At this point, you should add any required flags to the `cmake` command. Check the 'Options' section in CMakeLists.txt to see which options are available.
+1. Run `cmake` to configure the build, passing the path to the directory where the sources are located (just `..` if you created `build` inside the sources directory). At this point, you should add any required flags to the `cmake` command. Check the 'Options' section in CMakeLists.txt to see which options are available.
 
-```bash
-cmake .. -Dmaeparser_DIR=/home/schrodinger/maeparser_install -DCMAKE_INSTALL_PREFIX=/home/schrodinger/coordgen_install`
-```
+    ```bash
+    cmake .. -Dmaeparser_DIR=/home/schrodinger/maeparser_install -DCMAKE_INSTALL_PREFIX=/home/schrodinger/coordgen_install`
+    ```
 
-A few notes on the `maeparser_DIR` option:
+    A few notes on the maeparser dependency:
 
-- CMake will, by default, search your system's default library paths for the maeparser library. If a `CMAKE_INSTALL_PREFIX` was specified, CMake will also search for maeparser there.
+    - CMake will, by default, search your system's default library paths for the maeparser library. If a `CMAKE_INSTALL_PREFIX` was specified to Coordgen, CMake will also search for maeparser there.
 
-- If you used the `CMAKE_INSTALL_PREFIX` to build and install maeparser, you should give the exact same path to `maeparser_DIR`.
+    - If you already built and installed maeparser using the `CMAKE_INSTALL_PREFIX` to set the installation path, you should pass the exact same path to Coordgen with `maeparser_DIR`.
 
-- CMake will look for the required maeparser headers and library under the indicated path. In case your headers and library live under different paths, point `maeparser_DIR` to the path where your library lives, and point `maeparser_INCLUDE_DIRS` to the path above your `maeparser/Reader.hpp` header.
+    - If CMake cannot find a compiled library for maeparser, it will attempt to download the source code from GitHub and build it. The release to be downloaded if the library is not found can be set using the `-DMAEPARSER_VERSION` flag. The sources will be stored in a directory named like `maeparser-{MAEPARSER_VERSION}` under the coordgen sources.
 
-- If `maeparser_DIR` was passed to CMake, and the library was not found, CMake will **NOT** download the sources from GitHub (since we expected to find a compiled library).
+    - If `maeparser_DIR` was passed to CMake, and the library was not found, CMake will **NOT** download the sources from GitHub (since we expected to find a compiled library).
 
-- Even if the sources cannot be cloned/updated from GitHub, if a copy of maeparser's source is found in the right place (a `maeparser` directory inside Coordgen's source directory), it will be built if no compiled library is available.
+    - If a copy of maeparser's source is found under the proper path, it be used, instead of being downloaded again.
+
+    - If you want to use Coordgen in a CMake project that also depends on maeparser, set up the maeparser first, as Coordgen will be able to find and use it, without searching for further libraries or compiling it again from the source code.
 
 1. Build and install:
 
-```bash
-make -j install
-```
+    ```bash
+    make -j install
+    ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To build coordgen, you will need to have the following installed in your system:
 - A **C++ compiler** supporting the C++11 standard.
 - A compiled instance of the **maeparser library** or its source code.
 
-In case **maeparser** is not available on your system, neither as a compiled library or as source code,if a working `git` executable and an internet connection are available, the builder can automatically download the source and build **maeparser** for you.
+In case **maeparser** is not available on your system, neither as a compiled library or as source code, if a working `git` executable and an internet connection are available, the builder can automatically download the source and build **maeparser** for you.
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -3,19 +3,66 @@
 [![Build Status](https://travis-ci.org/schrodinger/coordgenlibs.svg?branch=master)](https://travis-ci.org/schrodinger/coordgenlibs)
 [![Build_Status](https://ci.appveyor.com/api/projects/status/github/schrodinger/coordgenlibs?branch=master&svg=true)](https://ci.appveyor.com/project/torcolvin/coordgenlibs-3h7cs)
 
-
 This is **Schrodinger, Inc's** 2D coordinate generation.  It was formerly proprietary code, but is now released under the [BSD license](https://github.com/schrodinger/coordgenlibs/blob/master/LICENSE).  The emphasis of these algorithms are on quality of 2D coordinates rather than speed of generation.  The algorithm distinguishes itself from many others by doing well with both macrocycles and metal complexes.  It also does extremely well on typical drug-like small molecules, and has been validated on millions of compounds.
 
 Schrodinger intends to continue to contribute to this code as it still uses it inside its products, but will also be happy if others contribute pull-requests when there are improvements they would like to make.  We'll also be happy to hear bug reports or feature requests from use of this code, though make no guarantee on our ability to process these.
 
-### Documentation
+## Documentation
+
 Examples and documentation will be added/improved over time
 
-### Usage example
+## Usage example
+
 Code for a sample executable is provided in the `example_dir` directory. Building the example executable is enabled by default, but can be disabled by means of the `COORDGEN_BUILD_EXAMPLE` option.
 
-### Automated Testing
-Automated testing is still primarily taking place inside Schrodinger's internal build system, although tests are incrementally being added to the `testing` directory. Building the tests is enabled by default, but can be disabled by means of the `COORDGEN_BUILD_TESTS` option.
+## Automated Testing
 
+Automated testing is still primarily taking place inside Schrodinger's internal build system, although tests are incrementally being added to the `testing` directory. Building the tests is enabled by default, but can be disabled by means of the `COORDGEN_BUILD_TESTS` option.
+d
 Memory debugging is, by default, configured to use `valgrind`. It can be run on the tests by passing `-DCMAKE_BUILD_TYPE=Debug` to cmake, to enable building the debugging symbols, and then using `ctest -T memcheck` inside the build directory.
 
+## Building from source
+
+### Requirements
+
+To build coordgen, you will need to have the following installed in your system:
+
+- **CMake** version 3.2 or later.
+- The development files for the **Boost libraries**. At least the **iostreams** and **regex** components are required. In case of also building the unit tests, the **filesystems** and **unit_test_framework** components will also be required.
+- A **C++ compiler** supporting the C++11 standard.
+- A compiled instance of the **maeparser library** or its source code.
+
+In case **maeparser** is not available on your system, neither as a compiled library or as source code,if a working `git` executable and an internet connection are available, the builder can automatically download the source and build **maeparser** for you.
+
+### Building
+
+1. Create a build directory inside the the one that contains Coordgen, and move into it:
+
+```bash
+mkdir build
+cd build
+```
+
+1. Run `cmake`, passing the path to the directory where the sources are located (just `..` if you created `build` inside the sources directory). At this point, you should add any required flags to the `cmake` command. Check the 'Options' section in CMakeLists.txt to see which options are available.
+
+```bash
+cmake .. -Dmaeparser_DIR=/home/schrodinger/maeparser_install -DCMAKE_INSTALL_PREFIX=/home/schrodinger/coordgen_install`
+```
+
+A few notes on the `maeparser_DIR` option:
+
+- CMake will, by default, search your system's default library paths for the maeparser library. If a `CMAKE_INSTALL_PREFIX` was specified, CMake will also search for maeparser there.
+
+- If you used the `CMAKE_INSTALL_PREFIX` to build and install maeparser, you should give the exact same path to `maeparser_DIR`.
+
+- CMake will look for the required maeparser headers and library under the indicated path. In case your headers and library live under different paths, point `maeparser_DIR` to the path where your library lives, and point `maeparser_INCLUDE_DIRS` to the path above your `maeparser/Reader.hpp` header.
+
+- If `maeparser_DIR` was passed to CMake, and the library was not found, CMake will **NOT** download the sources from GitHub (since we expected to find a compiled library).
+
+- Even if the sources cannot be cloned/updated from GitHub, if a copy of maeparser's source is found in the right place (a `maeparser` directory inside Coordgen's source directory), it will be built if no compiled library is available.
+
+1. Build and install:
+
+```bash
+make -j install
+```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,14 +20,6 @@ build:
   parallel: true
 
 before_build:
-  - git clone https://github.com/schrodinger/maeparser.git %APPVEYOR_BUILD_FOLDER%\maeparser
-  - mkdir %APPVEYOR_BUILD_FOLDER%\maeparser\build
-  - cd %APPVEYOR_BUILD_FOLDER%\maeparser\build
-  - cmake .. -G "Visual Studio 12 Win64" ^
-      -DBOOST_ROOT="%BOOST_ROOT_DIR%" ^
-      -DBOOST_LIBRARYDIR="%BOOST_LIBRARY_PATH%" ^
-      -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
-  - cmake --build . --target install --config Release
   - mkdir %APPVEYOR_BUILD_FOLDER%\build
   - cd %APPVEYOR_BUILD_FOLDER%\build
   - cmake .. -G "Visual Studio 12 Win64" ^

--- a/cmake/CoordgenUtils.cmake
+++ b/cmake/CoordgenUtils.cmake
@@ -1,0 +1,52 @@
+
+# Search for the maeparser library or clone the sources from GitHub
+macro(find_maeparser maeparser_DIR MAEPARSER_SOURCE_TAG)
+
+    find_package(maeparser QUIET)
+    if(maeparser_FOUND)
+        message(STATUS "Found compiled maeparser library at ${maeparser_DIR}")
+    elseif(NOT maeparser_DIR STREQUAL "")
+        message(FATAL_ERROR "*** Failed to find a compiled instance of maeparser under "
+                    "${maeparser_DIR}.")
+    else()
+        find_package(Git QUIET)
+
+        if(GIT_FOUND)
+            message(STATUS "*** maeparser binary installation NOT found, getting/updating "
+                    "maeparser sources from GitHub ...")
+
+            if (EXISTS "${CMAKE_SOURCE_DIR}/maeparser/.git")
+                execute_process(COMMAND ${GIT_EXECUTABLE} pull
+                                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/maeparser
+                                RESULT_VARIABLE GIT_RESULT)
+            else()
+                execute_process(COMMAND ${GIT_EXECUTABLE} clone
+                                https://github.com/schrodinger/maeparser.git
+                                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                                RESULT_VARIABLE GIT_RESULT)
+            endif()
+
+            if(NOT GIT_RESULT EQUAL "0")
+                message(FATAL_ERROR "Failed to get maeparser from GitHub.")
+            endif()
+
+            execute_process(COMMAND ${GIT_EXECUTABLE} checkout ${MAEPARSER_SOURCE_TAG}
+                            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/maeparser
+                            RESULT_VARIABLE GIT_RESULT)
+
+            if(NOT GIT_RESULT EQUAL "0")
+                message(FATAL_ERROR "Failed to check out tag ${MAEPARSER_SOURCE_TAG}.")
+            endif()
+
+        endif()
+
+        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/maeparser/CMakeLists.txt")
+            message(FATAL_ERROR "Failed to find a valid instance of maeparser's "
+                    "source code.")
+        endif()
+
+        set(maeparser_INCLUDE_DIRS ${CMAKE_SOURCE_DIR})
+        add_subdirectory(maeparser)
+    endif()
+
+endmacro()

--- a/cmake/CoordgenUtils.cmake
+++ b/cmake/CoordgenUtils.cmake
@@ -1,53 +1,43 @@
 
 # Search for the maeparser library or clone the sources from GitHub
-macro(find_maeparser maeparser_DIR MAEPARSER_SOURCE_TAG)
+macro(find_or_clone_maeparser)
 
     find_package(maeparser QUIET)
 
     if(maeparser_FOUND)
+
         message(STATUS "Found compiled maeparser library at ${maeparser_DIR}")
-    elseif(NOT maeparser_DIR STREQUAL "")
+
+    elseif(NOT "${maeparser_DIR}" STREQUAL "")
+
         message(FATAL_ERROR "*** Failed to find a compiled instance of maeparser under "
-                    "${maeparser_DIR}.")
+                    "'${maeparser_DIR}'.")
+
     else()
-        find_package(Git QUIET)
 
-        if(GIT_FOUND)
-            message(STATUS "*** maeparser binary installation NOT found, getting/updating "
-                    "maeparser sources from GitHub ...")
+        set(maeparser_DIR "${CMAKE_CURRENT_SOURCE_DIR}/maeparser-${MAEPARSER_VERSION}")
 
-            if (EXISTS "${MAEPARSER_SRC_DIR}/maeparser/.git")
-                execute_process(COMMAND ${GIT_EXECUTABLE} pull
-                                WORKING_DIRECTORY ${MAEPARSER_SRC_DIR}/maeparser
-                                RESULT_VARIABLE GIT_RESULT)
-            else()
-                execute_process(COMMAND ${GIT_EXECUTABLE} clone
-                                https://github.com/schrodinger/maeparser.git
-                                ${MAEPARSER_SRC_DIR}/maeparser WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                                RESULT_VARIABLE GIT_RESULT)
-            endif()
+        if(NOT EXISTS "${maeparser_DIR}/maeparser/CMakeLists.txt")
+            file(DOWNLOAD "https://github.com/schrodinger/maeparser/archive/${MAEPARSER_VERSION}.tar.gz"
+                "${maeparser_DIR}/maeparser-${MAEPARSER_VERSION}.tar.gz")
 
-            if(NOT GIT_RESULT EQUAL "0")
-                message(FATAL_ERROR "Failed to get maeparser from GitHub.")
-            endif()
+            execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf "maeparser-${MAEPARSER_VERSION}.tar.gz"
+                WORKING_DIRECTORY "${maeparser_DIR}")
 
-            execute_process(COMMAND ${GIT_EXECUTABLE} checkout ${MAEPARSER_SOURCE_TAG}
-                            WORKING_DIRECTORY ${MAEPARSER_SRC_DIR}/maeparser
-                            RESULT_VARIABLE GIT_RESULT)
-
-            if(NOT GIT_RESULT EQUAL "0")
-                message(FATAL_ERROR "Failed to check out tag ${MAEPARSER_SOURCE_TAG}.")
-            endif()
-
+            file(RENAME "${maeparser_DIR}/maeparser-${MAEPARSER_VERSION}" "${maeparser_DIR}/maeparser")
         endif()
 
-        if(NOT EXISTS "${MAEPARSER_SRC_DIR}/maeparser/CMakeLists.txt")
-            message(FATAL_ERROR "Failed to find a valid instance of maeparser's "
-                    "source code.")
+        if(EXISTS "${maeparser_DIR}/maeparser/CMakeLists.txt")
+            message(STATUS "Downloaded MaeParser '${MAEPARSER_VERSION}' to ${maeparser_DIR}.")
+        else()
+            message(FATAL_ERROR "Failed getting or unpacking Maeparser '${MAEPARSER_VERSION}'.")
         endif()
 
-        set(maeparser_INCLUDE_DIRS ${MAEPARSER_SRC_DIR})
-        add_subdirectory(${MAEPARSER_SRC_DIR}/maeparser)
+        add_subdirectory("${maeparser_DIR}/maeparser")
+
+        set(maeparser_INCLUDE_DIRS "${maeparser_DIR}")
+        set(maeparser_LIBRARIES maeparser)
+
     endif()
 
 endmacro()

--- a/cmake/CoordgenUtils.cmake
+++ b/cmake/CoordgenUtils.cmake
@@ -3,6 +3,7 @@
 macro(find_maeparser maeparser_DIR MAEPARSER_SOURCE_TAG)
 
     find_package(maeparser QUIET)
+
     if(maeparser_FOUND)
         message(STATUS "Found compiled maeparser library at ${maeparser_DIR}")
     elseif(NOT maeparser_DIR STREQUAL "")
@@ -15,14 +16,14 @@ macro(find_maeparser maeparser_DIR MAEPARSER_SOURCE_TAG)
             message(STATUS "*** maeparser binary installation NOT found, getting/updating "
                     "maeparser sources from GitHub ...")
 
-            if (EXISTS "${CMAKE_SOURCE_DIR}/maeparser/.git")
+            if (EXISTS "${MAEPARSER_SRC_DIR}/maeparser/.git")
                 execute_process(COMMAND ${GIT_EXECUTABLE} pull
-                                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/maeparser
+                                WORKING_DIRECTORY ${MAEPARSER_SRC_DIR}/maeparser
                                 RESULT_VARIABLE GIT_RESULT)
             else()
                 execute_process(COMMAND ${GIT_EXECUTABLE} clone
                                 https://github.com/schrodinger/maeparser.git
-                                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                                ${MAEPARSER_SRC_DIR}/maeparser WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                                 RESULT_VARIABLE GIT_RESULT)
             endif()
 
@@ -31,7 +32,7 @@ macro(find_maeparser maeparser_DIR MAEPARSER_SOURCE_TAG)
             endif()
 
             execute_process(COMMAND ${GIT_EXECUTABLE} checkout ${MAEPARSER_SOURCE_TAG}
-                            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/maeparser
+                            WORKING_DIRECTORY ${MAEPARSER_SRC_DIR}/maeparser
                             RESULT_VARIABLE GIT_RESULT)
 
             if(NOT GIT_RESULT EQUAL "0")
@@ -40,13 +41,13 @@ macro(find_maeparser maeparser_DIR MAEPARSER_SOURCE_TAG)
 
         endif()
 
-        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/maeparser/CMakeLists.txt")
+        if(NOT EXISTS "${MAEPARSER_SRC_DIR}/maeparser/CMakeLists.txt")
             message(FATAL_ERROR "Failed to find a valid instance of maeparser's "
                     "source code.")
         endif()
 
-        set(maeparser_INCLUDE_DIRS ${CMAKE_SOURCE_DIR})
-        add_subdirectory(maeparser)
+        set(maeparser_INCLUDE_DIRS ${MAEPARSER_SRC_DIR})
+        add_subdirectory(${MAEPARSER_SRC_DIR}/maeparser)
     endif()
 
 endmacro()

--- a/cmake/Findmaeparser.cmake
+++ b/cmake/Findmaeparser.cmake
@@ -1,0 +1,34 @@
+# Try to find Schrodinger's MAEParser libraries.
+#
+# Different version handling is not yet supported
+#
+# Once found, this will find and define the following variables:
+#
+# maeparser_INCLUDE_DIRS  - maeparser's includes directory
+# maeparser_LIBRARIES     - maeparser's shared libraries
+#
+#
+
+include(FindPackageHandleStandardArgs)
+
+find_path(maeparser_INCLUDE_DIRS
+    NAMES "maeparser/Reader.hpp"
+    HINTS ${MAEPARSER_DIR} ${maeparser_DIR}
+    PATH_SUFFIXES "include"
+    DOC "include path for maeparser"
+)
+message(STATUS "maeparser include dir set as '${maeparser_INCLUDE_DIRS}'")
+
+find_library(maeparser_LIBRARIES
+    NAMES maeparser
+    HINTS ${MAEPARSER_DIR} ${maeparser_DIR}
+    PATH_SUFFIXES "lib"
+    DOC "libraries for maeparser"
+)
+message(STATUS "maeparser libraries set as '${maeparser_LIBRARIES}'")
+
+get_filename_component(maeparser_DIR ${maeparser_LIBRARIES} PATH)
+
+find_package_handle_standard_args(maeparser FOUND_VAR maeparser_FOUND
+                                  REQUIRED_VARS maeparser_INCLUDE_DIRS
+                                  maeparser_LIBRARIES maeparser_DIR)

--- a/cmake/Findmaeparser.cmake
+++ b/cmake/Findmaeparser.cmake
@@ -13,7 +13,7 @@ include(FindPackageHandleStandardArgs)
 
 find_path(maeparser_INCLUDE_DIRS
     NAMES "maeparser/Reader.hpp"
-    HINTS ${MAEPARSER_DIR} ${maeparser_DIR}
+    HINTS ${maeparser_INCLUDE_DIRS} ${maeparser_DIR}
     PATH_SUFFIXES "include"
     DOC "include path for maeparser"
 )
@@ -21,14 +21,12 @@ message(STATUS "maeparser include dir set as '${maeparser_INCLUDE_DIRS}'")
 
 find_library(maeparser_LIBRARIES
     NAMES maeparser
-    HINTS ${MAEPARSER_DIR} ${maeparser_DIR}
+    HINTS ${maeparser_LIBRARIES} ${maeparser_DIR}
     PATH_SUFFIXES "lib"
     DOC "libraries for maeparser"
 )
 message(STATUS "maeparser libraries set as '${maeparser_LIBRARIES}'")
 
-get_filename_component(maeparser_DIR ${maeparser_LIBRARIES} PATH)
-
 find_package_handle_standard_args(maeparser FOUND_VAR maeparser_FOUND
                                   REQUIRED_VARS maeparser_INCLUDE_DIRS
-                                  maeparser_LIBRARIES maeparser_DIR)
+                                  maeparser_LIBRARIES)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ add_test(example ${CMAKE_BINARY_DIR}/example_dir/example)
 find_package(Boost COMPONENTS unit_test_framework filesystem REQUIRED)
 
 add_executable(test_coordgen test_coordgen.cpp)
-target_link_libraries(test_coordgen maeparser coordgen Boost::unit_test_framework Boost::filesystem)
+target_link_libraries(test_coordgen coordgen Boost::unit_test_framework Boost::filesystem)
 
 # Set the path for the input files
 get_filename_component(TEST_SAMPLES_PATH ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)


### PR DESCRIPTION
This aims at improving the way that the maeparser dependency is handled when building coordgen, and also makes it easier to include both in other projects. Also, it provides some documentation on how to build.

I brought in the CMake module we wrote to allow using `find_package()` to find maeparser compiled libraries, and also added another module to download maeparser from github if the library cannot be found.

Some details:
- The maeparser_DIR option now points to the install path, instead of the .cmake files, which was a bit obscure if you don't know how CMake works (this effectively changes the recommended solution from #37).

- If maeparser_DIR was specified (if it is not an empty string), maeparser's sources will NOT be used, and cmake will fail (since we expected to find a compiled library).

- If there is a copy of maeparser at the download location (inside a maeparser-{version} directory in coordgen's source dir), the download will be skipped, and the already present sources will be built.

- A specific branch/tag/commit may be specified to be downloaded. By default, the master branch will be used.

- Travis and Appveyor scripts have been updated, since we no longer need to build maeparser in advance.