### PR TITLE
Some (mostly automated) fixes to readability in coordgenlibs

### DIFF
--- a/CoordgenFragmentBuilder.cpp
+++ b/CoordgenFragmentBuilder.cpp
@@ -31,12 +31,15 @@ void CoordgenFragmentBuilder::initializeCoordinates(
 void CoordgenFragmentBuilder::rotateMainFragment(
     sketcherMinimizerFragment* f) const
 {
-    if (f->fixed)
+    if (f->fixed) {
         return;
-    if (f->isTemplated)
+    }
+    if (f->isTemplated) {
         return;
-    if (!f->constrained)
+    }
+    if (!f->constrained) {
         return;
+    }
 
     sketcherMinimizerPointF constrainOldCenter(0.f, 0.f);
     sketcherMinimizerPointF constrainNewCenter(0.f, 0.f);
@@ -134,8 +137,9 @@ bool CoordgenFragmentBuilder::findTemplate(
     for (auto& temp : sketcherMinimizer::m_templates.getTemplates()) {
         foundTemplate = sketcherMinimizer::compare(atoms, bonds, temp, mapping);
         if (foundTemplate) {
-            if (atoms.size() > 0)
+            if (atoms.size() > 0) {
                 atoms[0]->fragment->isTemplated = true;
+            }
             for (unsigned int i = 0; i < atoms.size(); i++) {
                 atoms[i]->setCoordinates(temp->_atoms[mapping[i]]->coordinates *
                                          bondLength);
@@ -160,10 +164,12 @@ sketcherMinimizerRing* CoordgenFragmentBuilder::findCentralRingOfSystem(
     size_t high_score = 0;
     for (sketcherMinimizerRing* r : rings) {
         size_t priority = 0;
-        if (r->isMacrocycle())
+        if (r->isMacrocycle()) {
             priority += 1000;
-        if (r->_atoms.size() == 6)
+        }
+        if (r->_atoms.size() == 6) {
             priority += 100;
+        }
         priority += r->_atoms.size();
         priority += 10 * (r->fusedWith.size());
         if (priority > high_score || highest == nullptr) {
@@ -274,11 +280,12 @@ CoordgenFragmentBuilder::getSharedAtomsWithAlreadyDrawnRing(
     for (auto i : ring->fusedWith) {
 
         if (i->coordinatesGenerated) {
-            if (!parent)
+            if (!parent) {
                 parent = i;
-            else {
-                if (i->_atoms.size() > parent->_atoms.size())
+            } else {
+                if (i->_atoms.size() > parent->_atoms.size()) {
                     parent = i;
+                }
             }
         }
     }
@@ -313,8 +320,9 @@ vector<sketcherMinimizerAtom*> CoordgenFragmentBuilder::orderChainOfAtoms(
     while (orderedAtoms.size() < atoms.size()) {
         orderedAtoms.push_back(atomToAdd);
         stillToAdd[atomToAdd] = false;
-        if (orderedAtoms.size() >= atoms.size())
+        if (orderedAtoms.size() >= atoms.size()) {
             break;
+        }
 
         for (sketcherMinimizerAtom* neighbor : atomToAdd->neighbors) {
             if (stillToAdd[neighbor]) {
@@ -336,8 +344,9 @@ CoordgenFragmentBuilder::orderRingAtoms(const sketcherMinimizerRing* ring)
 
 void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
 {
-    if (ring->coordinatesGenerated)
+    if (ring->coordinatesGenerated) {
         return;
+    }
 
     vector<sketcherMinimizerAtom*> atoms;
 
@@ -489,20 +498,23 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
             // parent i.e further away from its center.
             sketcherMinimizerPointF center = parent->findCenter();
             map<sketcherMinimizerAtom*, bool> fusionMap;
-            for (auto fusionAtom : fusionAtoms)
+            for (auto fusionAtom : fusionAtoms) {
                 fusionMap[fusionAtom] = true;
+            }
             float distance1 = 0.f, distance2 = 0.f;
             for (unsigned int i = 0; i < atoms.size(); i++) {
-                if (fusionMap[atoms[i]])
+                if (fusionMap[atoms[i]]) {
                     continue;
+                }
                 sketcherMinimizerPointF v1 = coords[i] - center;
                 sketcherMinimizerPointF v2 = coords2[i] - center;
                 distance1 += v1.length();
                 distance2 += v2.length();
             }
             vector<sketcherMinimizerPointF>* targetCoords = &coords;
-            if (distance1 < distance2)
+            if (distance1 < distance2) {
                 targetCoords = &coords2;
+            }
             for (unsigned int i = 0; i < atoms.size(); i++) {
                 atoms[i]->setCoordinates((*targetCoords)[i]);
             }
@@ -586,8 +598,9 @@ vector<float> CoordgenFragmentBuilder::neighborsAnglesAtCenter(
             }
             if (atom->bonds[0]->getBondOrder() +
                     atom->bonds[1]->getBondOrder() >=
-                4)
+                4) {
                 angleDivision = 2;
+            }
 
         } else if (atom->neighbors.size() == 4 && !atom->crossLayout) {
             angles.push_back(static_cast<float>(M_PI / 3));
@@ -688,18 +701,20 @@ void CoordgenFragmentBuilder::
         sketcherMinimizerPointF point = atom->coordinates + p;
         vector<sketcherMinimizerRing*> rings = atom->getFragment()->getRings();
         for (sketcherMinimizerRing* r : rings) {
-            if (r->isMacrocycle())
+            if (r->isMacrocycle()) {
                 continue;
+            }
             if (r->contains(point)) {
                 rin = true;
                 break;
             }
         }
         float scaledGap = gap;
-        if (gap > M_PI)
+        if (gap > M_PI) {
             scaledGap *= 10.f;
-        else if (rin)
+        } else if (rin) {
             scaledGap *= 0.2f;
+        }
         scaledGaps.push_back(scaledGap);
     }
     int bestI = 0;
@@ -735,8 +750,9 @@ void CoordgenFragmentBuilder::generateCoordinatesNeighborsOfFirstAtomInQueue(
     for (unsigned int i = 0; i < orderedNeighbors.size(); i++) {
         int n = i;
         sketcherMinimizerAtom* neigh = orderedNeighbors[n];
-        if (isAtomVisited.find(neigh) != isAtomVisited.end())
+        if (isAtomVisited.find(neigh) != isAtomVisited.end()) {
             continue;
+        }
         float s = sin(angles[n]);
         float c = cos(angles[n]);
         initialCoords.rotate(s, c);
@@ -775,8 +791,9 @@ void CoordgenFragmentBuilder::maybeAddMacrocycleDOF(
     if (atom->getRings().size() == 1 &&
         atom->getRings().at(0)->isMacrocycle() && atom->neighbors.size() == 3) {
         for (auto& bond : atom->getBonds()) {
-            if (bond->isStereo() && !bond->isTerminal())
+            if (bond->isStereo() && !bond->isTerminal()) {
                 return;
+            }
         }
         for (auto& neighbor : atom->neighbors) {
             if (!sketcherMinimizerAtom::shareARing(atom, neighbor)) {
@@ -791,8 +808,9 @@ void CoordgenFragmentBuilder::avoidZEInversions(
     const sketcherMinimizerAtom* at,
     set<sketcherMinimizerAtom*>& isAtomVisited) const
 {
-    if (!at->getRings().empty())
+    if (!at->getRings().empty()) {
         return;
+    }
     sketcherMinimizerBond* doubleBond = nullptr;
     vector<sketcherMinimizerAtom*> atomsToMirror;
     for (unsigned int i = 0; i < at->bonds.size(); i++) {
@@ -803,17 +821,20 @@ void CoordgenFragmentBuilder::avoidZEInversions(
             atomsToMirror.push_back(at->neighbors[i]);
         }
     }
-    if (doubleBond == nullptr)
+    if (doubleBond == nullptr) {
         return;
+    }
     if (atomsToMirror.size() && doubleBond) {
         sketcherMinimizerAtom* firstCIPNeighborStart =
             doubleBond->startAtomCIPFirstNeighbor();
-        if (firstCIPNeighborStart == nullptr)
+        if (firstCIPNeighborStart == nullptr) {
             return;
+        }
         sketcherMinimizerAtom* firstCIPNeighborEnd =
             doubleBond->endAtomCIPFirstNeighbor();
-        if (firstCIPNeighborEnd == nullptr)
+        if (firstCIPNeighborEnd == nullptr) {
             return;
+        }
         if (!doubleBond->checkStereoChemistry()) {
             for (sketcherMinimizerAtom* a : atomsToMirror) {
                 sketcherMinimizerAtom::mirrorCoordinates(a, doubleBond);
@@ -829,8 +850,9 @@ void CoordgenFragmentBuilder::buildFragment(
     buildNonRingAtoms(fragment);
     CoordgenMinimizer::avoidInternalClashes(fragment);
     fallbackIfNanCoordinates(fragment);
-    if (!fragment->getParent() && fragment->constrained)
+    if (!fragment->getParent() && fragment->constrained) {
         rotateMainFragment(fragment);
+    }
 
     // reset coordinates for fixed fragments:
     if (fragment->fixed) {
@@ -856,8 +878,9 @@ void CoordgenFragmentBuilder::initializeFusedRingInformation(
      with,
      or if they are connected in other ways (i.e. via a double bond).
      */
-    if (fragment->getRings().size() < 2)
+    if (fragment->getRings().size() < 2) {
         return;
+    }
     vector<sketcherMinimizerAtom*> fragmentAtoms = fragment->getAtoms();
     for (sketcherMinimizerAtom* atom : fragmentAtoms) {
         if (atom->rings.size() > 1) {
@@ -917,8 +940,9 @@ void CoordgenFragmentBuilder::initializeFusedRingInformation(
     for (sketcherMinimizerRing* r : fragmentRings) {
         for (unsigned int i = 0; i < r->fusedWith.size(); i++) {
             vector<sketcherMinimizerAtom*> fusionAtoms = r->fusionAtoms[i];
-            if (fusionAtoms.size() <= 2)
+            if (fusionAtoms.size() <= 2) {
                 continue;
+            }
             // find an atom with only one neighbor in the vector
             sketcherMinimizerAtom* startAtom = nullptr;
             for (sketcherMinimizerAtom* a : fusionAtoms) {
@@ -950,10 +974,11 @@ void CoordgenFragmentBuilder::initializeFusedRingInformation(
                     for (sketcherMinimizerAtom* n : a->neighbors) {
                         int nn = 0;
                         for (sketcherMinimizerRing* nr : n->rings) {
-                            if (nr == r)
+                            if (nr == r) {
                                 nn++;
-                            else if (nr == r->fusedWith[ii])
+                            } else if (nr == r->fusedWith[ii]) {
                                 nn++;
+                            }
                         }
                         if (nn == 1) {
                             found = true;
@@ -989,10 +1014,12 @@ void CoordgenFragmentBuilder::simplifyRingSystem(
     while (found) {
         found = false;
         for (sketcherMinimizerRing* r : allRings) {
-            if (alreadyChosenAsSide[r])
+            if (alreadyChosenAsSide[r]) {
                 continue;
-            if (r->isMacrocycle())
+            }
+            if (r->isMacrocycle()) {
                 continue;
+            }
             int n = 0;
             for (auto ringCounter = 0u; ringCounter < r->fusedWith.size();
                  ++ringCounter) {
@@ -1026,16 +1053,18 @@ void CoordgenFragmentBuilder::simplifyRingSystem(
      ring system
      */
     for (sketcherMinimizerRing* ring : allRings) {
-        if (!alreadyChosenAsSide[ring])
+        if (!alreadyChosenAsSide[ring]) {
             centralRings.push_back(ring);
+        }
     }
 }
 
 void CoordgenFragmentBuilder::buildRings(
     sketcherMinimizerFragment* fragment) const
 {
-    if (fragment->getRings().empty())
+    if (fragment->getRings().empty()) {
         return;
+    }
     initializeFusedRingInformation(fragment);
     vector<sketcherMinimizerRing*> fragmentRings = fragment->getRings();
     if (fragmentRings.size() == 1) {

--- a/CoordgenFragmentBuilder.cpp
+++ b/CoordgenFragmentBuilder.cpp
@@ -223,7 +223,7 @@ float CoordgenFragmentBuilder::newScorePlanarity(
 
     for (const auto& ring : rings) {
         if (ring->isMacrocycle() &&
-            m_macrocycleBuilder.findBondToOpen(ring) == NULL) {
+            m_macrocycleBuilder.findBondToOpen(ring) == nullptr) {
             continue;
         }
         if (ring->isMacrocycle()) {
@@ -270,15 +270,15 @@ CoordgenFragmentBuilder::getSharedAtomsWithAlreadyDrawnRing(
     vector<sketcherMinimizerAtom*>& fusionAtoms,
     sketcherMinimizerBond*& fusionBond) const
 {
-    sketcherMinimizerRing* parent = NULL;
-    for (unsigned int i = 0; i < ring->fusedWith.size(); i++) {
+    sketcherMinimizerRing* parent = nullptr;
+    for (auto i : ring->fusedWith) {
 
-        if (ring->fusedWith[i]->coordinatesGenerated) {
+        if (i->coordinatesGenerated) {
             if (!parent)
-                parent = ring->fusedWith[i];
+                parent = i;
             else {
-                if (ring->fusedWith[i]->_atoms.size() > parent->_atoms.size())
-                    parent = ring->fusedWith[i];
+                if (i->_atoms.size() > parent->_atoms.size())
+                    parent = i;
             }
         }
     }
@@ -341,8 +341,8 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
 
     vector<sketcherMinimizerAtom*> atoms;
 
-    sketcherMinimizerRing* parent = NULL;
-    sketcherMinimizerBond* fusionBond = NULL;
+    sketcherMinimizerRing* parent = nullptr;
+    sketcherMinimizerBond* fusionBond = nullptr;
     vector<sketcherMinimizerAtom*> fusionAtoms;
     parent = getSharedAtomsWithAlreadyDrawnRing(ring, fusionAtoms, fusionBond);
     atoms = orderRingAtoms(ring);
@@ -357,8 +357,8 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
         if (fusionAtoms.size() < 2) {
             sketcherMinimizerPointF coordinatesOfPivotAtom;
 
-            sketcherMinimizerAtom* pivotAtom = NULL;
-            sketcherMinimizerAtom* pivotAtomOnParent = NULL;
+            sketcherMinimizerAtom* pivotAtom = nullptr;
+            sketcherMinimizerAtom* pivotAtomOnParent = nullptr;
             if (!fusionAtoms.empty()) {
                 pivotAtom = fusionAtoms.at(0);
                 pivotAtomOnParent = fusionAtoms.at(0);
@@ -383,8 +383,8 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
                 }
             }
 
-            for (unsigned int i = 0; i < coords.size(); i++) {
-                coords[i] -= coordinatesOfPivotAtom;
+            for (auto& coord : coords) {
+                coord -= coordinatesOfPivotAtom;
             }
             sketcherMinimizerPointF center =
                 accumulate(coords.begin(), coords.end(),
@@ -409,14 +409,14 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
                 pivotAtomCoordinates - neighborsMean;
             direction.normalize();
             sketcherMinimizerPointF bondVector(0.f, 0.f);
-            if (fusionBond != NULL) {
+            if (fusionBond != nullptr) {
                 bondVector = direction * bondLength;
             }
-            for (unsigned int i = 0; i < coords.size(); i++) {
-                sketcherMinimizerPointF coordinates = coords[i];
+            for (auto& coord : coords) {
+                sketcherMinimizerPointF coordinates = coord;
                 coordinates.rotate(center.y(), center.x());
                 coordinates.rotate(-direction.y(), direction.x());
-                coords[i] = coordinates + pivotAtomCoordinates + bondVector;
+                coord = coordinates + pivotAtomCoordinates + bondVector;
             }
             for (unsigned int i = 0; i < coords.size(); i++) {
                 atoms[i]->setCoordinates(coords[i]);
@@ -435,9 +435,8 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
             // build 2 lists of coordinates, mirror of each other.
 
             vector<sketcherMinimizerPointF> coords2 = coords;
-            for (unsigned int i = 0; i < coords2.size(); i++) {
-                coords2[i] =
-                    sketcherMinimizerPointF(coords2[i].x(), -coords2[i].y());
+            for (auto& i : coords2) {
+                i = sketcherMinimizerPointF(i.x(), -i.y());
             }
             map<sketcherMinimizerAtom *, sketcherMinimizerPointF> map1, map2;
             for (unsigned int i = 0; i < atoms.size(); i++) {
@@ -490,8 +489,8 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
             // parent i.e further away from its center.
             sketcherMinimizerPointF center = parent->findCenter();
             map<sketcherMinimizerAtom*, bool> fusionMap;
-            for (unsigned int i = 0; i < fusionAtoms.size(); i++)
-                fusionMap[fusionAtoms[i]] = true;
+            for (auto fusionAtom : fusionAtoms)
+                fusionMap[fusionAtom] = true;
             float distance1 = 0.f, distance2 = 0.f;
             for (unsigned int i = 0; i < atoms.size(); i++) {
                 if (fusionMap[atoms[i]])
@@ -511,8 +510,7 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
             if (ring->fusedWith.size() == 1 &&
                 (*fusionAtoms.begin())->hasNoStereoActiveBonds() &&
                 (*fusionAtoms.rbegin())->hasNoStereoActiveBonds()) {
-                CoordgenFlipRingDOF* dof =
-                    new CoordgenFlipRingDOF(ring, fusionAtoms);
+                auto* dof = new CoordgenFlipRingDOF(ring, fusionAtoms);
                 ring->getAtoms().at(0)->fragment->addDof(dof);
             }
         }
@@ -531,7 +529,7 @@ CoordgenFragmentBuilder::listOfCoordinatesFromListofRingAtoms(
 {
     vector<sketcherMinimizerPointF> out;
     assert(atoms.size());
-    float a = static_cast<float>(2 * M_PI / atoms.size());
+    auto a = static_cast<float>(2 * M_PI / atoms.size());
     sketcherMinimizerPointF coords(0.f, 0.f);
     float angle = 0;
     for (unsigned int n = 0; n < atoms.size(); n++) {
@@ -621,9 +619,9 @@ void CoordgenFragmentBuilder::initializeVariablesForNeighboursCoordinates(
         orderedNeighbors = atom->neighbors;
     } else {
         vector<sketcherMinimizerAtomPriority> atomPriorities;
-        for (unsigned int i = 0; i < atom->neighbors.size(); i++) {
+        for (auto& neighbor : atom->neighbors) {
             sketcherMinimizerAtomPriority p;
-            p.a = atom->neighbors[i];
+            p.a = neighbor;
             atomPriorities.push_back(p);
         }
         sketcherMinimizerAtom::orderAtomPriorities(atomPriorities, atom);
@@ -764,7 +762,7 @@ void CoordgenFragmentBuilder::generateCoordinatesNeighborsOfFirstAtomInQueue(
     for (auto& neighbor : at->neighbors) {
         if (!sketcherMinimizerAtom::shareARing(at, neighbor) &&
             at->getFragment() == neighbor->getFragment()) {
-            CoordgenScaleAtomsDOF* dof = new CoordgenScaleAtomsDOF(at);
+            auto* dof = new CoordgenScaleAtomsDOF(at);
             dof->addAtom(neighbor);
             at->fragment->addDof(dof);
         }
@@ -782,8 +780,7 @@ void CoordgenFragmentBuilder::maybeAddMacrocycleDOF(
         }
         for (auto& neighbor : atom->neighbors) {
             if (!sketcherMinimizerAtom::shareARing(atom, neighbor)) {
-                CoordgenInvertBondDOF* dof =
-                    new CoordgenInvertBondDOF(atom, neighbor);
+                auto* dof = new CoordgenInvertBondDOF(atom, neighbor);
                 atom->fragment->addDof(dof);
             }
         }
@@ -796,7 +793,7 @@ void CoordgenFragmentBuilder::avoidZEInversions(
 {
     if (!at->getRings().empty())
         return;
-    sketcherMinimizerBond* doubleBond = NULL;
+    sketcherMinimizerBond* doubleBond = nullptr;
     vector<sketcherMinimizerAtom*> atomsToMirror;
     for (unsigned int i = 0; i < at->bonds.size(); i++) {
         if (at->bonds[i]->isStereo() &&
@@ -806,16 +803,16 @@ void CoordgenFragmentBuilder::avoidZEInversions(
             atomsToMirror.push_back(at->neighbors[i]);
         }
     }
-    if (doubleBond == NULL)
+    if (doubleBond == nullptr)
         return;
     if (atomsToMirror.size() && doubleBond) {
         sketcherMinimizerAtom* firstCIPNeighborStart =
             doubleBond->startAtomCIPFirstNeighbor();
-        if (firstCIPNeighborStart == NULL)
+        if (firstCIPNeighborStart == nullptr)
             return;
         sketcherMinimizerAtom* firstCIPNeighborEnd =
             doubleBond->endAtomCIPFirstNeighbor();
-        if (firstCIPNeighborEnd == NULL)
+        if (firstCIPNeighborEnd == nullptr)
             return;
         if (!doubleBond->checkStereoChemistry()) {
             for (sketcherMinimizerAtom* a : atomsToMirror) {
@@ -923,7 +920,7 @@ void CoordgenFragmentBuilder::initializeFusedRingInformation(
             if (fusionAtoms.size() <= 2)
                 continue;
             // find an atom with only one neighbor in the vector
-            sketcherMinimizerAtom* startAtom = NULL;
+            sketcherMinimizerAtom* startAtom = nullptr;
             for (sketcherMinimizerAtom* a : fusionAtoms) {
                 int counter = 0;
                 for (sketcherMinimizerAtom* n : a->neighbors) {

--- a/CoordgenFragmentBuilder.cpp
+++ b/CoordgenFragmentBuilder.cpp
@@ -439,7 +439,7 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
                 coords2[i] =
                     sketcherMinimizerPointF(coords2[i].x(), -coords2[i].y());
             }
-            map<sketcherMinimizerAtom*, sketcherMinimizerPointF> map1, map2;
+            map<sketcherMinimizerAtom *, sketcherMinimizerPointF> map1, map2;
             for (unsigned int i = 0; i < atoms.size(); i++) {
                 map1[atoms[i]] = coords[i];
                 map2[atoms[i]] = coords2[i];

--- a/CoordgenFragmenter.cpp
+++ b/CoordgenFragmenter.cpp
@@ -22,12 +22,12 @@ void CoordgenFragmenter::splitIntoFragments(sketcherMinimizerMolecule* molecule)
      */
     vector<sketcherMinimizerFragment*> fragments;
     foreach (sketcherMinimizerAtom* atom, molecule->getAtoms()) {
-        atom->setFragment(NULL);
+        atom->setFragment(nullptr);
     }
 
     /* molecule with a single atom and no bonds */
     if (molecule->getAtoms().size() == 1) {
-        sketcherMinimizerFragment* fragment = new sketcherMinimizerFragment();
+        auto* fragment = new sketcherMinimizerFragment();
         sketcherMinimizerAtom* onlyAtom = molecule->getAtoms().at(0);
         fragment->addAtom(onlyAtom);
         fragments.push_back(fragment);
@@ -73,13 +73,13 @@ void CoordgenFragmenter::addRingInformation(sketcherMinimizerRing* ring)
 void CoordgenFragmenter::processInterFragmentBond(
     sketcherMinimizerBond* bond, vector<sketcherMinimizerFragment*>& fragments)
 {
-    if (bond->getStartAtom()->getFragment() == NULL) {
-        sketcherMinimizerFragment* fragment = new sketcherMinimizerFragment();
+    if (bond->getStartAtom()->getFragment() == nullptr) {
+        auto* fragment = new sketcherMinimizerFragment();
         fragment->addAtom(bond->getStartAtom());
         fragments.push_back(fragment);
     }
-    if (bond->getEndAtom()->getFragment() == NULL) {
-        sketcherMinimizerFragment* fragment = new sketcherMinimizerFragment();
+    if (bond->getEndAtom()->getFragment() == nullptr) {
+        auto* fragment = new sketcherMinimizerFragment();
         fragment->addAtom(bond->getEndAtom());
         fragments.push_back(fragment);
     }
@@ -88,17 +88,17 @@ void CoordgenFragmenter::processInterFragmentBond(
 void CoordgenFragmenter::processBondInternalToFragment(
     sketcherMinimizerBond* bond, vector<sketcherMinimizerFragment*>& fragments)
 {
-    if (bond->getStartAtom()->getFragment() == NULL &&
-        bond->getEndAtom()->getFragment() == NULL) {
+    if (bond->getStartAtom()->getFragment() == nullptr &&
+        bond->getEndAtom()->getFragment() == nullptr) {
         /* add the two atoms to a new fragment */
-        sketcherMinimizerFragment* fragment = new sketcherMinimizerFragment();
+        auto* fragment = new sketcherMinimizerFragment();
         fragment->addAtom(bond->getStartAtom());
         fragment->addAtom(bond->getEndAtom());
         fragments.push_back(fragment);
-    } else if (bond->getEndAtom()->getFragment() == NULL) {
+    } else if (bond->getEndAtom()->getFragment() == nullptr) {
         /* extend fragment of start atom */
         bond->getStartAtom()->getFragment()->addAtom(bond->getEndAtom());
-    } else if (bond->getStartAtom()->getFragment() == NULL) {
+    } else if (bond->getStartAtom()->getFragment() == nullptr) {
         /* extend fragment of end atom */
         bond->getEndAtom()->getFragment()->addAtom(bond->getStartAtom());
     } else if (bond->getStartAtom()->getFragment() !=
@@ -118,7 +118,7 @@ void CoordgenFragmenter::joinFragments(
     }
 
     // remove fragment2 from fragments and free memory
-    std::vector<sketcherMinimizerFragment*>::iterator positionOfFragment2 =
+    auto positionOfFragment2 =
         remove(fragments.begin(), fragments.end(), fragment2);
     fragments.erase(positionOfFragment2, fragments.end());
     delete fragment2;
@@ -307,7 +307,7 @@ vector<sketcherMinimizerFragment*> CoordgenFragmenter::findLongestChain(
         parentMap[fragment] = fragment; // mark first fragment as parent of
                                         // itself so it results visited
         q.push(fragment);
-        sketcherMinimizerFragment* lastFragment = NULL;
+        sketcherMinimizerFragment* lastFragment = nullptr;
         while (q.size()) {
             lastFragment = q.front();
             q.pop();
@@ -317,7 +317,7 @@ vector<sketcherMinimizerFragment*> CoordgenFragmenter::findLongestChain(
                     (b->getStartAtom()->getFragment() != lastFragment
                          ? b->getStartAtom()->getFragment()
                          : b->getEndAtom()->getFragment());
-                if (parentMap[childFragment] != NULL)
+                if (parentMap[childFragment] != nullptr)
                     continue;
                 if (!childFragment->isChain)
                     continue;

--- a/CoordgenFragmenter.cpp
+++ b/CoordgenFragmenter.cpp
@@ -33,8 +33,9 @@ void CoordgenFragmenter::splitIntoFragments(sketcherMinimizerMolecule* molecule)
         fragments.push_back(fragment);
     }
     foreach (sketcherMinimizerBond* bond, molecule->_bonds) {
-        if (bond->isResidueInteraction())
+        if (bond->isResidueInteraction()) {
             continue;
+        }
         if (bond->isInterFragment()) {
             processInterFragmentBond(bond, fragments);
         } else {
@@ -53,8 +54,9 @@ void CoordgenFragmenter::splitIntoFragments(sketcherMinimizerMolecule* molecule)
 
 void CoordgenFragmenter::addBondInformation(sketcherMinimizerBond* bond)
 {
-    if (bond->isResidueInteraction())
+    if (bond->isResidueInteraction()) {
         return;
+    }
     if (bond->getStartAtom()->getFragment() ==
         bond->getEndAtom()->getFragment()) {
         bond->getStartAtom()->getFragment()->addBond(bond);
@@ -181,18 +183,22 @@ bool CoordgenFragmenter::isChain(const sketcherMinimizerFragment* fragment)
 {
     /* can this fragment be part of a zig-zag chain, e.g. exane? */
     vector<sketcherMinimizerAtom*> fragmentAtoms = fragment->getAtoms();
-    if (fragmentAtoms.size() > 3)
+    if (fragmentAtoms.size() > 3) {
         return false;
+    }
     foreach (sketcherMinimizerAtom* atom, fragmentAtoms) {
-        if (atom->getBonds().size() > 3)
+        if (atom->getBonds().size() > 3) {
             return false;
-        if (atom->getRings().size())
+        }
+        if (atom->getRings().size()) {
             return false;
+        }
     }
     vector<sketcherMinimizerBond*> fragmentBonds = fragment->getBonds();
     foreach (sketcherMinimizerBond* bond, fragmentBonds) {
-        if (bond->getBondOrder() > 2)
+        if (bond->getBondOrder() > 2) {
             return false;
+        }
     }
     return true;
 }
@@ -205,10 +211,12 @@ bool CoordgenFragmenter::hasPriority(const sketcherMinimizerFragment* fragment1,
     while (!checkNoMore) {
         size_t leftValue = getValueOfCheck(fragment1, checkN, checkNoMore);
         size_t rightValue = getValueOfCheck(fragment2, checkN, checkNoMore);
-        if (leftValue > rightValue)
+        if (leftValue > rightValue) {
             return true;
-        if (leftValue < rightValue)
+        }
+        if (leftValue < rightValue) {
             return false;
+        }
         ++checkN;
     }
     return false;
@@ -256,13 +264,15 @@ sketcherMinimizerFragment* CoordgenFragmenter::considerChains(
 {
 
     foreach (sketcherMinimizerFragment* fragment, fragments) {
-        if (fragment->fixed || fragment->constrained)
+        if (fragment->fixed || fragment->constrained) {
             return mainFragment;
+        }
     }
     vector<sketcherMinimizerFragment*> longestChain =
         findLongestChain(fragments);
-    if (longestChain.size() >= acceptableChainLength(mainFragment))
+    if (longestChain.size() >= acceptableChainLength(mainFragment)) {
         mainFragment = longestChain.at(0);
+    }
     return mainFragment;
 }
 
@@ -289,19 +299,22 @@ vector<sketcherMinimizerFragment*> CoordgenFragmenter::findLongestChain(
 {
     vector<sketcherMinimizerFragment*> longestChain;
     foreach (sketcherMinimizerFragment* fragment, fragments) {
-        if (!fragment->isChain)
+        if (!fragment->isChain) {
             continue;
+        }
         int chainN = 0;
         foreach (sketcherMinimizerBond* b, fragment->_interFragmentBonds) {
             sketcherMinimizerFragment* childFragment =
                 (b->getStartAtom()->getFragment() != fragment
                      ? b->getStartAtom()->getFragment()
                      : b->getEndAtom()->getFragment());
-            if (childFragment->isChain)
+            if (childFragment->isChain) {
                 ++chainN;
+            }
         }
-        if (chainN > 1)
+        if (chainN > 1) {
             continue; // it's in the middle of a chain
+        }
         queue<sketcherMinimizerFragment*> q;
         map<sketcherMinimizerFragment*, sketcherMinimizerFragment*> parentMap;
         parentMap[fragment] = fragment; // mark first fragment as parent of
@@ -317,10 +330,12 @@ vector<sketcherMinimizerFragment*> CoordgenFragmenter::findLongestChain(
                     (b->getStartAtom()->getFragment() != lastFragment
                          ? b->getStartAtom()->getFragment()
                          : b->getEndAtom()->getFragment());
-                if (parentMap[childFragment] != nullptr)
+                if (parentMap[childFragment] != nullptr) {
                     continue;
-                if (!childFragment->isChain)
+                }
+                if (!childFragment->isChain) {
                     continue;
+                }
                 parentMap[childFragment] = lastFragment;
                 q.push(childFragment);
             }
@@ -334,8 +349,9 @@ vector<sketcherMinimizerFragment*> CoordgenFragmenter::findLongestChain(
             }
             chain.insert(chain.begin(), recursiveFragment);
         }
-        if (chain.size() > longestChain.size())
+        if (chain.size() > longestChain.size()) {
             longestChain = chain;
+        }
     }
     return longestChain;
 }
@@ -354,8 +370,9 @@ void CoordgenFragmenter::addParentRelationsToFragments(
                 (bond->getStartAtom()->getFragment() == fragment
                      ? bond->getEndAtom()->getFragment()
                      : bond->getStartAtom()->getFragment());
-            if (childFragment == fragment->getParent())
+            if (childFragment == fragment->getParent()) {
                 continue;
+            }
             fragment->_children.push_back(childFragment);
             childFragment->setParent(fragment);
             childFragment->_bondToParent = bond;

--- a/CoordgenMacrocycleBuilder.cpp
+++ b/CoordgenMacrocycleBuilder.cpp
@@ -101,23 +101,27 @@ void Polyomino::reassignHexs() const
 bool Polyomino::isTheSameAs(Polyomino& p) const
 {
     // mirrored polyominoes are considered to be different
-    if (size() != p.size())
+    if (size() != p.size()) {
         return false;
+    }
     vector<hexCoords> targetCoords;
     foreach (Hex* hex, p.m_list) {
         targetCoords.push_back(hex->coords());
     }
-    if (!targetCoords.size())
+    if (!targetCoords.size()) {
         return true; // both polyominoes are empty
+    }
     int lowestx = m_list[0]->coords().x;
     int lowesty = m_list[0]->coords().y;
     foreach (Hex* hex, m_list) {
         int x = hex->coords().x;
         int y = hex->coords().y;
-        if (x < lowestx)
+        if (x < lowestx) {
             lowestx = x;
-        if (y < lowesty)
+        }
+        if (y < lowesty) {
             lowesty = y;
+        }
     }
     for (unsigned int i = 0; i < 6;
          i++) { // explore 6 possible positions rotating the coordinates 30
@@ -169,8 +173,9 @@ void Polyomino::buildSkewedBoxShape(int x, int y, bool pentagon)
             addHex(hexCoords(xx, yy));
         }
     }
-    if (pentagon)
+    if (pentagon) {
         markOneVertexAsPentagon();
+    }
 }
 
 void Polyomino::buildRaggedSmallerBoxShape(
@@ -185,15 +190,17 @@ void Polyomino::buildRaggedSmallerBoxShape(
             addHex(hexCoords(startx + xx, yy));
         }
         yy++;
-        if (yy >= y)
+        if (yy >= y) {
             break;
+        }
         for (int xx = 0; xx < x - 1; xx++) {
             addHex(hexCoords(startx + xx, yy));
         }
         startx--;
     }
-    if (pentagon)
+    if (pentagon) {
         markOneVertexAsPentagon();
+    }
 }
 
 void Polyomino::buildRaggedBiggerBoxShape(
@@ -208,15 +215,17 @@ void Polyomino::buildRaggedBiggerBoxShape(
             addHex(hexCoords(startx + xx, yy));
         }
         yy++;
-        if (yy >= y)
+        if (yy >= y) {
             break;
+        }
         for (int xx = 0; xx < x + 1; xx++) {
             addHex(hexCoords(startx + xx - 1, yy));
         }
         startx--;
     }
-    if (pentagon)
+    if (pentagon) {
         markOneVertexAsPentagon();
+    }
 }
 
 void Polyomino::buildRaggedBoxShape(int x, int y, bool pentagon)
@@ -228,15 +237,17 @@ void Polyomino::buildRaggedBoxShape(int x, int y, bool pentagon)
             addHex(hexCoords(startx + xx, yy));
         }
         yy++;
-        if (yy >= y)
+        if (yy >= y) {
             break;
+        }
         for (int xx = 0; xx < x; xx++) {
             addHex(hexCoords(startx + xx, yy));
         }
         startx--;
     }
-    if (pentagon)
+    if (pentagon) {
         markOneVertexAsPentagon();
+    }
 }
 
 void Polyomino::buildWithVerticesN(int totVertices)
@@ -252,8 +263,9 @@ void Polyomino::buildWithVerticesN(int totVertices)
         unsigned int bestI = 0;
         for (unsigned int i = 0; i < nextCoords.size(); i++) {
             hexCoords c = nextCoords[i];
-            if (countNeighbors(c) != 2)
+            if (countNeighbors(c) != 2) {
                 continue;
+            }
             int distance = c.distanceFrom(hexCoords(0, 0));
 
             if (lowestDistance == -1 || distance < lowestDistance) {
@@ -265,11 +277,13 @@ void Polyomino::buildWithVerticesN(int totVertices)
 
         addHex(nextCoords[bestI]);
         for (unsigned int i = 0; i < nextCoords.size(); i++) {
-            if (i == bestI)
+            if (i == bestI) {
                 continue;
+            }
             hexCoords c = nextCoords[i];
-            if (countNeighbors(c) == 3)
+            if (countNeighbors(c) == 3) {
                 addHex(c);
+            }
         }
         vertices += 2;
     }
@@ -336,14 +350,17 @@ vector<hexCoords> Polyomino::freeVertexNeighborPositions(vertexCoords v) const
         return out;
     }
     Hex* h = getHex(hexCoords(v.x - direction, v.y));
-    if (!h)
+    if (!h) {
         out.emplace_back(v.x - direction, v.y);
+    }
     h = getHex(hexCoords(v.x, v.y - direction));
-    if (!h)
+    if (!h) {
         out.emplace_back(v.x, v.y - direction);
+    }
     h = getHex(hexCoords(v.x, v.y)); // z - direction
-    if (!h)
+    if (!h) {
         out.emplace_back(v.x, v.y);
+    }
     return out;
 }
 
@@ -356,14 +373,17 @@ vector<Hex*> Polyomino::vertexNeighbors(vertexCoords v) const
         return out;
     }
     Hex* h = getHex(hexCoords(v.x - direction, v.y));
-    if (h)
+    if (h) {
         out.push_back(h);
+    }
     h = getHex(hexCoords(v.x, v.y - direction));
-    if (h)
+    if (h) {
         out.push_back(h);
+    }
     h = getHex(hexCoords(v.x, v.y)); // z - direction
-    if (h)
+    if (h) {
         out.push_back(h);
+    }
     return out;
 }
 
@@ -387,8 +407,9 @@ int Polyomino::countNeighbors(hexCoords h) const
     int out = 0;
     vector<hexCoords> neighs = Hex::neighboringPositions(h);
     for (auto neigh : neighs) {
-        if (getHex(neigh) != nullptr)
+        if (getHex(neigh) != nullptr) {
             out++;
+        }
     }
     return out;
 }
@@ -408,11 +429,13 @@ std::vector<hexCoords> Polyomino::allFreeNeighbors() const
         std::vector<hexCoords> neighborsCoords = i->neighbors();
         for (auto neighborsCoord : neighborsCoords) {
             bool isPresent = (getHex(neighborsCoord) != nullptr);
-            if (isPresent)
+            if (isPresent) {
                 continue;
+            }
             int index = getIndexInList(neighborsCoord);
-            if (visited[index])
+            if (visited[index]) {
                 continue;
+            }
             visited[index] = true;
             out.push_back(neighborsCoord);
         }
@@ -464,15 +487,17 @@ bool Polyomino::isEquivalentWithout(hexCoords c) const
 {
     /* does removing this hexagon yield another polyomino with the same number
      of vertices? true if hte hexagon has 3 neighbors all next to each other */
-    if (countNeighbors(c) != 3)
+    if (countNeighbors(c) != 3) {
         return false;
+    }
     vector<hexCoords> neighs = Hex::neighboringPositions(c);
     for (unsigned int i = 0; i < neighs.size(); i++) {
         int i2 = (i - 1 + 6) % 6;
         int i3 = (i - 2 + 6) % 6;
         if (getHex(neighs[i]) != nullptr && getHex(neighs[i2]) != nullptr &&
-            getHex(neighs[i3]) != nullptr)
+            getHex(neighs[i3]) != nullptr) {
             return true;
+        }
     }
     return false;
 }
@@ -494,14 +519,18 @@ vertexCoords Polyomino::coordinatesOfSubstituent(const vertexCoords pos) const
         vertexCoords parentCoords = neighbors[0]->coords().toVertexCoords();
         vertexCoords v = pos - parentCoords;
         int d = -1;
-        if (v.x + v.y + v.z > 0)
+        if (v.x + v.y + v.z > 0) {
             d = 1;
-        if (v.x == 0)
+        }
+        if (v.x == 0) {
             v.x -= d;
-        if (v.y == 0)
+        }
+        if (v.y == 0) {
             v.y -= d;
-        if (v.z == 0)
+        }
+        if (v.z == 0) {
             v.z -= d;
+        }
         out = parentCoords + v;
     } else if (neighbors.size() == 2) {
         /*
@@ -535,8 +564,9 @@ vector<vertexCoords> Polyomino::getPath() const
                 }
             }
         }
-        if (!skip)
+        if (!skip) {
             out.push_back(currentVertex);
+        }
 
         currentVertex = nextVertex;
 
@@ -647,8 +677,9 @@ vector<sketcherMinimizerPointF> CoordgenMacrocycleBuilder::newMacrocycle(
                     break;
                 }
             }
-            if (checkedMacrocycles > MAX_MACROCYCLES)
+            if (checkedMacrocycles > MAX_MACROCYCLES) {
                 break;
+            }
 
             pols = listOfEquivalents(pols);
             pols = removeDuplicates(pols);
@@ -691,8 +722,9 @@ CoordgenMacrocycleBuilder::findBondToOpen(sketcherMinimizerRing* ring) const
     foreach (sketcherMinimizerBond* bond, ring->_bonds) {
         size_t score = 0;
         if (ring->isMacrocycle()) {
-            if (bond->getBondOrder() != 1)
+            if (bond->getBondOrder() != 1) {
                 continue;
+            }
 
             bool nextToMultipleBond = false;
             for (auto otherBond : bond->getStartAtom()->bonds) {
@@ -707,8 +739,9 @@ CoordgenMacrocycleBuilder::findBondToOpen(sketcherMinimizerRing* ring) const
                     break;
                 }
             }
-            if (nextToMultipleBond)
+            if (nextToMultipleBond) {
                 continue;
+            }
         }
         score += bond->rings.size() * 10;
         score += bond->getStartAtom()->neighbors.size();
@@ -731,14 +764,16 @@ bool CoordgenMacrocycleBuilder::openCycleAndGenerateCoords(
     min.m_fragmentBuilder.setForceOpenMacrocycles(true);
     auto* minMol = new sketcherMinimizerMolecule;
     sketcherMinimizerBond* bondToBreak = findBondToOpen(ring);
-    if (!bondToBreak)
+    if (!bondToBreak) {
         return false;
+    }
     sketcherMinimizerAtom* a = ring->_atoms[0];
     // vector<sketcherMinimizerAtom*> atoms = a->getFragment()->getAtoms();
     vector<sketcherMinimizerAtom*> atoms = a->molecule->getAtoms();
     foreach (sketcherMinimizerAtom* at, atoms) {
-        if (at->isResidue())
+        if (at->isResidue()) {
             continue;
+        }
         auto* new_at = new sketcherMinimizerAtom;
         atomMap[at] = new_at;
         new_at->templateCoordinates = at->coordinates;
@@ -754,8 +789,9 @@ bool CoordgenMacrocycleBuilder::openCycleAndGenerateCoords(
     vector<sketcherMinimizerBond*> bonds = a->molecule->getBonds();
 
     foreach (sketcherMinimizerBond* bo, bonds) {
-        if (bo == bondToBreak || bo->isResidueInteraction())
+        if (bo == bondToBreak || bo->isResidueInteraction()) {
             continue;
+        }
         auto* new_bo = new sketcherMinimizerBond;
         new_bo->bondOrder = bo->bondOrder;
         new_bo->startAtom = atomMap[bo->startAtom];
@@ -857,8 +893,9 @@ vector<ringConstraint> CoordgenMacrocycleBuilder::getRingConstraints(
                     for (auto n : a->neighbors) {
                         if (find(atoms.begin(), atoms.end(), n) ==
                             atoms.end()) {
-                            if (r->containsAtom(n))
+                            if (r->containsAtom(n)) {
                                 forceOutside = true;
+                            }
                             break;
                         }
                     }
@@ -885,8 +922,9 @@ CoordgenMacrocycleBuilder::getDoubleBondConstraints(
                 cerr << "bad input to get double bond constraints" << endl;
                 break;
             }
-            if (b->bondOrder != 2)
+            if (b->bondOrder != 2) {
                 continue;
+            }
             bool smallRingBond = false;
             if (b->rings.size() > 1) {
                 for (auto& ring : b->rings) {
@@ -896,8 +934,9 @@ CoordgenMacrocycleBuilder::getDoubleBondConstraints(
                     }
                 }
             }
-            if (smallRingBond)
+            if (smallRingBond) {
                 continue;
+            }
             int previousI =
                 static_cast<int>((i + atoms.size() - 1) % atoms.size());
             int followingI = (i + 2) % atoms.size();
@@ -945,8 +984,9 @@ int CoordgenMacrocycleBuilder::getNumberOfChildren(
         visited[thisA] = true;
         n++;
         for (auto n : thisA->neighbors) {
-            if (visited[n])
+            if (visited[n]) {
                 continue;
+            }
             q.push(n);
         }
     }
@@ -960,18 +1000,21 @@ pathRestraints CoordgenMacrocycleBuilder::getPathRestraints(
     vector<int> heteroAtoms;
     vector<pair<int, int>> substitutedAtoms;
     for (unsigned int i = 0; i < atoms.size(); i++) {
-        if (atoms[i]->atomicNumber != 6)
+        if (atoms[i]->atomicNumber != 6) {
             heteroAtoms.push_back(i);
+        }
         if (atoms[i]->neighbors.size() != 2) {
             int totN = 0;
             int prevI = static_cast<int>((i + atoms.size() - 1) % atoms.size());
             int postI = (i + 1) % atoms.size();
             for (unsigned int j = 0; j < atoms[i]->neighbors.size(); j++) {
                 sketcherMinimizerAtom* n = atoms[i]->neighbors[j];
-                if (n == atoms[prevI])
+                if (n == atoms[prevI]) {
                     continue;
-                if (n == atoms[postI])
+                }
+                if (n == atoms[postI]) {
                     continue;
+                }
                 totN += getNumberOfChildren(n, atoms[i]);
             }
             substitutedAtoms.emplace_back(i, totN);
@@ -992,12 +1035,14 @@ bool CoordgenMacrocycleBuilder::checkDoubleBoundConstraints(
         counter = (startI + dbConstraint.atom1) % vertices.size();
         sketcherMinimizerPointF p2 = coordsOfVertex(vertices[counter]);
         counter = startI + dbConstraint.atom2;
-        if (counter >= vertices.size())
+        if (counter >= vertices.size()) {
             counter -= vertices.size();
+        }
         sketcherMinimizerPointF p3 = coordsOfVertex(vertices[counter]);
         counter = startI + dbConstraint.followingAtom;
-        if (counter >= vertices.size())
+        if (counter >= vertices.size()) {
             counter -= vertices.size();
+        }
         sketcherMinimizerPointF p4 = coordsOfVertex(vertices[counter]);
         if (sketcherMinimizerMaths::sameSide(p1, p4, p2, p3) ==
             dbConstraint.trans) {
@@ -1013,8 +1058,9 @@ int CoordgenMacrocycleBuilder::scorePath(Polyomino& p,
                                          pathConstraints& pc,
                                          pathRestraints& pr) const
 {
-    if (!scorePathConstraints(pc, p, path, neighborNs, startI))
+    if (!scorePathConstraints(pc, p, path, neighborNs, startI)) {
         return PATH_FAILED;
+    }
     return scorePathRestraints(pr, p, path, neighborNs, startI);
 }
 
@@ -1028,8 +1074,9 @@ int CoordgenMacrocycleBuilder::scorePathRestraints(pathRestraints& pr,
     set<vertexCoords> usedSubstituentCoordinates;
     for (int heteroAtom : pr.heteroAtoms) {
         int counter = (heteroAtom + startI) % neighborNs.size();
-        if (neighborNs[counter] == 1)
+        if (neighborNs[counter] == 1) {
             score -= HETEROATOM_RESTRAINT; // heteroatom placed towards outside
+        }
     }
     for (unsigned int i = 0; i < pr.substitutedAtoms.size(); i++) {
         int counter =
@@ -1041,8 +1088,9 @@ int CoordgenMacrocycleBuilder::scorePathRestraints(pathRestraints& pr,
             vertexCoords substituentsCoordinates =
                 p.coordinatesOfSubstituent(path[i]);
             if (usedSubstituentCoordinates.find(substituentsCoordinates) !=
-                usedSubstituentCoordinates.end())
+                usedSubstituentCoordinates.end()) {
                 score -= SUBSTITUENTS_TO_SAME_VERTEX_RESTRAINT;
+            }
             if (find(path.begin(), path.end(), substituentsCoordinates) !=
                 path.end()) {
                 // substituent would clash with path
@@ -1061,10 +1109,13 @@ bool CoordgenMacrocycleBuilder::scorePathConstraints(pathConstraints& pc,
                                                      int& startI) const
 {
 
-    if (!checkRingConstraints(pc.ringConstraints, p, path, neighborNs, startI))
+    if (!checkRingConstraints(pc.ringConstraints, p, path, neighborNs,
+                              startI)) {
         return false;
-    if (!checkDoubleBoundConstraints(pc.doubleBonds, path, startI))
+    }
+    if (!checkDoubleBoundConstraints(pc.doubleBonds, path, startI)) {
         return false;
+    }
     return true;
 }
 
@@ -1128,8 +1179,9 @@ int CoordgenMacrocycleBuilder::getLowestPeriod(
                 break;
             }
         }
-        if (!hasDifference)
+        if (!hasDifference) {
             return period;
+        }
     }
     return static_cast<int>(neighbors.size());
 }
@@ -1153,12 +1205,14 @@ bool CoordgenMacrocycleBuilder::matchPolyominoes(vector<Polyomino>& pols,
                 bestScore = bestScoreOfThis;
                 bestStart = bestStartOfThis;
                 bestP = i;
-                if (bestScore == 0)
+                if (bestScore == 0) {
                     return true;
+                }
             }
         }
-        if (checkedMacrocycles++ > MAX_MACROCYCLES)
+        if (checkedMacrocycles++ > MAX_MACROCYCLES) {
             break;
+        }
     }
     return matched;
 }
@@ -1285,8 +1339,9 @@ CoordgenMacrocycleBuilder::buildSquaredShapes(int totVertices) const
                            // shapes to be evaluated first (they have more space
                            // inside and less risk of substituents clashes
             int i2 = xandy - i;
-            if (i < 2 || i2 < 2)
+            if (i < 2 || i2 < 2) {
                 continue;
+            }
             {
                 Polyomino p;
                 p.buildRaggedBoxShape(i, i2, pentagon);

--- a/CoordgenMacrocycleBuilder.cpp
+++ b/CoordgenMacrocycleBuilder.cpp
@@ -44,8 +44,8 @@ Polyomino::Polyomino(const Polyomino& rhs)
     clear();
     pentagonVertices = rhs.pentagonVertices;
     resizeGrid(1);
-    for (unsigned int i = 0; i < rhs.m_list.size(); i++) {
-        addHex(rhs.m_list[i]->coords());
+    for (auto i : rhs.m_list) {
+        addHex(i->coords());
     }
     reassignHexs();
 }
@@ -55,8 +55,8 @@ Polyomino& Polyomino::operator=(const Polyomino& rhs)
     clear();
     resizeGrid(1);
     pentagonVertices = rhs.pentagonVertices;
-    for (unsigned int i = 0; i < rhs.m_list.size(); i++) {
-        addHex(rhs.m_list[i]->coords());
+    for (auto i : rhs.m_list) {
+        addHex(i->coords());
     }
     reassignHexs();
     return *this;
@@ -69,8 +69,8 @@ Polyomino::~Polyomino()
 
 void Polyomino::clear()
 {
-    for (unsigned int i = 0; i < m_list.size(); i++) {
-        delete m_list[i];
+    for (auto& i : m_list) {
+        delete i;
     }
     m_list.clear();
 }
@@ -90,12 +90,10 @@ void Polyomino::resizeGrid(int i) const
 
 void Polyomino::reassignHexs() const
 {
-    for (unsigned int j = 0; j < m_grid.size(); j++) {
-        m_grid[j] = NULL;
+    for (auto& j : m_grid) {
+        j = nullptr;
     }
-    for (unsigned int i = 0; i < m_list.size(); i++) {
-        Hex* hex = m_list[i];
-
+    for (auto hex : m_list) {
         m_grid[getIndexInList(hex->coords())] = hex;
     }
 }
@@ -134,16 +132,15 @@ bool Polyomino::isTheSameAs(Polyomino& p) const
             }
         }
         // translate
-        for (unsigned int j = 0; j < targetCoords.size(); j++) {
-            targetCoords[j] =
-                hexCoords(targetCoords[j].x + lowestx - lowestTargetX,
-                          targetCoords[j].y + lowesty - lowestTargetY);
+        for (auto& targetCoord : targetCoords) {
+            targetCoord = hexCoords(targetCoord.x + lowestx - lowestTargetX,
+                                    targetCoord.y + lowesty - lowestTargetY);
         }
         // check
 
         bool same = true;
-        for (unsigned int j = 0; j < targetCoords.size(); j++) {
-            if (!getHex(targetCoords[j])) {
+        for (auto targetCoord : targetCoords) {
+            if (!getHex(targetCoord)) {
                 same = false;
                 break;
             }
@@ -152,8 +149,8 @@ bool Polyomino::isTheSameAs(Polyomino& p) const
             return true;
         }
         // rotate
-        for (unsigned int j = 0; j < targetCoords.size(); j++) {
-            targetCoords[j] = targetCoords[j].rotate30Degrees();
+        for (auto& targetCoord : targetCoords) {
+            targetCoord = targetCoord.rotate30Degrees();
         }
     }
     return false;
@@ -340,13 +337,13 @@ vector<hexCoords> Polyomino::freeVertexNeighborPositions(vertexCoords v) const
     }
     Hex* h = getHex(hexCoords(v.x - direction, v.y));
     if (!h)
-        out.push_back(hexCoords(v.x - direction, v.y));
+        out.emplace_back(v.x - direction, v.y);
     h = getHex(hexCoords(v.x, v.y - direction));
     if (!h)
-        out.push_back(hexCoords(v.x, v.y - direction));
+        out.emplace_back(v.x, v.y - direction);
     h = getHex(hexCoords(v.x, v.y)); // z - direction
     if (!h)
-        out.push_back(hexCoords(v.x, v.y));
+        out.emplace_back(v.x, v.y);
     return out;
 }
 
@@ -375,23 +372,22 @@ vertexCoords Polyomino::findOuterVertex()
 {
     // find a hexagon with a free vertex in direction (1, 0, 0). Such a hexagon
     // is guarateed to exist in a polyomino.
-    for (unsigned int i = 0; i < m_list.size(); i++) {
-        Hex* h = m_list[i];
+    for (auto h : m_list) {
         vertexCoords vert(h->x() + 1, h->y(), h->z());
         if (hexagonsAtVertex(vert) == 1) {
             return vert;
         }
     }
     cerr << "something went wrong in finding the outer vertex" << endl;
-    return vertexCoords(0, 0, 0);
+    return {0, 0, 0};
 }
 
 int Polyomino::countNeighbors(hexCoords h) const
 {
     int out = 0;
     vector<hexCoords> neighs = Hex::neighboringPositions(h);
-    for (unsigned int i = 0; i < neighs.size(); i++) {
-        if (getHex(neighs[i]) != NULL)
+    for (auto neigh : neighs) {
+        if (getHex(neigh) != nullptr)
             out++;
     }
     return out;
@@ -399,26 +395,26 @@ int Polyomino::countNeighbors(hexCoords h) const
 
 std::vector<hexCoords> Polyomino::allFreeNeighbors() const
 {
-    for (unsigned int i = 0; i < m_list.size();
-         i++) { // make sure that the grid is big enough to store every neighbor
-        getIndexInList(hexCoords(m_list[i]->x() + 1, m_list[i]->y() + 1));
-        getIndexInList(hexCoords(m_list[i]->x() - 1, m_list[i]->y() - 1));
+    for (auto i : m_list) { // make sure that the grid is big enough to store
+                            // every neighbor
+        getIndexInList(hexCoords(i->x() + 1, i->y() + 1));
+        getIndexInList(hexCoords(i->x() - 1, i->y() - 1));
     }
     std::vector<hexCoords> out;
     std::vector<bool> visited(
         m_grid.size(),
         false); // keep track if a neighbors has already been checked or not
-    for (unsigned int i = 0; i < m_list.size(); i++) {
-        std::vector<hexCoords> neighborsCoords = m_list[i]->neighbors();
-        for (unsigned int j = 0; j < neighborsCoords.size(); j++) {
-            bool isPresent = (getHex(neighborsCoords[j]) != NULL);
+    for (auto i : m_list) {
+        std::vector<hexCoords> neighborsCoords = i->neighbors();
+        for (auto neighborsCoord : neighborsCoords) {
+            bool isPresent = (getHex(neighborsCoord) != nullptr);
             if (isPresent)
                 continue;
-            int index = getIndexInList(neighborsCoords[j]);
+            int index = getIndexInList(neighborsCoord);
             if (visited[index])
                 continue;
             visited[index] = true;
-            out.push_back(neighborsCoords[j]);
+            out.push_back(neighborsCoord);
         }
     }
     return out;
@@ -461,7 +457,7 @@ void Polyomino::removeHex(hexCoords coords)
         }
     }
     delete hex;
-    m_grid[index] = NULL;
+    m_grid[index] = nullptr;
 }
 
 bool Polyomino::isEquivalentWithout(hexCoords c) const
@@ -474,8 +470,8 @@ bool Polyomino::isEquivalentWithout(hexCoords c) const
     for (unsigned int i = 0; i < neighs.size(); i++) {
         int i2 = (i - 1 + 6) % 6;
         int i3 = (i - 2 + 6) % 6;
-        if (getHex(neighs[i]) != NULL && getHex(neighs[i2]) != NULL &&
-            getHex(neighs[i3]) != NULL)
+        if (getHex(neighs[i]) != nullptr && getHex(neighs[i2]) != nullptr &&
+            getHex(neighs[i3]) != nullptr)
             return true;
     }
     return false;
@@ -513,10 +509,8 @@ vertexCoords Polyomino::coordinatesOfSubstituent(const vertexCoords pos) const
          neighbor we are looking for
          */
         vertexCoords parent1Coords = neighbors[0]->coords().toVertexCoords();
-        ;
         vertexCoords v = pos - parent1Coords;
         vertexCoords parent2Coords = neighbors[1]->coords().toVertexCoords();
-        ;
         out = parent2Coords - v;
     }
     return out;
@@ -534,8 +528,8 @@ vector<vertexCoords> Polyomino::getPath() const
     do {
         bool skip = false;
         if (pentagonVertices.size()) {
-            for (unsigned int j = 0; j < pentagonVertices.size(); j++) {
-                if (pentagonVertices[j] == currentVertex) {
+            for (auto pentagonVertice : pentagonVertices) {
+                if (pentagonVertice == currentVertex) {
                     skip = true;
                     break;
                 }
@@ -564,12 +558,12 @@ vector<hexCoords> Hex::neighboringPositions(hexCoords h)
     int xx = h.x;
     int yy = h.y;
     vector<hexCoords> out;
-    out.push_back(hexCoords(xx + 1, yy)); // z-1
-    out.push_back(hexCoords(xx + 1, yy - 1));
-    out.push_back(hexCoords(xx, yy - 1)); // z+1
-    out.push_back(hexCoords(xx - 1, yy)); // z+1
-    out.push_back(hexCoords(xx - 1, yy + 1));
-    out.push_back(hexCoords(xx, yy + 1)); // z-1
+    out.emplace_back(xx + 1, yy); // z-1
+    out.emplace_back(xx + 1, yy - 1);
+    out.emplace_back(xx, yy - 1); // z+1
+    out.emplace_back(xx - 1, yy); // z+1
+    out.emplace_back(xx - 1, yy + 1);
+    out.emplace_back(xx, yy + 1); // z-1
     return out;
 }
 
@@ -600,7 +594,7 @@ vertexCoords Hex::followingVertex(vertexCoords v) const
     } else {
         cerr << "wrong input to transform to following vertex" << endl;
     }
-    return vertexCoords(x() + dx, y() + dy, z() + dz);
+    return {x() + dx, y() + dy, z() + dz};
 }
 
 float CoordgenMacrocycleBuilder::getPrecision() const
@@ -692,7 +686,7 @@ vector<sketcherMinimizerPointF> CoordgenMacrocycleBuilder::newMacrocycle(
 sketcherMinimizerBond*
 CoordgenMacrocycleBuilder::findBondToOpen(sketcherMinimizerRing* ring) const
 {
-    sketcherMinimizerBond* bestBond = NULL;
+    sketcherMinimizerBond* bestBond = nullptr;
     size_t bestScore = 0;
     foreach (sketcherMinimizerBond* bond, ring->_bonds) {
         size_t score = 0;
@@ -719,7 +713,7 @@ CoordgenMacrocycleBuilder::findBondToOpen(sketcherMinimizerRing* ring) const
         score += bond->rings.size() * 10;
         score += bond->getStartAtom()->neighbors.size();
         score += bond->getEndAtom()->neighbors.size();
-        if (bestBond == NULL || score < bestScore) {
+        if (bestBond == nullptr || score < bestScore) {
             bestScore = score;
             bestBond = bond;
         }
@@ -735,7 +729,7 @@ bool CoordgenMacrocycleBuilder::openCycleAndGenerateCoords(
     sketcherMinimizer min(getPrecision());
     min.m_minimizer.skipMinimization = true;
     min.m_fragmentBuilder.setForceOpenMacrocycles(true);
-    sketcherMinimizerMolecule* minMol = new sketcherMinimizerMolecule;
+    auto* minMol = new sketcherMinimizerMolecule;
     sketcherMinimizerBond* bondToBreak = findBondToOpen(ring);
     if (!bondToBreak)
         return false;
@@ -745,7 +739,7 @@ bool CoordgenMacrocycleBuilder::openCycleAndGenerateCoords(
     foreach (sketcherMinimizerAtom* at, atoms) {
         if (at->isResidue())
             continue;
-        sketcherMinimizerAtom* new_at = new sketcherMinimizerAtom;
+        auto* new_at = new sketcherMinimizerAtom;
         atomMap[at] = new_at;
         new_at->templateCoordinates = at->coordinates;
         new_at->coordinates = at->coordinates;
@@ -762,7 +756,7 @@ bool CoordgenMacrocycleBuilder::openCycleAndGenerateCoords(
     foreach (sketcherMinimizerBond* bo, bonds) {
         if (bo == bondToBreak || bo->isResidueInteraction())
             continue;
-        sketcherMinimizerBond* new_bo = new sketcherMinimizerBond;
+        auto* new_bo = new sketcherMinimizerBond;
         new_bo->bondOrder = bo->bondOrder;
         new_bo->startAtom = atomMap[bo->startAtom];
         new_bo->endAtom = atomMap[bo->endAtom];
@@ -773,7 +767,7 @@ bool CoordgenMacrocycleBuilder::openCycleAndGenerateCoords(
     min.initialize(minMol);
     min.findFragments();
     min.m_minimizer.buildFromFragments(true);
-    sketcherMinimizerBond* brokenBond = new sketcherMinimizerBond;
+    auto* brokenBond = new sketcherMinimizerBond;
     brokenBond->bondOrder = bondToBreak->bondOrder;
     brokenBond->startAtom = atomMap[bondToBreak->startAtom];
     brokenBond->endAtom = atomMap[bondToBreak->endAtom];
@@ -808,8 +802,8 @@ vector<Polyomino>
 CoordgenMacrocycleBuilder::listOfEquivalents(const vector<Polyomino>& l) const
 {
     vector<Polyomino> out;
-    for (unsigned int i = 0; i < l.size(); i++) {
-        vector<Polyomino> newV = listOfEquivalent(l[i]);
+    for (const auto& i : l) {
+        vector<Polyomino> newV = listOfEquivalent(i);
         out.reserve(out.size() + newV.size());
         out.insert(out.end(), newV.begin(), newV.end());
     }
@@ -823,8 +817,8 @@ vector<Polyomino> CoordgenMacrocycleBuilder::listOfEquivalent(
     vector<Polyomino> out;
     vector<Hex*> l = p.m_list;
     size_t pentagonVs = p.pentagonVertices.size();
-    for (unsigned int i = 0; i < l.size(); i++) {
-        hexCoords c = l[i]->coords();
+    for (auto& i : l) {
+        hexCoords c = i->coords();
         if (p.isEquivalentWithout(c)) {
             Polyomino newP = p;
             newP.pentagonVertices.clear();
@@ -860,8 +854,7 @@ vector<ringConstraint> CoordgenMacrocycleBuilder::getRingConstraints(
                                                      // current cycle and all
                                                      // fused macrocycles
                     bool forceOutside = false;
-                    for (unsigned int jj = 0; jj < a->neighbors.size(); jj++) {
-                        sketcherMinimizerAtom* n = a->neighbors[jj];
+                    for (auto n : a->neighbors) {
                         if (find(atoms.begin(), atoms.end(), n) ==
                             atoms.end()) {
                             if (r->containsAtom(n))
@@ -869,7 +862,7 @@ vector<ringConstraint> CoordgenMacrocycleBuilder::getRingConstraints(
                             break;
                         }
                     }
-                    out.push_back(ringConstraint(i, r, forceOutside));
+                    out.emplace_back(i, r, forceOutside);
                 }
             }
         }
@@ -896,8 +889,8 @@ CoordgenMacrocycleBuilder::getDoubleBondConstraints(
                 continue;
             bool smallRingBond = false;
             if (b->rings.size() > 1) {
-                for (unsigned int r = 0; r < b->rings.size(); r++) {
-                    if (b->rings[r]->_atoms.size() < MACROCYCLE) {
+                for (auto& ring : b->rings) {
+                    if (ring->_atoms.size() < MACROCYCLE) {
                         smallRingBond = true;
                         break;
                     }
@@ -951,8 +944,7 @@ int CoordgenMacrocycleBuilder::getNumberOfChildren(
         q.pop();
         visited[thisA] = true;
         n++;
-        for (unsigned int i = 0; i < thisA->neighbors.size(); i++) {
-            sketcherMinimizerAtom* n = thisA->neighbors[i];
+        for (auto n : thisA->neighbors) {
             if (visited[n])
                 continue;
             q.push(n);
@@ -982,7 +974,7 @@ pathRestraints CoordgenMacrocycleBuilder::getPathRestraints(
                     continue;
                 totN += getNumberOfChildren(n, atoms[i]);
             }
-            substitutedAtoms.push_back(pair<int, int>(i, totN));
+            substitutedAtoms.emplace_back(i, totN);
         }
     }
     pr.heteroAtoms = heteroAtoms;
@@ -994,22 +986,21 @@ bool CoordgenMacrocycleBuilder::checkDoubleBoundConstraints(
     vector<doubleBondConstraint>& dbConstraints, vector<vertexCoords>& vertices,
     int& startI) const
 {
-    for (unsigned int i = 0; i < dbConstraints.size(); i++) {
-        size_t counter =
-            (startI + dbConstraints[i].previousAtom) % vertices.size();
+    for (auto& dbConstraint : dbConstraints) {
+        size_t counter = (startI + dbConstraint.previousAtom) % vertices.size();
         sketcherMinimizerPointF p1 = coordsOfVertex(vertices[counter]);
-        counter = (startI + dbConstraints[i].atom1) % vertices.size();
+        counter = (startI + dbConstraint.atom1) % vertices.size();
         sketcherMinimizerPointF p2 = coordsOfVertex(vertices[counter]);
-        counter = startI + dbConstraints[i].atom2;
+        counter = startI + dbConstraint.atom2;
         if (counter >= vertices.size())
             counter -= vertices.size();
         sketcherMinimizerPointF p3 = coordsOfVertex(vertices[counter]);
-        counter = startI + dbConstraints[i].followingAtom;
+        counter = startI + dbConstraint.followingAtom;
         if (counter >= vertices.size())
             counter -= vertices.size();
         sketcherMinimizerPointF p4 = coordsOfVertex(vertices[counter]);
         if (sketcherMinimizerMaths::sameSide(p1, p4, p2, p3) ==
-            dbConstraints[i].trans) {
+            dbConstraint.trans) {
             return false;
         }
     }
@@ -1035,8 +1026,8 @@ int CoordgenMacrocycleBuilder::scorePathRestraints(pathRestraints& pr,
 {
     int score = 0;
     set<vertexCoords> usedSubstituentCoordinates;
-    for (unsigned int i = 0; i < pr.heteroAtoms.size(); i++) {
-        int counter = (pr.heteroAtoms[i] + startI) % neighborNs.size();
+    for (int heteroAtom : pr.heteroAtoms) {
+        int counter = (heteroAtom + startI) % neighborNs.size();
         if (neighborNs[counter] == 1)
             score -= HETEROATOM_RESTRAINT; // heteroatom placed towards outside
     }
@@ -1084,22 +1075,21 @@ bool CoordgenMacrocycleBuilder::checkRingConstraints(
                        // ring map to the same hexagon
 {
     std::map<sketcherMinimizerRing*, vector<hexCoords>> allowedHexs;
-    for (unsigned int i = 0; i < ringConstraints.size(); i++) {
-        unsigned int counter = (ringConstraints[i].atom + startI) % path.size();
-        if (ringConstraints[i].forceOutside) {
+    for (auto& ringConstraint : ringConstraints) {
+        unsigned int counter = (ringConstraint.atom + startI) % path.size();
+        if (ringConstraint.forceOutside) {
             if (neighborNs[counter] != 1) {
                 return false;
             }
         }
-        sketcherMinimizerRing* r = ringConstraints[i].ring;
+        sketcherMinimizerRing* r = ringConstraint.ring;
         vector<hexCoords> newPos = p.freeVertexNeighborPositions(path[counter]);
         vector<hexCoords> oldPos = allowedHexs[r];
         vector<hexCoords> nextPos;
         if (!oldPos.size()) {
             nextPos = newPos;
         } else {
-            for (unsigned int pp = 0; pp < newPos.size(); pp++) {
-                hexCoords toCheck = newPos[pp];
+            for (auto toCheck : newPos) {
                 if (find(oldPos.begin(), oldPos.end(), toCheck) !=
                     oldPos.end()) {
                     // hexCoords was already marked as allowed and is now
@@ -1120,8 +1110,8 @@ CoordgenMacrocycleBuilder::getVertexNeighborNs(Polyomino& p,
                                                vector<vertexCoords>& path) const
 {
     vector<int> out;
-    for (unsigned int i = 0; i < path.size(); i++) {
-        out.push_back(static_cast<int>(p.hexagonsAtVertex(path[i])));
+    for (auto i : path) {
+        out.push_back(static_cast<int>(p.hexagonsAtVertex(i)));
     }
     return out;
 }
@@ -1231,16 +1221,16 @@ CoordgenMacrocycleBuilder::removeDuplicates(vector<Polyomino>& pols) const
     // for performance
 
     vector<Polyomino> out;
-    for (unsigned int i = 0; i < pols.size(); i++) {
+    for (auto& pol : pols) {
         bool duplicate = false;
-        for (unsigned int j = 0; j < out.size(); j++) {
-            if (pols[i].isTheSameAs(out[j])) {
+        for (auto& j : out) {
+            if (pol.isTheSameAs(j)) {
                 duplicate = true;
                 break;
             }
         }
         if (!duplicate) {
-            out.push_back(pols[i]);
+            out.push_back(pol);
         }
     }
     return out;

--- a/CoordgenMacrocycleBuilder.h
+++ b/CoordgenMacrocycleBuilder.h
@@ -36,22 +36,28 @@ struct ringConstraint {
 struct vertexCoords {
     bool operator!=(const vertexCoords& rhs) const
     {
-        if (x != rhs.x)
+        if (x != rhs.x) {
             return true;
-        if (y != rhs.y)
+        }
+        if (y != rhs.y) {
             return true;
-        if (z != rhs.z)
+        }
+        if (z != rhs.z) {
             return true;
+        }
         return false;
     }
     bool operator<(const vertexCoords& rhs) const
     {
-        if (x < rhs.x)
+        if (x < rhs.x) {
             return true;
-        if (y < rhs.y)
+        }
+        if (y < rhs.y) {
             return true;
-        if (z < rhs.z)
+        }
+        if (z < rhs.z) {
             return true;
+        }
         return false;
     }
     friend const vertexCoords operator+(const vertexCoords& v1,
@@ -67,8 +73,9 @@ struct vertexCoords {
 
     bool operator==(const vertexCoords& rhs) const
     {
-        if (x == rhs.x && y == rhs.y && z == rhs.z)
+        if (x == rhs.x && y == rhs.y && z == rhs.z) {
             return true;
+        }
         return false;
     }
 
@@ -103,8 +110,9 @@ struct hexCoords {
     }
     bool operator==(const hexCoords& rhs) const
     {
-        if (x == rhs.x && y == rhs.y)
+        if (x == rhs.x && y == rhs.y) {
             return true;
+        }
         return false;
     }
     int x, y;

--- a/CoordgenMacrocycleBuilder.h
+++ b/CoordgenMacrocycleBuilder.h
@@ -119,9 +119,9 @@ struct hexCoords {
     hexCoords rotate30Degrees()
     {
         int z = -x - y;
-        return hexCoords(-z, -x);
+        return {-z, -x};
     }
-    vertexCoords toVertexCoords() const { return vertexCoords(x, y, -x - y); }
+    vertexCoords toVertexCoords() const { return {x, y, -x - y}; }
 
   private:
     friend std::ostream& operator<<(std::ostream& os, const hexCoords& h);
@@ -133,8 +133,8 @@ struct hexCoords {
 struct Hex {
     Hex(hexCoords coords) : m_coords(coords) {}
     void setCoords(hexCoords coords) { m_coords = coords; }
-    int x() const { return m_coords.x; };
-    int y() const { return m_coords.y; };
+    int x() const { return m_coords.x; }
+    int y() const { return m_coords.y; }
     int z() const { return -x() - y(); }
     hexCoords coords() const { return m_coords; }
     hexCoords m_coords;
@@ -277,8 +277,8 @@ class EXPORT_COORDGEN Polyomino
 class EXPORT_COORDGEN CoordgenMacrocycleBuilder
 {
   public:
-    CoordgenMacrocycleBuilder() : m_forceOpenMacrocycles(false){};
-    ~CoordgenMacrocycleBuilder(){};
+    CoordgenMacrocycleBuilder() = default;
+    ~CoordgenMacrocycleBuilder() = default;
 
     /* assign coordinates to macrocycle */
     std::vector<sketcherMinimizerPointF>
@@ -299,7 +299,7 @@ class EXPORT_COORDGEN CoordgenMacrocycleBuilder
 
     /* Skip the polyomino approach and fall back to opening the macrocycle when
      * generating coordinates */
-    bool m_forceOpenMacrocycles;
+    bool m_forceOpenMacrocycles = false;
 
     float getPrecision() const;
 

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -64,15 +64,18 @@ void CoordgenMinimizer::clearInteractions()
 
 void CoordgenMinimizer::run()
 {
-    if (skipMinimization)
+    if (skipMinimization) {
         return;
-    if (!_interactions.size())
+    }
+    if (!_interactions.size()) {
         setupInteractions();
+    }
 
     for (int iterations = 0; iterations < m_maxIterations; ++iterations) {
         scoreInteractions();
-        if (!applyForces())
+        if (!applyForces()) {
             break;
+        }
     }
     fixRingsShape();
 }
@@ -82,16 +85,19 @@ bool CoordgenMinimizer::applyForces(float maxd)
     float delta = 0.001f; // minimum squared displacement
     float distance = 0.f;
     for (auto atom : _atoms) {
-        if (atom->fixed)
+        if (atom->fixed) {
             continue;
+        }
         sketcherMinimizerPointF displacement = atom->force * FORCE_MULTIPLIER;
         if (displacement.x() != displacement.x() ||
-            displacement.y() != displacement.y())
+            displacement.y() != displacement.y()) {
             displacement = sketcherMinimizerPointF(0.f, 0.f);
+        }
         float dsquare = displacement.x() * displacement.x() +
                         displacement.y() * displacement.y();
-        if (dsquare < SKETCHER_EPSILON)
+        if (dsquare < SKETCHER_EPSILON) {
             dsquare = SKETCHER_EPSILON;
+        }
         if (dsquare > maxd * maxd) {
             displacement *= maxd / sqrt(dsquare);
         }
@@ -123,40 +129,50 @@ void CoordgenMinimizer::addClashInteractionsOfMolecule(
 
     if (atoms.size() > 1) {
         for (sketcherMinimizerAtom* atom : atoms) {
-            if (atom->isResidue())
+            if (atom->isResidue()) {
                 continue;
+            }
 
             for (sketcherMinimizerBond* bond : bonds) {
-                if (bond->isResidueInteraction())
+                if (bond->isResidueInteraction()) {
                     continue;
+                }
                 sketcherMinimizerAtom* at2 = atom;
                 sketcherMinimizerAtom* at1 = bond->startAtom;
                 sketcherMinimizerAtom* at3 = bond->endAtom;
-                if (at1 == at2 || at1 == at3 || at2 == at3)
+                if (at1 == at2 || at1 == at3 || at2 == at3) {
                     continue;
+                }
                 if (at1->fragment->getDofsOfAtom(at1).empty() &&
                     at2->fragment->getDofsOfAtom(at2).empty() &&
                     at3->fragment->getDofsOfAtom(at3).empty() &&
                     !intrafragmentClashes) {
-                    if (at1->fragment == at2->fragment)
+                    if (at1->fragment == at2->fragment) {
                         continue;
-                    if (at3->fragment == at2->fragment)
+                    }
+                    if (at3->fragment == at2->fragment) {
                         continue;
+                    }
                 }
-                if (at2->fixed && at1->fixed && at3->fixed)
+                if (at2->fixed && at1->fixed && at3->fixed) {
                     continue;
+                }
 
-                if (at1->isNeighborOf(at2))
+                if (at1->isNeighborOf(at2)) {
                     continue;
-                for (sketcherMinimizerAtom* n : at1->neighbors) {
-                    if (n->isNeighborOf(at2))
-                        continue;
                 }
-                if (at3->isNeighborOf(at2))
-                    continue;
-                for (sketcherMinimizerAtom* n : at3->neighbors) {
-                    if (n->isNeighborOf(at2))
+                for (sketcherMinimizerAtom* n : at1->neighbors) {
+                    if (n->isNeighborOf(at2)) {
                         continue;
+                    }
+                }
+                if (at3->isNeighborOf(at2)) {
+                    continue;
+                }
+                for (sketcherMinimizerAtom* n : at3->neighbors) {
+                    if (n->isNeighborOf(at2)) {
+                        continue;
+                    }
                 }
 
                 if (!(at1->rigid && at2->rigid && at3->rigid)) {
@@ -165,11 +181,13 @@ void CoordgenMinimizer::addClashInteractionsOfMolecule(
                     auto* interaction =
                         new sketcherMinimizerClashInteraction(at1, at2, at3);
                     float restVK = 0.8f;
-                    if (at2->atomicNumber == 6 && at2->charge == 0)
+                    if (at2->atomicNumber == 6 && at2->charge == 0) {
                         restVK -= 0.1f;
+                    }
                     if (at1->atomicNumber == 6 && at1->charge == 0 &&
-                        at3->atomicNumber == 6 && at3->charge == 0)
+                        at3->atomicNumber == 6 && at3->charge == 0) {
                         restVK -= 0.1f;
+                    }
 
                     interaction->restV =
                         (bondLength * restVK) * (bondLength * restVK);
@@ -186,8 +204,9 @@ void CoordgenMinimizer::addStretchInteractionsOfMolecule(
 {
     vector<sketcherMinimizerBond*> bonds = molecule->getBonds();
     foreach (sketcherMinimizerBond* bo, bonds) {
-        if (bo->isResidueInteraction())
+        if (bo->isResidueInteraction()) {
             continue;
+        }
         sketcherMinimizerAtom* at1 = bo->startAtom;
         sketcherMinimizerAtom* at2 = bo->endAtom;
         auto* interaction = new sketcherMinimizerStretchInteraction(at1, at2);
@@ -397,16 +416,19 @@ void CoordgenMinimizer::addBendInteractionsOfMolecule(
                 at->clockwiseOrderedNeighbors();
             float angle = 120.f;
             if (nbonds == 2) {
-                if (at->bonds[0]->bondOrder + at->bonds[1]->bondOrder > 3)
+                if (at->bonds[0]->bondOrder + at->bonds[1]->bondOrder > 3) {
                     angle = 180.f;
+                }
             }
-            if (nbonds > 2)
+            if (nbonds > 2) {
                 angle = 360.f / nbonds;
+            }
             for (int i = 0; i < nbonds; i++) {
                 int j = (i - 1 + nbonds) % nbonds;
-                if (nbonds == 2 && i == 1)
+                if (nbonds == 2 && i == 1) {
                     continue; // first and last interaction are the same if
-                              // there is just one interaction
+                }
+                // there is just one interaction
                 sketcherMinimizerAtom* at1 = orderedNeighs[i];
                 sketcherMinimizerAtom* at2 = at;
                 sketcherMinimizerAtom* at3 = orderedNeighs[j];
@@ -422,8 +444,9 @@ void CoordgenMinimizer::addBendInteractionsOfMolecule(
                         /* if the rings are to be drawn as fused, they will
                          * result in a bigger ring */
                         for (unsigned int i = 0; i < r->fusedWith.size(); i++) {
-                            if (r->fusedWith[i]->isMacrocycle())
+                            if (r->fusedWith[i]->isMacrocycle()) {
                                 continue;
+                            }
                             if (r->fusionAtoms[i].size() > 2) {
                                 extraAtoms += static_cast<int>(
                                     r->fusedWith[i]->_atoms.size() -
@@ -667,14 +690,16 @@ bool CoordgenMinimizer::findIntermolecularClashes(
 {
     // could be made faster for instance checking the molecules bounding boxes
     // first
-    if (mol1 == mol2)
+    if (mol1 == mol2) {
         return false;
+    }
     float threshold2 = threshold * threshold;
     foreach (sketcherMinimizerAtom* a, mol1->_atoms) {
         foreach (sketcherMinimizerAtom* a2, mol2->_atoms) {
             if (sketcherMinimizerMaths::squaredDistance(
-                    a->coordinates, a2->coordinates) < threshold2)
+                    a->coordinates, a2->coordinates) < threshold2) {
                 return true;
+            }
         }
     }
 
@@ -682,24 +707,27 @@ bool CoordgenMinimizer::findIntermolecularClashes(
         foreach (sketcherMinimizerBond* b, mol2->_bonds) {
             if (sketcherMinimizerMaths::squaredDistancePointSegment(
                     a->coordinates, b->startAtom->coordinates,
-                    b->endAtom->coordinates) < threshold2)
+                    b->endAtom->coordinates) < threshold2) {
                 return true;
+            }
         }
     }
     foreach (sketcherMinimizerAtom* a, mol2->_atoms) {
         foreach (sketcherMinimizerBond* b, mol1->_bonds) {
             if (sketcherMinimizerMaths::squaredDistancePointSegment(
                     a->coordinates, b->startAtom->coordinates,
-                    b->endAtom->coordinates) < threshold2)
+                    b->endAtom->coordinates) < threshold2) {
                 return true;
+            }
         }
     }
     foreach (sketcherMinimizerBond* b, mol1->_bonds) {
         foreach (sketcherMinimizerBond* b2, mol2->_bonds) {
             if (sketcherMinimizerMaths::intersectionOfSegments(
                     b->startAtom->coordinates, b->endAtom->coordinates,
-                    b2->startAtom->coordinates, b2->endAtom->coordinates))
+                    b2->startAtom->coordinates, b2->endAtom->coordinates)) {
                 return true;
+            }
         }
     }
 
@@ -711,8 +739,9 @@ bool CoordgenMinimizer::findIntermolecularClashes(
 {
     for (unsigned int i = 0; i < mols.size(); i++) {
         for (unsigned int j = i + 1; j < mols.size(); j++) {
-            if (findIntermolecularClashes(mols[i], mols[j], threshold))
+            if (findIntermolecularClashes(mols[i], mols[j], threshold)) {
                 return true;
+            }
         }
     }
     return false;
@@ -733,8 +762,9 @@ void CoordgenMinimizer::fixRingsShape()
 
     for (int iterations = 0; iterations < m_maxIterations; ++iterations) {
         scoreInteractions();
-        if (!applyForces(1))
+        if (!applyForces(1)) {
             break;
+        }
     }
 }
 
@@ -752,8 +782,9 @@ float CoordgenMinimizer::scoreClashes(
     E += scoreDofs(molecule);
     E += scoreCrossBonds(molecule, residueInteractions);
     E += scoreAtomsInsideRings();
-    if (scoreProximityRelationsOnOppositeSid)
+    if (scoreProximityRelationsOnOppositeSid) {
         E += scoreProximityRelationsOnOppositeSides();
+    }
     return E;
 }
 
@@ -771,8 +802,9 @@ float CoordgenMinimizer::scoreDofs(sketcherMinimizerMolecule* molecule) const
 float CoordgenMinimizer::scoreCrossBonds(sketcherMinimizerMolecule* molecule,
                                          bool residueInteractions) const
 {
-    if (m_scoreResidueInteractions == false)
+    if (m_scoreResidueInteractions == false) {
         residueInteractions = false;
+    }
 
     float out = 0.f;
     vector<sketcherMinimizerBond*> bonds = molecule->getBonds();
@@ -780,14 +812,17 @@ float CoordgenMinimizer::scoreCrossBonds(sketcherMinimizerMolecule* molecule,
 
         for (unsigned int b = 0; b < bonds.size() - 1; b++) {
             sketcherMinimizerBond* b1 = bonds[b];
-            if (b1->isResidueInteraction())
+            if (b1->isResidueInteraction()) {
                 continue;
+            }
             for (unsigned int bb = b + 1; bb < bonds.size(); bb++) {
                 sketcherMinimizerBond* b2 = bonds[bb];
-                if (b2->isResidueInteraction())
+                if (b2->isResidueInteraction()) {
                     continue;
-                if (b2->startAtom->molecule != b1->startAtom->molecule)
+                }
+                if (b2->startAtom->molecule != b1->startAtom->molecule) {
                     continue;
+                }
                 if (bondsClash(b1, b2)) {
                     float penalty = STANDARD_CROSSING_BOND_PENALTY;
                     if (b1->isTerminal() || b2->isTerminal()) {
@@ -827,17 +862,21 @@ float CoordgenMinimizer::scoreCrossBonds(sketcherMinimizerMolecule* molecule,
 
                         for (auto b2 : _bonds) {
                             if (b2->startAtom ==
-                                r->residueInteractions[ri1]->endAtom)
+                                r->residueInteractions[ri1]->endAtom) {
                                 continue;
+                            }
                             if (b2->endAtom ==
-                                r->residueInteractions[ri1]->endAtom)
+                                r->residueInteractions[ri1]->endAtom) {
                                 continue;
+                            }
                             if (b2->startAtom ==
-                                r->residueInteractions[ri2]->endAtom)
+                                r->residueInteractions[ri2]->endAtom) {
                                 continue;
+                            }
                             if (b2->endAtom ==
-                                r->residueInteractions[ri2]->endAtom)
+                                r->residueInteractions[ri2]->endAtom) {
                                 continue;
+                            }
 
                             if (sketcherMinimizerMaths::intersectionOfSegments(
                                     a1->coordinates, a2->coordinates,
@@ -860,26 +899,34 @@ float CoordgenMinimizer::scoreAtomsInsideRings() const
     float cutOff = bondLength;
     foreach (sketcherMinimizerMolecule* m, _molecules) {
         foreach (sketcherMinimizerRing* r, m->_rings) {
-            if (r->_atoms.size() > MACROCYCLE)
+            if (r->_atoms.size() > MACROCYCLE) {
                 continue;
-            if (r->_atoms.size() < 3)
+            }
+            if (r->_atoms.size() < 3) {
                 continue;
+            }
             sketcherMinimizerPointF c = r->findCenter();
             foreach (sketcherMinimizerAtom* a, m->_atoms) {
-                if (a->fragment == r->_atoms[0]->fragment)
+                if (a->fragment == r->_atoms[0]->fragment) {
                     continue;
+                }
                 sketcherMinimizerPointF d = c - a->coordinates;
-                if (d.x() > cutOff)
+                if (d.x() > cutOff) {
                     continue;
-                if (d.y() > cutOff)
+                }
+                if (d.y() > cutOff) {
                     continue;
-                if (d.x() < -cutOff)
+                }
+                if (d.x() < -cutOff) {
                     continue;
-                if (d.y() < -cutOff)
+                }
+                if (d.y() < -cutOff) {
                     continue;
+                }
                 float sq = d.squareLength();
-                if (sq > cutOff * cutOff)
+                if (sq > cutOff * cutOff) {
                     continue;
+                }
                 float dist = d.length();
                 if (dist < cutOff) {
                     out += 50 + 100 * (1 - (dist / cutOff));
@@ -894,8 +941,9 @@ float CoordgenMinimizer::scoreProximityRelationsOnOppositeSides() const
 {
     float out = 0.f;
     foreach (sketcherMinimizerMolecule* m, _molecules) {
-        if (m->_atoms.size() < 2)
+        if (m->_atoms.size() < 2) {
             continue;
+        }
         for (unsigned int i = 0; i < m->m_proximityRelations.size(); i++) {
             sketcherMinimizerPointF v1, v2;
             sketcherMinimizerMolecule* otherMol1 = nullptr;
@@ -910,8 +958,9 @@ float CoordgenMinimizer::scoreProximityRelationsOnOppositeSides() const
                 v1 = pr1->endAtom->getSingleAdditionVector();
                 otherMol1 = pr1->startAtom->molecule;
             }
-            if (otherMol1 == m)
+            if (otherMol1 == m) {
                 continue;
+            }
 
             for (unsigned int j = i + 1; j < m->m_proximityRelations.size();
                  j++) {
@@ -919,21 +968,25 @@ float CoordgenMinimizer::scoreProximityRelationsOnOppositeSides() const
 
                 sketcherMinimizerBond* pr2 = m->m_proximityRelations[j];
                 if (pr2->startAtom->molecule == m) {
-                    if (pr2->startAtom->fragment == f1)
+                    if (pr2->startAtom->fragment == f1) {
                         continue;
+                    }
                     v2 = pr2->startAtom->getSingleAdditionVector();
                     otherMol2 = pr2->endAtom->molecule;
 
                 } else {
-                    if (pr2->endAtom->fragment == f1)
+                    if (pr2->endAtom->fragment == f1) {
                         continue;
+                    }
                     v2 = pr2->endAtom->getSingleAdditionVector();
                     otherMol2 = pr2->startAtom->molecule;
                 }
-                if (otherMol2 == m)
+                if (otherMol2 == m) {
                     continue;
-                if (otherMol1 != otherMol2)
+                }
+                if (otherMol1 != otherMol2) {
                     continue;
+                }
                 float angle = sketcherMinimizerMaths::unsignedAngle(
                     v1, sketcherMinimizerPointF(0.f, 0.f), v2);
                 if (angle > 90) {
@@ -968,8 +1021,9 @@ void CoordgenMinimizer::runExhaustiveSearchLevel(
     vector<CoordgenFragmentDOF*>& dofs, float& bestResult, bool& abort,
     CoordgenDOFSolutions& solutions)
 {
-    if (abort)
+    if (abort) {
         return;
+    }
     if (iterator == dofs.end()) {
         float result = solutions.scoreCurrentSolution();
         if (result < clashEnergyThreshold) {
@@ -1041,16 +1095,19 @@ bool CoordgenMinimizer::growSolutions(
     sort(bestSolutions.begin(), bestSolutions.end());
     growingSolutions.clear();
     int maxN = static_cast<int>(6 * getPrecision());
-    if (maxN < 1)
+    if (maxN < 1) {
         maxN = 1;
+    }
     int n = 0;
 
     for (auto solution : bestSolutions) {
-        if (n > maxN)
+        if (n > maxN) {
             break;
+        }
         for (auto dof : solutions.getAllDofs()) {
-            if (dof->tier() > currentTier)
+            if (dof->tier() > currentTier) {
                 continue;
+            }
             solutions.loadSolution(solution.second);
             for (int i = 1; i < dof->numberOfStates(); ++i) {
                 dof->changeState();
@@ -1059,11 +1116,13 @@ bool CoordgenMinimizer::growSolutions(
                 if (allScoredSolutions.find(newSolution) ==
                     allScoredSolutions.end()) {
                     float score = solutions.scoreCurrentSolution();
-                    if (score == REJECTED_SOLUTION_SCORE)
+                    if (score == REJECTED_SOLUTION_SCORE) {
                         return false;
+                    }
                     allScoredSolutions.insert(newSolution);
-                    if (score < bestScore)
+                    if (score < bestScore) {
                         bestScore = score;
+                    }
                     if (score < bestScoreForRun &&
                         score < REJECTED_SOLUTION_SCORE) {
                         growingSolutions[newSolution] = score;
@@ -1112,9 +1171,9 @@ bool CoordgenMinimizer::runLocalSearch(sketcherMinimizerMolecule* molecule,
             float lastResult = clashE;
             bool foundOptimalPosition = runExhaustiveSearch(
                 molecule, combinationOfDofs, clashE, solutions);
-            if (foundOptimalPosition)
+            if (foundOptimalPosition) {
                 return true;
-            else if (clashE < lastResult - SKETCHER_EPSILON) {
+            } else if (clashE < lastResult - SKETCHER_EPSILON) {
                 downhill = true;
             }
         }
@@ -1126,10 +1185,12 @@ bool CoordgenMinimizer::flipFragments(sketcherMinimizerMolecule* molecule,
                                       float& clashE)
 {
     float bestResult = clashE;
-    if (skipFlipFragments)
+    if (skipFlipFragments) {
         return true;
-    if (bestResult < clashEnergyThreshold)
+    }
+    if (bestResult < clashEnergyThreshold) {
         return true;
+    }
     vector<CoordgenFragmentDOF *> dofs, onlyFlipDofs;
     vector<sketcherMinimizerFragment*> fragments = molecule->getFragments();
     reverse(fragments.begin(), fragments.end());
@@ -1185,8 +1246,9 @@ bool CoordgenMinimizer::avoidClashesOfMolecule(
 bool CoordgenMinimizer::avoidClashes()
 {
     bool allCleanPoses = true;
-    if (skipAvoidClashes)
+    if (skipAvoidClashes) {
         return true;
+    }
     foreach (sketcherMinimizerMolecule* molecule, _molecules) {
         auto cleanPose = avoidClashesOfMolecule(molecule);
         allCleanPoses = allCleanPoses && cleanPose;
@@ -1200,34 +1262,46 @@ void CoordgenMinimizer::avoidInternalClashes(
     // avoid intraFragmentClashes
     vector<sketcherMinimizerAtom*> fragmentAtoms = fragment->getAtoms();
     foreach (sketcherMinimizerAtom* a, fragmentAtoms) {
-        if (a->neighbors.size() != 1)
+        if (a->neighbors.size() != 1) {
             continue;
-        if (a->needsCheckForClashes)
+        }
+        if (a->needsCheckForClashes) {
             continue;
-        if (a->fixed)
+        }
+        if (a->fixed) {
             continue;
-        if (!fragment->getDofsOfAtom(a).empty())
+        }
+        if (!fragment->getDofsOfAtom(a).empty()) {
             continue;
+        }
         foreach (sketcherMinimizerAtom* a2, fragmentAtoms) {
-            if (a == a2)
+            if (a == a2) {
                 continue;
-            if (!fragment->getDofsOfAtom(a2).empty())
+            }
+            if (!fragment->getDofsOfAtom(a2).empty()) {
                 continue;
-            if (sketcherMinimizer::getBond(a, a2))
+            }
+            if (sketcherMinimizer::getBond(a, a2)) {
                 continue;
+            }
             float dx = a2->coordinates.x() - a->coordinates.x();
-            if (dx > bondLength * 0.5f)
+            if (dx > bondLength * 0.5f) {
                 continue;
-            if (dx < -bondLength * 0.5f)
+            }
+            if (dx < -bondLength * 0.5f) {
                 continue;
+            }
             float dy = a2->coordinates.y() - a->coordinates.y();
-            if (dy > bondLength * 0.5f)
+            if (dy > bondLength * 0.5f) {
                 continue;
-            if (dy < -bondLength * 0.5f)
+            }
+            if (dy < -bondLength * 0.5f) {
                 continue;
+            }
             float squareD = dx * dx + dy * dy;
-            if (squareD > bondLength * 0.5f * bondLength * 0.5f)
+            if (squareD > bondLength * 0.5f * bondLength * 0.5f) {
                 continue;
+            }
 
             sketcherMinimizerPointF vec =
                 a->coordinates - a->neighbors[0]->coordinates;
@@ -1244,8 +1318,9 @@ void CoordgenMinimizer::avoidInternalClashes(
 bool CoordgenMinimizer::bondsClash(sketcherMinimizerBond* bond,
                                    sketcherMinimizerBond* bond2) const
 {
-    if (bond == bond2)
+    if (bond == bond2) {
         return false;
+    }
     if (bond->getStartAtom() == bond2->getStartAtom() ||
         bond->getStartAtom() == bond2->getEndAtom() ||
         bond->getEndAtom() == bond2->getStartAtom() ||
@@ -1288,24 +1363,29 @@ bool CoordgenMinimizer::bondsClash(sketcherMinimizerBond* bond,
 void CoordgenMinimizer::avoidTerminalClashes(
     sketcherMinimizerMolecule* molecule, float& clashE)
 {
-    if (clashE < 0.1)
+    if (clashE < 0.1) {
         return;
+    }
     for (auto bond : molecule->getBonds()) {
-        if (bond->isResidueInteraction())
+        if (bond->isResidueInteraction()) {
             continue;
-        if (!bond->isTerminal())
+        }
+        if (!bond->isTerminal()) {
             continue;
+        }
         sketcherMinimizerAtom* terminalAtom = bond->getEndAtom();
         sketcherMinimizerAtom* rootAtom = bond->getStartAtom();
         if (terminalAtom->getBonds().size() != 1) {
             terminalAtom = bond->getStartAtom();
             rootAtom = bond->getEndAtom();
         }
-        if (terminalAtom->fixed)
+        if (terminalAtom->fixed) {
             continue;
+        }
         for (auto bond2 : molecule->getBonds()) {
-            if (bond2->isResidueInteraction())
+            if (bond2->isResidueInteraction()) {
                 continue;
+            }
             if (bondsClash(bond, bond2)) {
                 terminalAtom->setCoordinates(rootAtom->getCoordinates() +
                                              (terminalAtom->getCoordinates() -
@@ -1324,20 +1404,23 @@ void CoordgenMinimizer::maybeMinimizeRings(
     for (auto r : rings) {
         if (r->_atoms.size() == 5) {
             for (auto& _atom : r->_atoms) {
-                if (_atom->rings.size() > 2)
+                if (_atom->rings.size() > 2) {
                     found = true;
+                }
             }
         }
         if (r->isMacrocycle() && r->_atoms.size() % 2 != 0) {
             for (auto& _atom : r->_atoms) {
-                if (_atom->rings.size() > 2)
+                if (_atom->rings.size() > 2) {
                     found = true;
+                }
             }
         }
     }
 
-    if (!found)
+    if (!found) {
         return;
+    }
     rings.at(0)->getAtoms().at(0)->molecule->requireMinimization();
 }
 
@@ -1398,8 +1481,9 @@ bool CoordgenMinimizer::hasNaNCoordinates(
 {
     foreach (sketcherMinimizerAtom* a, atoms)
         if (a->coordinates.x() != a->coordinates.x() ||
-            a->coordinates.y() != a->coordinates.y())
+            a->coordinates.y() != a->coordinates.y()) {
             return true;
+        }
     return false;
 }
 
@@ -1411,8 +1495,9 @@ bool CoordgenMinimizer::hasNaNCoordinates()
 void CoordgenMinimizer::checkForClashes(sketcherMinimizerAtom* a)
 {
 
-    if (a->fixed)
+    if (a->fixed) {
         return;
+    }
 
     sketcherMinimizerPointF oldCoordinates = a->coordinates;
     vector<sketcherMinimizerPointF> coordsVect;
@@ -1449,14 +1534,18 @@ void CoordgenMinimizer::checkForClashes(sketcherMinimizerAtom* a)
         float clashE = 0;
         vector<sketcherMinimizerBond*> bonds = a->getFragment()->getBonds();
         foreach (sketcherMinimizerBond* b, bonds) {
-            if (!b->startAtom->coordinatesSet)
+            if (!b->startAtom->coordinatesSet) {
                 continue;
-            if (!b->endAtom->coordinatesSet)
+            }
+            if (!b->endAtom->coordinatesSet) {
                 continue;
-            if (b->startAtom == a)
+            }
+            if (b->startAtom == a) {
                 continue;
-            if (b->endAtom == a)
+            }
+            if (b->endAtom == a) {
                 continue;
+            }
             clashI.atom1 = b->startAtom;
             clashI.atom2 = a;
             clashI.atom3 = b->endAtom;
@@ -1466,16 +1555,21 @@ void CoordgenMinimizer::checkForClashes(sketcherMinimizerAtom* a)
         foreach (sketcherMinimizerBond* b, a->bonds) {
             vector<sketcherMinimizerAtom*> atoms = a->getFragment()->getAtoms();
             foreach (sketcherMinimizerAtom* atom, atoms) {
-                if (atom == a)
+                if (atom == a) {
                     continue;
-                if (!b->startAtom->coordinatesSet)
+                }
+                if (!b->startAtom->coordinatesSet) {
                     continue;
-                if (!b->endAtom->coordinatesSet)
+                }
+                if (!b->endAtom->coordinatesSet) {
                     continue;
-                if (b->startAtom == atom)
+                }
+                if (b->startAtom == atom) {
                     continue;
-                if (b->endAtom == atom)
+                }
+                if (b->endAtom == atom) {
                     continue;
+                }
                 clashI.atom1 = b->startAtom;
                 clashI.atom2 = atom;
                 clashI.atom3 = b->endAtom;
@@ -1483,10 +1577,12 @@ void CoordgenMinimizer::checkForClashes(sketcherMinimizerAtom* a)
             }
         }
 
-        if (clashE < SKETCHER_EPSILON)
+        if (clashE < SKETCHER_EPSILON) {
             return;
-        if (i == 0)
+        }
+        if (i == 0) {
             bestE = clashE;
+        }
         if (clashE < bestE) {
             bestE = clashE;
             bestI = i;
@@ -1521,8 +1617,9 @@ CoordgenDOFSolutions::findBestSolution() const
 std::vector<short unsigned int> CoordgenDOFSolutions::getCurrentSolution()
 {
     std::vector<short unsigned int> solution;
-    for (auto dof : m_allDofs)
+    for (auto dof : m_allDofs) {
         solution.push_back(dof->getCurrentState());
+    }
     return solution;
 }
 
@@ -1544,8 +1641,9 @@ bool CoordgenDOFSolutions::hasSolution(
 float CoordgenDOFSolutions::scoreCurrentSolution()
 {
     std::vector<short unsigned int> solution;
-    for (auto dof : m_allDofs)
+    for (auto dof : m_allDofs) {
         solution.push_back(dof->getCurrentState());
+    }
     //   for (auto dof : solution) cerr <<dof;
     //   cerr << endl;
     auto position = m_solutions.find(solution);

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -123,11 +123,11 @@ void CoordgenMinimizer::addClashInteractionsOfMolecule(
     vector<sketcherMinimizerBond*> bonds = molecule->getBonds();
 
     if (atoms.size() > 1) {
-        for (sketcherMinimizerAtom* atom: atoms) {
+        for (sketcherMinimizerAtom* atom : atoms) {
             if (atom->isResidue())
                 continue;
 
-            for (sketcherMinimizerBond* bond: bonds) {
+            for (sketcherMinimizerBond* bond : bonds) {
                 if (bond->isResidueInteraction())
                     continue;
                 sketcherMinimizerAtom* at2 = atom;
@@ -149,13 +149,13 @@ void CoordgenMinimizer::addClashInteractionsOfMolecule(
 
                 if (at1->isNeighborOf(at2))
                     continue;
-                for (sketcherMinimizerAtom* n: at1->neighbors) {
+                for (sketcherMinimizerAtom* n : at1->neighbors) {
                     if (n->isNeighborOf(at2))
                         continue;
                 }
                 if (at3->isNeighborOf(at2))
                     continue;
-                for (sketcherMinimizerAtom* n: at3->neighbors) {
+                for (sketcherMinimizerAtom* n : at3->neighbors) {
                     if (n->isNeighborOf(at2))
                         continue;
                 }
@@ -1007,7 +1007,7 @@ std::vector<std::vector<CoordgenFragmentDOF*>>
 CoordgenMinimizer::buildTuplesOfDofs(const vector<CoordgenFragmentDOF*>& dofs,
                                      unsigned int order) const
 {
-    std::vector<std::vector<CoordgenFragmentDOF*>> growingVector,
+    std::vector<std::vector<CoordgenFragmentDOF *>> growingVector,
         lastOrderVector;
     for (auto dof : dofs) {
         std::vector<CoordgenFragmentDOF*> tuple;
@@ -1141,7 +1141,7 @@ bool CoordgenMinimizer::flipFragments(sketcherMinimizerMolecule* molecule,
         return true;
     if (bestResult < clashEnergyThreshold)
         return true;
-    vector<CoordgenFragmentDOF*> dofs, onlyFlipDofs;
+    vector<CoordgenFragmentDOF *> dofs, onlyFlipDofs;
     vector<sketcherMinimizerFragment*> fragments = molecule->getFragments();
     reverse(fragments.begin(), fragments.end());
     for (auto fragment : fragments) {

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -123,11 +123,11 @@ void CoordgenMinimizer::addClashInteractionsOfMolecule(
     vector<sketcherMinimizerBond*> bonds = molecule->getBonds();
 
     if (atoms.size() > 1) {
-        foreach (sketcherMinimizerAtom* atom, atoms) {
+        for (sketcherMinimizerAtom* atom: atoms) {
             if (atom->isResidue())
                 continue;
 
-            foreach (sketcherMinimizerBond* bond, bonds) {
+            for (sketcherMinimizerBond* bond: bonds) {
                 if (bond->isResidueInteraction())
                     continue;
                 sketcherMinimizerAtom* at2 = atom;
@@ -149,13 +149,13 @@ void CoordgenMinimizer::addClashInteractionsOfMolecule(
 
                 if (at1->isNeighborOf(at2))
                     continue;
-                foreach (sketcherMinimizerAtom* n, at1->neighbors) {
+                for (sketcherMinimizerAtom* n: at1->neighbors) {
                     if (n->isNeighborOf(at2))
                         continue;
                 }
                 if (at3->isNeighborOf(at2))
                     continue;
-                foreach (sketcherMinimizerAtom* n, at3->neighbors) {
+                for (sketcherMinimizerAtom* n: at3->neighbors) {
                     if (n->isNeighborOf(at2))
                         continue;
                 }

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -52,8 +52,8 @@ CoordgenMinimizer::~CoordgenMinimizer()
 
 void CoordgenMinimizer::clearInteractions()
 {
-    for (unsigned int i = 0; i < _interactions.size(); i++) {
-        delete _interactions[i];
+    for (auto& _interaction : _interactions) {
+        delete _interaction;
     }
     _interactions.clear();
     _intramolecularClashInteractions.clear();
@@ -81,8 +81,7 @@ bool CoordgenMinimizer::applyForces(float maxd)
 {
     float delta = 0.001f; // minimum squared displacement
     float distance = 0.f;
-    for (unsigned int i = 0; i < _atoms.size(); i++) {
-        sketcherMinimizerAtom* atom = _atoms[i];
+    for (auto atom : _atoms) {
         if (atom->fixed)
             continue;
         sketcherMinimizerPointF displacement = atom->force * FORCE_MULTIPLIER;
@@ -163,7 +162,7 @@ void CoordgenMinimizer::addClashInteractionsOfMolecule(
                 if (!(at1->rigid && at2->rigid && at3->rigid)) {
 
                     //                }
-                    sketcherMinimizerClashInteraction* interaction =
+                    auto* interaction =
                         new sketcherMinimizerClashInteraction(at1, at2, at3);
                     float restVK = 0.8f;
                     if (at2->atomicNumber == 6 && at2->charge == 0)
@@ -191,8 +190,7 @@ void CoordgenMinimizer::addStretchInteractionsOfMolecule(
             continue;
         sketcherMinimizerAtom* at1 = bo->startAtom;
         sketcherMinimizerAtom* at2 = bo->endAtom;
-        sketcherMinimizerStretchInteraction* interaction =
-            new sketcherMinimizerStretchInteraction(at1, at2);
+        auto* interaction = new sketcherMinimizerStretchInteraction(at1, at2);
         interaction->k *= 0.1f;
         interaction->restV = bondLength;
         if (at1->rigid && at2->rigid) {
@@ -373,9 +371,8 @@ void CoordgenMinimizer::addChiralInversionConstraintsOfMolecule(
                     sketcherMinimizer::getBond(atoms[a1], atoms[i]);
                 if (bond->isStereo()) {
                     bool cis = bond->markedAsCis(atoms[a11], atoms[a2]);
-                    sketcherMinimizerEZConstrainInteraction* ezint =
-                        new sketcherMinimizerEZConstrainInteraction(
-                            atoms[a11], atoms[a1], atoms[i], atoms[a2], cis);
+                    auto* ezint = new sketcherMinimizerEZConstrainInteraction(
+                        atoms[a11], atoms[a1], atoms[i], atoms[a2], cis);
                     _interactions.push_back(ezint);
                 }
             }
@@ -413,7 +410,7 @@ void CoordgenMinimizer::addBendInteractionsOfMolecule(
                 sketcherMinimizerAtom* at1 = orderedNeighs[i];
                 sketcherMinimizerAtom* at2 = at;
                 sketcherMinimizerAtom* at3 = orderedNeighs[j];
-                sketcherMinimizerBendInteraction* interaction =
+                auto* interaction =
                     new sketcherMinimizerBendInteraction(at1, at2, at3);
                 interactions.push_back(interaction);
                 interaction->restV = angle;
@@ -440,7 +437,7 @@ void CoordgenMinimizer::addBendInteractionsOfMolecule(
                         ringInteractions.push_back(interaction);
                     } else {
                         if (nbonds == 3) {
-                            sketcherMinimizerAtom* otherAtom = NULL;
+                            sketcherMinimizerAtom* otherAtom = nullptr;
                             for (auto atom : orderedNeighs) {
                                 if (atom != at1 && atom != at3) {
                                     otherAtom = atom;
@@ -610,7 +607,7 @@ void CoordgenMinimizer::setupInteractionsOnlyResidues()
             if (res2 >= res) {
                 continue;
             }
-            sketcherMinimizerClashInteraction* minimizerInteraction =
+            auto* minimizerInteraction =
                 new sketcherMinimizerClashInteraction(res, res2, res);
             minimizerInteraction->restV = CLASH_DISTANCE * CLASH_DISTANCE;
             _interactions.push_back(minimizerInteraction);
@@ -637,9 +634,8 @@ void CoordgenMinimizer::setupInteractionsProteinOnly(
             if (res == interaction->startAtom || res == interaction->endAtom) {
                 continue;
             }
-            sketcherMinimizerClashInteraction* minimizerInteraction =
-                new sketcherMinimizerClashInteraction(
-                    interaction->startAtom, res, interaction->endAtom);
+            auto* minimizerInteraction = new sketcherMinimizerClashInteraction(
+                interaction->startAtom, res, interaction->endAtom);
             minimizerInteraction->restV = bondLength * bondLength;
             _interactions.push_back(minimizerInteraction);
         }
@@ -657,8 +653,7 @@ void CoordgenMinimizer::setupInteractions(bool intrafragmentClashes)
 float CoordgenMinimizer::scoreInteractions()
 {
     float totalEnergy = 0.f;
-    for (unsigned int i = 0; i < _interactions.size(); i++) {
-        sketcherMinimizerInteraction* interaction = _interactions[i];
+    for (auto interaction : _interactions) {
         interaction->score(totalEnergy);
     }
     return totalEnergy;
@@ -725,14 +720,12 @@ bool CoordgenMinimizer::findIntermolecularClashes(
 
 void CoordgenMinimizer::fixRingsShape()
 {
-    for (unsigned int i = 0; i < _bendInteractions.size(); i++) {
-        sketcherMinimizerBendInteraction* in = _bendInteractions[i];
+    for (auto in : _bendInteractions) {
         if (in->isRing) {
             in->k *= 10;
         }
     }
-    for (unsigned int i = 0; i < _stretchInteractions.size(); i++) {
-        sketcherMinimizerStretchInteraction* in = _stretchInteractions[i];
+    for (auto in : _stretchInteractions) {
         if (sketcherMinimizer::sameRing(in->atom1, in->atom2)) {
             in->k *= 10;
         }
@@ -812,8 +805,7 @@ float CoordgenMinimizer::scoreCrossBonds(sketcherMinimizerMolecule* molecule,
         }
     }
     if (_residueInteractions.size() && residueInteractions) {
-        for (unsigned int a = 0; a < _residues.size(); a++) {
-            sketcherMinimizerResidue* r = _residues[a];
+        for (auto r : _residues) {
             if (r->residueInteractions.size() > 1) {
                 for (unsigned int ri1 = 0;
                      ri1 < r->residueInteractions.size() - 1; ri1++) {
@@ -833,8 +825,7 @@ float CoordgenMinimizer::scoreCrossBonds(sketcherMinimizerMolecule* molecule,
                             out += 15.f;
                         }
 
-                        for (unsigned int bb = 0; bb < _bonds.size(); bb++) {
-                            sketcherMinimizerBond* b2 = _bonds[bb];
+                        for (auto b2 : _bonds) {
                             if (b2->startAtom ==
                                 r->residueInteractions[ri1]->endAtom)
                                 continue;
@@ -907,9 +898,9 @@ float CoordgenMinimizer::scoreProximityRelationsOnOppositeSides() const
             continue;
         for (unsigned int i = 0; i < m->m_proximityRelations.size(); i++) {
             sketcherMinimizerPointF v1, v2;
-            sketcherMinimizerMolecule* otherMol1 = NULL;
+            sketcherMinimizerMolecule* otherMol1 = nullptr;
             sketcherMinimizerBond* pr1 = m->m_proximityRelations[i];
-            sketcherMinimizerFragment* f1 = NULL;
+            sketcherMinimizerFragment* f1 = nullptr;
             if (pr1->startAtom->molecule == m) {
                 f1 = pr1->startAtom->fragment;
                 v1 = pr1->startAtom->getSingleAdditionVector();
@@ -924,7 +915,7 @@ float CoordgenMinimizer::scoreProximityRelationsOnOppositeSides() const
 
             for (unsigned int j = i + 1; j < m->m_proximityRelations.size();
                  j++) {
-                sketcherMinimizerMolecule* otherMol2 = NULL;
+                sketcherMinimizerMolecule* otherMol2 = nullptr;
 
                 sketcherMinimizerBond* pr2 = m->m_proximityRelations[j];
                 if (pr2->startAtom->molecule == m) {
@@ -1045,9 +1036,7 @@ bool CoordgenMinimizer::growSolutions(
     std::vector<std::pair<float, std::vector<short unsigned int>>>
         bestSolutions;
     for (auto solution : growingSolutions) {
-        bestSolutions.push_back(
-            std::pair<float, std::vector<short unsigned int>>(solution.second,
-                                                              solution.first));
+        bestSolutions.emplace_back(solution.second, solution.first);
     }
     sort(bestSolutions.begin(), bestSolutions.end());
     growingSolutions.clear();
@@ -1332,17 +1321,16 @@ void CoordgenMinimizer::maybeMinimizeRings(
     const vector<sketcherMinimizerRing*>& rings)
 {
     bool found = false;
-    for (unsigned int rr = 0; rr < rings.size(); rr++) {
-        sketcherMinimizerRing* r = rings[rr];
+    for (auto r : rings) {
         if (r->_atoms.size() == 5) {
-            for (unsigned int i = 0; i < r->_atoms.size(); i++) {
-                if (r->_atoms[i]->rings.size() > 2)
+            for (auto& _atom : r->_atoms) {
+                if (_atom->rings.size() > 2)
                     found = true;
             }
         }
         if (r->isMacrocycle() && r->_atoms.size() % 2 != 0) {
-            for (unsigned int i = 0; i < r->_atoms.size(); i++) {
-                if (r->_atoms[i]->rings.size() > 2)
+            for (auto& _atom : r->_atoms) {
+                if (_atom->rings.size() > 2)
                     found = true;
             }
         }

--- a/example_dir/example.cpp
+++ b/example_dir/example.cpp
@@ -6,7 +6,7 @@ int main()
     sketcherMinimizer minimizer;
 
     /* create a molecule */
-    sketcherMinimizerMolecule* min_mol = new sketcherMinimizerMolecule();
+    auto* min_mol = new sketcherMinimizerMolecule();
 
     /* add an atom and set its parameters */
     auto a1 = min_mol->addNewAtom();

--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -1094,12 +1094,11 @@ std::vector<sketcherMinimizerResidue*> sketcherMinimizer::orderResiduesOfChains(
             vec.push_back(res);
         }
     }
-    sort(vec.begin(), vec.end(),
-         [](const sketcherMinimizerResidue* firstRes,
-            const sketcherMinimizerResidue* secondRes) {
-             return firstRes->residueInteractions.size() >
-                    secondRes->residueInteractions.size();
-         });
+    sort(vec.begin(), vec.end(), [](const sketcherMinimizerResidue* firstRes,
+                                    const sketcherMinimizerResidue* secondRes) {
+        return firstRes->residueInteractions.size() >
+               secondRes->residueInteractions.size();
+    });
     std::set<sketcherMinimizerResidue*> visitedResidues;
     std::queue<sketcherMinimizerResidue*> residueQueue;
     std::vector<sketcherMinimizerResidue*> finalVec;
@@ -1200,12 +1199,12 @@ void sketcherMinimizer::placeResiduesInCrowns()
                  interactionsOfSecond += res->residueInteractions.size();
              }
              float interactionScaling = 3.f;
-             float score1 = firstSSE.size() + interactionScaling *
-                                                  interactionsOfFirst /
-                                                  firstSSE.size();
-             float score2 = secondSSE.size() + interactionScaling *
-                                                   interactionsOfSecond /
-                                                   secondSSE.size();
+             float score1 =
+                 firstSSE.size() +
+                 interactionScaling * interactionsOfFirst / firstSSE.size();
+             float score2 =
+                 secondSSE.size() +
+                 interactionScaling * interactionsOfSecond / secondSSE.size();
              return score1 > score2;
          });
     bool needOtherShape = true;
@@ -1560,11 +1559,10 @@ vector<sketcherMinimizerPointF> sketcherMinimizer::shapeAroundLigand(int crownN)
     ms.setThreshold(0);
     ms.run();
     auto result = ms.getOrderedCoordinatesPoints();
-    sort(result.begin(), result.end(),
-         [](const vector<float>& firstContour,
-            const vector<float>& secondContour) {
-             return firstContour.size() > secondContour.size();
-         });
+    sort(result.begin(), result.end(), [](const vector<float>& firstContour,
+                                          const vector<float>& secondContour) {
+        return firstContour.size() > secondContour.size();
+    });
     vector<sketcherMinimizerPointF> returnValue;
     if (result.size() > 0) {
         for (unsigned int i = 0; i < result.at(0).size(); i += 2) {
@@ -2833,7 +2831,7 @@ sketcherMinimizerAtom*
 sketcherMinimizer::pickBestAtom(vector<sketcherMinimizerAtom*>& atoms)
 {
 
-    vector<sketcherMinimizerAtom*> candidates, oldCandidates;
+    vector<sketcherMinimizerAtom *> candidates, oldCandidates;
 
     {
         size_t biggestSize = atoms[0]->fragment->numberOfChildrenAtoms;

--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -97,12 +97,14 @@ void sketcherMinimizer::canonicalOrdering(sketcherMinimizerMolecule* minMol)
         do {
             int scoreMaxI = -1;
             for (unsigned int i = 0; i < scores.size(); i++) {
-                if (minMol->_atoms[i]->_generalUseVisited)
+                if (minMol->_atoms[i]->_generalUseVisited) {
                     continue;
-                if (scoreMaxI == -1)
+                }
+                if (scoreMaxI == -1) {
                     scoreMaxI = i;
-                else if (scores[i] > scores[scoreMaxI])
+                } else if (scores[i] > scores[scoreMaxI]) {
                     scoreMaxI = i;
+                }
             }
             if (scoreMaxI > -1) {
                 queue<sketcherMinimizerAtom*> q;
@@ -118,12 +120,12 @@ void sketcherMinimizer::canonicalOrdering(sketcherMinimizerMolecule* minMol)
                         neighI = -1;
                         for (unsigned int i = 0; i < at->neighbors.size();
                              i++) {
-                            if (at->bonds[i]->_SSSRVisited)
+                            if (at->bonds[i]->_SSSRVisited) {
                                 continue;
-                            else {
-                                if (neighI == -1)
+                            } else {
+                                if (neighI == -1) {
                                     neighI = i;
-                                else {
+                                } else {
                                     if (scores[at->neighbors[neighI]
                                                    ->_generalUseN] <
                                         scores[at->neighbors[i]
@@ -163,8 +165,9 @@ void sketcherMinimizer::initialize(
     _referenceBonds = minMol->_bonds;
 
     for (auto& _bond : minMol->_bonds) {
-        if (_bond->skip)
+        if (_bond->skip) {
             continue;
+        }
         if (_bond->bondOrder == 1 || _bond->bondOrder == 2) {
             if (sketcherMinimizerAtom::isMetal(
                     _bond->startAtom->atomicNumber) ||
@@ -175,24 +178,29 @@ void sketcherMinimizer::initialize(
     }
 
     for (auto& _bond : minMol->_bonds) {
-        if (_bond->skip)
+        if (_bond->skip) {
             continue;
+        }
         if (_bond->bondOrder == 0) {
             m_proximityRelations.push_back(_bond);
         } else if (_bond->isResidueInteraction()) {
-            if (!_bond->startAtom->isResidue() && !_bond->endAtom->isResidue())
+            if (!_bond->startAtom->isResidue() &&
+                !_bond->endAtom->isResidue()) {
                 m_proximityRelations.push_back(_bond);
+            }
         }
     }
     for (auto& m_extraBond : m_extraBonds) {
-        if (m_extraBond->skip)
+        if (m_extraBond->skip) {
             continue;
+        }
         if (m_extraBond->bondOrder == 0) {
             m_proximityRelations.push_back(m_extraBond);
         } else if (m_extraBond->isResidueInteraction()) {
             if (!m_extraBond->startAtom->isResidue() &&
-                !m_extraBond->endAtom->isResidue())
+                !m_extraBond->endAtom->isResidue()) {
                 m_proximityRelations.push_back(m_extraBond);
+            }
         }
     }
 
@@ -223,17 +231,19 @@ void sketcherMinimizer::initialize(
         if (!a->hidden) {
             _atoms.push_back(a);
         }
-        if (a->isResidue())
+        if (a->isResidue()) {
             _residues.push_back(static_cast<sketcherMinimizerResidue*>(a));
+        }
     }
 
     foreach (sketcherMinimizerBond* b, minMol->_bonds) {
         if (!b->startAtom->hidden && !b->endAtom->hidden) {
             _bonds.push_back(b);
         }
-        if (b->isResidueInteraction())
+        if (b->isResidueInteraction()) {
             _residueInteractions.push_back(
                 static_cast<sketcherMinimizerResidueInteraction*>(b));
+        }
     }
 
     minMol->forceUpdateStruct(minMol->_atoms, minMol->_bonds, minMol->_rings);
@@ -241,8 +251,9 @@ void sketcherMinimizer::initialize(
 
     foreach (sketcherMinimizerBond* b, m_proximityRelations) {
         b->startAtom->molecule->m_proximityRelations.push_back(b);
-        if (b->endAtom != b->startAtom)
+        if (b->endAtom != b->startAtom) {
             b->endAtom->molecule->m_proximityRelations.push_back(b);
+        }
     }
 
     flagCrossAtoms();
@@ -256,8 +267,9 @@ void sketcherMinimizer::initialize(
 
 bool sketcherMinimizer::structurePassSanityCheck() const
 {
-    if (!_atoms.size())
+    if (!_atoms.size()) {
         return false;
+    }
     for (auto molecule : _molecules) {
         if (molecule->_rings.size() > MAX_NUMBER_OF_RINGS) {
             return false;
@@ -284,12 +296,14 @@ bool sketcherMinimizer::runGenerateCoordinates()
 void sketcherMinimizer::flagCrossAtoms()
 {
     foreach (sketcherMinimizerAtom* at, _atoms)
-        if (at->atomicNumber == 16 || at->atomicNumber == 15)
+        if (at->atomicNumber == 16 || at->atomicNumber == 15) {
             at->crossLayout = true;
+        }
 
     foreach (sketcherMinimizerAtom* at, _atoms) {
-        if (at->crossLayout)
+        if (at->crossLayout) {
             continue;
+        }
         int cross = 0;
         foreach (sketcherMinimizerAtom* n, at->neighbors) {
             if (n->neighbors.size() > 3) {
@@ -359,8 +373,9 @@ void sketcherMinimizer::splitIntoMolecules(
         q.pop();
         a->_generalUseVisited = true;
         foreach (sketcherMinimizerAtom* n, a->neighbors) {
-            if (!n->_generalUseVisited && !n->hidden)
+            if (!n->_generalUseVisited && !n->hidden) {
                 q.push(n);
+            }
         }
     }
     vector<sketcherMinimizerAtom*> newAtoms;
@@ -421,39 +436,47 @@ sketcherMinimizer::sameRing(const sketcherMinimizerAtom* at1,
                             const sketcherMinimizerAtom* at2,
                             const sketcherMinimizerAtom* at3)
 {
-    if (!at1->rings.size())
+    if (!at1->rings.size()) {
         return nullptr;
-    if (!at2->rings.size())
+    }
+    if (!at2->rings.size()) {
         return nullptr;
-    if (!at3->rings.size())
+    }
+    if (!at3->rings.size()) {
         return nullptr;
+    }
     sketcherMinimizerRing* r = nullptr;
     foreach (sketcherMinimizerRing* ring, at1->rings) {
-        if (ring->isMacrocycle())
+        if (ring->isMacrocycle()) {
             continue;
+        }
         foreach (sketcherMinimizerRing* ring2, at2->rings) {
-            if (ring != ring2)
+            if (ring != ring2) {
                 continue;
+            }
             foreach (sketcherMinimizerRing* ring3, at3->rings) {
                 if (ring3 == ring2) {
-                    if (!r)
+                    if (!r) {
                         r = ring2;
-                    else if (ring2->_atoms.size() < r->_atoms.size())
+                    } else if (ring2->_atoms.size() < r->_atoms.size()) {
                         r = ring2;
+                    }
                 }
             }
         }
     }
     foreach (sketcherMinimizerRing* ring, at1->rings) {
         foreach (sketcherMinimizerRing* ring2, at2->rings) {
-            if (ring != ring2)
+            if (ring != ring2) {
                 continue;
+            }
             foreach (sketcherMinimizerRing* ring3, at3->rings) {
                 if (ring3 == ring2) {
-                    if (!r)
+                    if (!r) {
                         r = ring2;
-                    else if (ring2->_atoms.size() < r->_atoms.size())
+                    } else if (ring2->_atoms.size() < r->_atoms.size()) {
                         r = ring2;
+                    }
                 }
             }
         }
@@ -464,8 +487,9 @@ sketcherMinimizer::sameRing(const sketcherMinimizerAtom* at1,
 void sketcherMinimizer::writeStereoChemistry()
 {
     foreach (sketcherMinimizerAtom* a, _atoms) {
-        if (a->hasStereochemistrySet)
+        if (a->hasStereochemistrySet) {
             a->writeStereoChemistry();
+        }
     }
     assignPseudoZ();
 }
@@ -495,8 +519,9 @@ void sketcherMinimizer::assignPseudoZ()
                     lastAtom->_generalUseVisited = true;
                     for (unsigned int i = 0; i < lastAtom->neighbors.size();
                          i++) {
-                        if (lastAtom->neighbors[i]->_generalUseVisited)
+                        if (lastAtom->neighbors[i]->_generalUseVisited) {
                             continue;
+                        }
                         float Z = lastAtom->m_pseudoZ;
                         sketcherMinimizerBond* b = lastAtom->bonds[i];
                         if (b->hasStereochemistryDisplay) {
@@ -531,8 +556,9 @@ void sketcherMinimizer::assignPseudoZ()
                         q.push(lastAtom->neighbors[i]);
                     }
                 }
-            } else
+            } else {
                 finished = true;
+            }
         }
     }
 }
@@ -569,20 +595,24 @@ void sketcherMinimizer::maybeFlip()
 {
 
     foreach (sketcherMinimizerMolecule* mol, _molecules) {
-        if (mol->hasFixedFragments)
+        if (mol->hasFixedFragments) {
             continue;
-        if (mol->hasConstrainedFragments)
+        }
+        if (mol->hasConstrainedFragments) {
             continue;
-        if (mol->_atoms.size() < 2)
+        }
+        if (mol->_atoms.size() < 2) {
             continue;
+        }
 
         float scoreY = 0.f, scoreX = 0.f;
         maybeFlipPeptides(mol->getAtoms(), scoreX);
         sketcherMinimizerPointF cent(0.f, 0.f);
         foreach (sketcherMinimizerAtom* a, mol->_atoms)
             cent += a->coordinates;
-        if (mol->_atoms.size())
+        if (mol->_atoms.size()) {
             cent /= mol->_atoms.size();
+        }
 
         foreach (sketcherMinimizerFragment* f, mol->_fragments) {
             vector<sketcherMinimizerRing*> rings = f->getRings();
@@ -615,8 +645,9 @@ void sketcherMinimizer::maybeFlip()
                 size_t totalN = 0;
                 int totalRings = 0;
                 foreach (sketcherMinimizerRing* r, rings) {
-                    if (r->_atoms.size() < 4)
+                    if (r->_atoms.size() < 4) {
                         continue;
+                    }
 
                     sketcherMinimizerPointF c = r->findCenter();
                     center += c;
@@ -647,27 +678,31 @@ void sketcherMinimizer::maybeFlip()
         foreach (sketcherMinimizerAtom* a, mol->_atoms) {
             float x = a->coordinates.x();
             float y = a->coordinates.y();
-            if (x < minx)
+            if (x < minx) {
                 minx = x;
-            else if (x > maxx)
+            } else if (x > maxx) {
                 maxx = x;
-            if (y < miny)
+            }
+            if (y < miny) {
                 miny = y;
-            else if (y > maxy)
+            } else if (y > maxy) {
                 maxy = y;
+            }
         }
 
         float meanx = (maxx + minx) * 0.5f;
         float meany = (maxy + miny) * 0.5f;
 
-        if (meanx - cent.x() > SKETCHER_EPSILON)
+        if (meanx - cent.x() > SKETCHER_EPSILON) {
             scoreX -= 0.5f;
-        else if (meanx - cent.x() < -SKETCHER_EPSILON)
+        } else if (meanx - cent.x() < -SKETCHER_EPSILON) {
             scoreX += 0.5f;
-        if (meany - cent.y() > SKETCHER_EPSILON)
+        }
+        if (meany - cent.y() > SKETCHER_EPSILON) {
             scoreY += 0.5f;
-        else if (meany - cent.y() < -SKETCHER_EPSILON)
+        } else if (meany - cent.y() < -SKETCHER_EPSILON) {
             scoreY -= 0.5f;
+        }
 
         foreach (sketcherMinimizerBond* b, mol->_bonds) {
             if (b->bondOrder == 2) {
@@ -677,19 +712,21 @@ void sketcherMinimizer::maybeFlip()
 
                     float diff = b->startAtom->coordinates.y() -
                                  b->endAtom->coordinates.y();
-                    if (diff > SKETCHER_EPSILON)
+                    if (diff > SKETCHER_EPSILON) {
                         scoreY += 1;
-                    else if (diff < -SKETCHER_EPSILON)
+                    } else if (diff < -SKETCHER_EPSILON) {
                         scoreY -= 1;
+                    }
                 } else if (b->endAtom->neighbors.size() == 1 &&
                            b->startAtom->neighbors.size() > 1) {
 
                     float diff = b->endAtom->coordinates.y() -
                                  b->startAtom->coordinates.y();
-                    if (diff > SKETCHER_EPSILON)
+                    if (diff > SKETCHER_EPSILON) {
                         scoreY += 1;
-                    else if (diff < -SKETCHER_EPSILON)
+                    } else if (diff < -SKETCHER_EPSILON) {
                         scoreY -= 1;
+                    }
                 }
             }
         }
@@ -712,8 +749,9 @@ void sketcherMinimizer::addToVector(float weight, float angle,
                                     vector<pair<float, float>>& angles)
 {
     angle = roundToTwoDecimalDigits(angle);
-    while (angle <= 0)
+    while (angle <= 0) {
         angle += static_cast<float>(M_PI);
+    }
     for (unsigned int i = 0; i < angles.size(); i++) {
         if (angles[i].second < angle - SKETCHER_EPSILON) {
             if (i == angles.size() - 1) {
@@ -730,8 +768,9 @@ void sketcherMinimizer::addToVector(float weight, float angle,
             break;
         }
     }
-    if (!angles.size())
+    if (!angles.size()) {
         angles.emplace_back(weight, angle);
+    }
 }
 
 /* if a peptide chain is present rotate the molecule so it's horizontal */
@@ -765,8 +804,9 @@ void sketcherMinimizer::bestRotation()
 {
     foreach (sketcherMinimizerMolecule* mol, _molecules) {
         vector<pair<float, float>> angles;
-        if (mol->hasFixedFragments || mol->hasConstrainedFragments)
+        if (mol->hasFixedFragments || mol->hasConstrainedFragments) {
             continue;
+        }
         addBestRotationInfoForPeptides(angles, mol->getAtoms());
         float angle = 0.f;
         float lastAngle;
@@ -774,26 +814,33 @@ void sketcherMinimizer::bestRotation()
         float weight = 1.f;
         auto increment = static_cast<float>(M_PI / 6);
         foreach (sketcherMinimizerAtom* a, mol->_atoms) {
-            if (a->rings.size())
+            if (a->rings.size()) {
                 continue;
+            }
             if (a->neighbors.size() > 1) {
                 for (i = 0; i < a->neighbors.size() - 1; i++) {
                     for (j = i + 1; j < a->neighbors.size(); j++) {
 
                         weight = 6;
 
-                        if (a->neighbors[i]->neighbors.size() != 1)
+                        if (a->neighbors[i]->neighbors.size() != 1) {
                             weight += 2;
-                        if (a->neighbors[j]->neighbors.size() != 1)
+                        }
+                        if (a->neighbors[j]->neighbors.size() != 1) {
                             weight += 2;
-                        if (a->neighbors[j]->atomicNumber == 6)
+                        }
+                        if (a->neighbors[j]->atomicNumber == 6) {
                             weight += 1;
-                        if (a->neighbors[j]->atomicNumber == 6)
+                        }
+                        if (a->neighbors[j]->atomicNumber == 6) {
                             weight += 1;
-                        if (a->neighbors[i]->charge == 0)
+                        }
+                        if (a->neighbors[i]->charge == 0) {
                             weight += 1;
-                        if (a->neighbors[j]->charge == 0)
+                        }
+                        if (a->neighbors[j]->charge == 0) {
                             weight += 1;
+                        }
 
                         sketcherMinimizerPointF p =
                             a->neighbors[i]->coordinates -
@@ -816,24 +863,28 @@ void sketcherMinimizer::bestRotation()
             }
             lastAngle = angle;
             for (unsigned int i = 0; i < 6; i++) {
-                if (i == 1 || i == 5)
+                if (i == 1 || i == 5) {
                     weight = 5.f;
-                else if (i == 0 || i == 3)
+                } else if (i == 0 || i == 3) {
                     weight = 1.5f;
-                else
+                } else {
                     weight = 1.f;
+                }
                 if (b->bondOrder == 2 && i == 3 &&
                     (b->startAtom->neighbors.size() == 1 ||
-                     b->endAtom->neighbors.size() == 1))
+                     b->endAtom->neighbors.size() == 1)) {
                     weight += 1.5;
+                }
 
                 if (b->startAtom->neighbors.size() == 1 &&
-                    b->endAtom->neighbors.size() == 1 && i == 0)
+                    b->endAtom->neighbors.size() == 1 && i == 0) {
                     weight += 10;
+                }
                 addToVector(weight, lastAngle, angles);
                 lastAngle += increment;
-                if (lastAngle > M_PI)
+                if (lastAngle > M_PI) {
                     lastAngle -= static_cast<float>(M_PI);
+                }
             }
         }
 
@@ -922,16 +973,18 @@ void sketcherMinimizer::bestRotation()
         if (angles.size()) {
             int bestI = 0;
             for (i = 0; i < angles.size(); i++) {
-                if (angles[i].first > angles[bestI].first)
+                if (angles[i].first > angles[bestI].first) {
                     bestI = i;
+                }
             }
             float s = -sin(angles[bestI].second);
             float c = cos(angles[bestI].second);
             sketcherMinimizerPointF center(0.f, 0.f);
             foreach (sketcherMinimizerAtom* at, mol->_atoms)
                 center += at->coordinates;
-            if (mol->_atoms.size())
+            if (mol->_atoms.size()) {
                 center /= mol->_atoms.size();
+            }
 
             foreach (sketcherMinimizerAtom* at, mol->_atoms) {
                 sketcherMinimizerPointF v = at->coordinates - center;
@@ -948,8 +1001,9 @@ void sketcherMinimizer::findFragments()
     assert(_molecules.size());
     foreach (sketcherMinimizerMolecule* mol, _molecules) {
         CoordgenFragmenter::splitIntoFragments(mol);
-        if (!mol->_fragments.size())
+        if (!mol->_fragments.size()) {
             continue;
+        }
         vector<sketcherMinimizerFragment*> fragments = mol->_fragments;
         _fragments.reserve(_fragments.size() + fragments.size());
         _fragments.insert(_fragments.end(), fragments.begin(), fragments.end());
@@ -1253,8 +1307,9 @@ float sketcherMinimizer::getResidueDistance(
             }
             totalF += increment * result;
         }
-        if (res == resToConsider)
+        if (res == resToConsider) {
             break;
+        }
         lastRes = res;
     }
     return totalF;
@@ -1280,10 +1335,11 @@ float sketcherMinimizer::scoreSSEPosition(
             residuePosition = -1;
             residueCoordinates = res->coordinates;
         } else {
-            if (!penalties[index])
+            if (!penalties[index]) {
                 residuePosition = 0;
-            else
+            } else {
                 residuePosition = 1;
+            }
         }
         if (residuePosition != -1) {
             score += scoreResiduePosition(index, shape, shapeN, penalties, res);
@@ -1326,8 +1382,9 @@ void sketcherMinimizer::placeSSE(const vector<sketcherMinimizerResidue*>& SSE,
         float distance = 5.f / shape.size();
         for (float increment = -1 * distance; increment <= 1 * distance;
              increment += distance) {
-            if (increment == 0)
+            if (increment == 0) {
                 continue;
+            }
             float score =
                 scoreSSEPosition(SSE, shape, shapeN, penalties, f, increment);
             scoredSolutions.emplace_back(score, Solution(f, increment));
@@ -1337,8 +1394,9 @@ void sketcherMinimizer::placeSSE(const vector<sketcherMinimizerResidue*>& SSE,
         min_element(scoredSolutions.begin(), scoredSolutions.end());
     set<sketcherMinimizerResidue*> alreadyPlaced;
     for (auto residue : SSE) {
-        if (residue->coordinatesSet)
+        if (residue->coordinatesSet) {
             continue; // placed in a previous crown
+        }
         float f = getResidueDistance(bestResult->second.first,
                                      bestResult->second.second, residue, SSE);
         int index = getShapeIndex(shape, f);
@@ -1356,8 +1414,9 @@ void sketcherMinimizer::placeSSE(const vector<sketcherMinimizerResidue*>& SSE,
     // mark the current solution to prevent other residues from being placed on
     // top of these
     markSolution(bestResult->second, SSE, shape, penalties, outliers);
-    for (auto res : alreadyPlaced)
+    for (auto res : alreadyPlaced) {
         res->coordinatesSet = true;
+    }
     for (auto res : SSE) {
         if (res->m_isWaterMap && res->m_isClashing && res->coordinatesSet &&
             res->m_closestLigandAtom != nullptr) {
@@ -1521,8 +1580,9 @@ vector<sketcherMinimizerPointF> sketcherMinimizer::shapeAroundLigand(int crownN)
                 auto vect = a->coordinates - p;
                 float D = vect.length();
                 D -= dist + border;
-                if (D < shortestD || shortestD < 0)
+                if (D < shortestD || shortestD < 0) {
                     shortestD = D;
+                }
             }
 
             for (auto b : bonds) {
@@ -1540,8 +1600,9 @@ vector<sketcherMinimizerPointF> sketcherMinimizer::shapeAroundLigand(int crownN)
                              distance2 * (1 - distancePercentage);
                 D -= dist + border;
 
-                if (D < shortestD)
+                if (D < shortestD) {
                     shortestD = D;
+                }
             }
 
             ms.setValue(shortestD, i, j);
@@ -1573,8 +1634,9 @@ float sketcherMinimizer::scoreResiduePosition(
     float clashingLigandAtomsPenalty = 100.f;
     vector<sketcherMinimizerAtom*> targets;
     for (auto interactionPartner : residue->residueInteractionPartners) {
-        if (interactionPartner->coordinatesSet)
+        if (interactionPartner->coordinatesSet) {
             targets.push_back(interactionPartner);
+        }
     }
     float interactionsF = 1.f;
     if (targets.empty() && residue->m_closestLigandAtom != nullptr) {
@@ -1585,8 +1647,9 @@ float sketcherMinimizer::scoreResiduePosition(
     for (auto target : targets) {
         int clashingLigandAtoms = 0;
         for (auto ligandAtom : _atoms) {
-            if (ligandAtom == target)
+            if (ligandAtom == target) {
                 continue;
+            }
             auto ligandAtomPos = ligandAtom->coordinates;
             float squareDist =
                 sketcherMinimizerMaths::squaredDistancePointSegment(
@@ -1686,8 +1749,9 @@ sketcherMinimizer::exploreMolPosition(sketcherMinimizerMolecule* mol,
             sketcherMinimizerPointF(-((1 + i) * gridD), -((1 + i) * gridD)));
 
         bool noClash = true;
-        if (distanceFromAtoms < 0)
+        if (distanceFromAtoms < 0) {
             distanceFromAtoms = bondLength * 1.8;
+        }
         float dist = distanceFromAtoms;
 
         for (const auto& pc : pointstoTest) {
@@ -1696,10 +1760,12 @@ sketcherMinimizer::exploreMolPosition(sketcherMinimizerMolecule* mol,
             foreach (sketcherMinimizerAtom* at, mol->_atoms) {
                 sketcherMinimizerPointF placeNextTo = at->coordinates + v;
                 foreach (sketcherMinimizerMolecule* m, _molecules) {
-                    if (!m->isPlaced)
+                    if (!m->isPlaced) {
                         continue;
-                    if (m == mol)
+                    }
+                    if (m == mol) {
                         continue;
+                    }
                     foreach (sketcherMinimizerAtom* a, m->_atoms) {
                         dist = distanceFromAtoms;
 
@@ -1712,18 +1778,22 @@ sketcherMinimizer::exploreMolPosition(sketcherMinimizerMolecule* mol,
                         }
                     }
 
-                    if (!noClash)
+                    if (!noClash) {
                         break;
+                    }
                 }
 
-                if (!noClash)
+                if (!noClash) {
                     break;
+                }
             }
-            if (noClash)
+            if (noClash) {
                 break;
+            }
         }
-        if (noClash)
+        if (noClash) {
             break;
+        }
     }
     return v;
 }
@@ -1787,8 +1857,9 @@ sketcherMinimizerPointF sketcherMinimizer::exploreGridAround(
             sketcherMinimizerPointF(-((1 + i) * gridD), -((1 + i) * gridD)));
 
         bool noClash = true;
-        if (distanceFromAtoms < 0)
+        if (distanceFromAtoms < 0) {
             distanceFromAtoms = bondLength * 1.8;
+        }
         float distanceFromResidues = bondLength * 1.3;
         float watermapDistance = 10;
         float dist = distanceFromAtoms;
@@ -1801,16 +1872,19 @@ sketcherMinimizerPointF sketcherMinimizer::exploreGridAround(
             placeNextTo = point.y() * direction + point.x() * directionNormal +
                           centerOfGrid;
             foreach (sketcherMinimizerMolecule* m, _molecules) {
-                if (!m->isPlaced)
+                if (!m->isPlaced) {
                     continue;
+                }
                 foreach (sketcherMinimizerAtom* a, m->_atoms) {
-                    if (a->isResidue())
+                    if (a->isResidue()) {
                         dist = distanceFromResidues;
-                    else
+                    } else {
                         dist = distanceFromAtoms;
+                    }
                     if (watermap) {
-                        if (!a->isResidue())
+                        if (!a->isResidue()) {
                             continue;
+                        }
                         dist = watermapDistance;
                     }
                     if (((a->coordinates.x() < placeNextTo.x() + dist + dx) &&
@@ -1858,15 +1932,18 @@ sketcherMinimizerPointF sketcherMinimizer::exploreGridAround(
                     }
                 }
 
-                if (!noClash)
+                if (!noClash) {
                     break;
+                }
             }
 
-            if (noClash)
+            if (noClash) {
                 break;
+            }
         }
-        if (noClash)
+        if (noClash) {
             break;
+        }
     }
     return placeNextTo;
 }
@@ -1910,8 +1987,9 @@ vector<proximityData> sketcherMinimizer::buildProximityDataVector(
             }
         }
         for (unsigned int i = 0; i < centers.size(); i++) {
-            if (counters[i] > 0)
+            if (counters[i] > 0) {
                 centers[i] /= counters[i];
+            }
             additionVectors[i].normalize();
         }
         data.additionVectors = additionVectors;
@@ -1935,8 +2013,9 @@ void sketcherMinimizer::rotateMoleculesWithProximityRelations(
             proximityDataVector[m].additionVectors;
         vector<sketcherMinimizerPointF> centers =
             proximityDataVector[m].centers;
-        if (mol->_atoms.size() < 2)
+        if (mol->_atoms.size() < 2) {
             continue;
+        }
 
         sketcherMinimizerPointF direction(1, 0);
         if (metaAtom->bonds.size() == 1) {
@@ -1991,14 +2070,17 @@ void sketcherMinimizer::translateMoleculesWithProximityRelations(
     do {
         cleverPlacing = !cleverPlacing; // alternatively try to be smart aboout
                                         // single atom mols
-        if (!cleverPlacing)
+        if (!cleverPlacing) {
             counterN++;
+        }
 
         for (auto mol : proximityMols) {
             bool residue = false;
-            if (mol->_atoms.size() == 1)
-                if (mol->_atoms[0]->isResidue())
+            if (mol->_atoms.size() == 1) {
+                if (mol->_atoms[0]->isResidue()) {
                     residue = true;
+                }
+            }
             if (!residue) {
                 if (mol->hasConstrainedFragments) {
                     mol->isPlaced = true;
@@ -2024,8 +2106,9 @@ void sketcherMinimizer::translateMoleculesWithProximityRelations(
                         atomsN++;
                     }
                 }
-                if (atomsN > 0)
+                if (atomsN > 0) {
                     atomsCenter /= atomsN;
+                }
 
                 /* positioning */
                 sketcherMinimizerPointF placeNextTo = templateCenters[mol];
@@ -2052,8 +2135,9 @@ void sketcherMinimizer::translateMoleculesWithProximityRelations(
                                 pr->endAtom->molecule != mol) {
                                 sketcherMinimizerPointF addV =
                                     pr->endAtom->getSingleAdditionVector();
-                                if (addV.length() < SKETCHER_EPSILON)
+                                if (addV.length() < SKETCHER_EPSILON) {
                                     continue;
+                                }
                                 addV.normalize();
                                 addV *= bondLength * counterN;
                                 coords += pr->endAtom->coordinates + addV;
@@ -2062,8 +2146,9 @@ void sketcherMinimizer::translateMoleculesWithProximityRelations(
                                        pr->startAtom->molecule != mol) {
                                 sketcherMinimizerPointF addV =
                                     pr->startAtom->getSingleAdditionVector();
-                                if (addV.length() < SKETCHER_EPSILON)
+                                if (addV.length() < SKETCHER_EPSILON) {
                                     continue;
+                                }
 
                                 addV.normalize();
                                 addV *= bondLength * counterN;
@@ -2119,8 +2204,9 @@ void sketcherMinimizer::placeMoleculesWithProximityRelations(
     }
 
     foreach (sketcherMinimizerBond* b, m_proximityRelations) {
-        if (b->startAtom->molecule == b->endAtom->molecule)
+        if (b->startAtom->molecule == b->endAtom->molecule) {
             continue;
+        }
         sketcherMinimizerAtom* at1 = molMap[b->startAtom->molecule];
         sketcherMinimizerAtom* at2 = molMap[b->endAtom->molecule];
         bool found = false;
@@ -2168,23 +2254,26 @@ void sketcherMinimizer::placeMoleculesWithProximityRelations(
     sketcherMinimizerMolecule* centralMol = proximityMols[0];
     foreach (sketcherMinimizerMolecule* mol, proximityMols) {
         if (mol->m_proximityRelations.size() >
-            centralMol->m_proximityRelations.size())
+            centralMol->m_proximityRelations.size()) {
             centralMol = mol;
-        else if (mol->m_proximityRelations.size() ==
-                     centralMol->m_proximityRelations.size() &&
-                 mol->_atoms.size() > centralMol->_atoms.size())
+        } else if (mol->m_proximityRelations.size() ==
+                       centralMol->m_proximityRelations.size() &&
+                   mol->_atoms.size() > centralMol->_atoms.size()) {
             centralMol = mol;
+        }
     }
-    if (centralMol->_atoms.size() < MINIMUM_LIGAND_ATOMS)
+    if (centralMol->_atoms.size() < MINIMUM_LIGAND_ATOMS) {
         ligandResidueStyle = false;
+    }
     map<sketcherMinimizerMolecule*, sketcherMinimizerPointF> templateCenters;
 
     foreach (sketcherMinimizerMolecule* mol, proximityMols) {
         sketcherMinimizerPointF point(0, 0);
 
         sketcherMinimizerAtom* at = molMap[mol];
-        if (at)
+        if (at) {
             point = at->coordinates;
+        }
         templateCenters[mol] = point;
     }
 
@@ -2196,14 +2285,16 @@ void sketcherMinimizer::placeMoleculesWithProximityRelations(
         while (q.size()) {
             sketcherMinimizerMolecule* mol = q.front();
             q.pop();
-            if (mol->isPlaced)
+            if (mol->isPlaced) {
                 continue;
+            }
             if (mol == centralMol) {
                 mol->isPlaced = true;
             } else {
                 sketcherMinimizerMolecule* parent = getParent[mol];
-                if (parent != nullptr)
+                if (parent != nullptr) {
                     placeMolResidueLigandStyle(mol, parent);
+                }
             }
             foreach (sketcherMinimizerBond* b, mol->m_proximityRelations) {
                 if (!b->startAtom->molecule
@@ -2257,8 +2348,9 @@ void sketcherMinimizer::placeMolResidueLigandStyle(
             at = b->startAtom;
             parentAt = b->endAtom;
         }
-        if (at == nullptr || parentAt == nullptr)
+        if (at == nullptr || parentAt == nullptr) {
             continue;
+        }
         n++;
         sketcherMinimizerPointF paddV = parentAt->getSingleAdditionVector();
         if (b->isResidueInteraction()) {
@@ -2326,11 +2418,13 @@ void sketcherMinimizer::flipIfCrossingInteractions(
             continue;
         }
         if (!(pr1->startAtom->molecule->isPlaced ||
-              pr1->startAtom->molecule == mol))
+              pr1->startAtom->molecule == mol)) {
             continue;
+        }
         if (!(pr1->endAtom->molecule->isPlaced ||
-              pr1->endAtom->molecule == mol))
+              pr1->endAtom->molecule == mol)) {
             continue;
+        }
 
         for (unsigned int bb2 = bb + 1; bb2 < mol->m_proximityRelations.size();
              bb2++) {
@@ -2339,11 +2433,13 @@ void sketcherMinimizer::flipIfCrossingInteractions(
                 continue;
             }
             if (!(pr2->startAtom->molecule->isPlaced ||
-                  pr2->startAtom->molecule == mol))
+                  pr2->startAtom->molecule == mol)) {
                 continue;
+            }
             if (!(pr2->endAtom->molecule->isPlaced ||
-                  pr2->endAtom->molecule == mol))
+                  pr2->endAtom->molecule == mol)) {
                 continue;
+            }
 
             if (sketcherMinimizerMaths::intersectionOfSegments(
                     pr1->startAtom->coordinates, pr1->endAtom->coordinates,
@@ -2351,15 +2447,17 @@ void sketcherMinimizer::flipIfCrossingInteractions(
                 /* mirror the coordinates */
                 sketcherMinimizerAtom* p1 = nullptr;
                 sketcherMinimizerAtom* p2 = nullptr;
-                if (pr1->startAtom->molecule == mol)
+                if (pr1->startAtom->molecule == mol) {
                     p1 = pr1->startAtom;
-                else if (pr1->endAtom->molecule == mol)
+                } else if (pr1->endAtom->molecule == mol) {
                     p1 = pr1->endAtom;
+                }
 
-                if (pr2->startAtom->molecule == mol)
+                if (pr2->startAtom->molecule == mol) {
                     p2 = pr2->startAtom;
-                else if (pr2->endAtom->molecule == mol)
+                } else if (pr2->endAtom->molecule == mol) {
                     p2 = pr2->endAtom;
+                }
                 if (p1 && p2) {
                     sketcherMinimizerPointF middleP =
                         p1->coordinates + p2->coordinates;
@@ -2385,8 +2483,9 @@ void sketcherMinimizer::flipIfCrossingInteractions(
                 }
             }
         }
-        if (out)
+        if (out) {
             break;
+        }
     }
 }
 
@@ -2434,20 +2533,26 @@ void sketcherMinimizer::arrangeMultipleMolecules()
             foundCounterion = false;
             foreach (sketcherMinimizerMolecule* mol, _molecules) {
                 bool residue = false;
-                if (mol->_atoms.size() == 1)
-                    if (mol->_atoms[0]->isResidue())
+                if (mol->_atoms.size() == 1) {
+                    if (mol->_atoms[0]->isResidue()) {
                         residue = true;
-                if (!residue) {
-                    if (mol->hasConstrainedFragments)
-                        mol->isPlaced = true;
+                    }
                 }
-                if (mol->hasFixedFragments)
+                if (!residue) {
+                    if (mol->hasConstrainedFragments) {
+                        mol->isPlaced = true;
+                    }
+                }
+                if (mol->hasFixedFragments) {
                     mol->isPlaced = true;
+                }
 
-                if (mol->isPlaced)
+                if (mol->isPlaced) {
                     continue;
-                if (residue)
+                }
+                if (residue) {
                     continue;
+                }
                 int charge = mol->totalCharge();
                 if (charge == 0) {
                     sketcherMinimizerPointF counterionMin, counterionMax;
@@ -2484,8 +2589,9 @@ void sketcherMinimizer::arrangeMultipleMolecules()
         while (foundCounterion) {
             foundCounterion = false;
             foreach (sketcherMinimizerMolecule* mol, _molecules) {
-                if (mol->isPlaced)
+                if (mol->isPlaced) {
                     continue;
+                }
                 int charge = mol->totalCharge();
                 if (charge != 0) {
                     sketcherMinimizerPointF counterionMin, counterionMax;
@@ -2505,13 +2611,16 @@ void sketcherMinimizer::arrangeMultipleMolecules()
 
                     foreach (sketcherMinimizerMolecule* m, _molecules) {
                         bool found = false;
-                        if (!m->isPlaced)
+                        if (!m->isPlaced) {
                             continue;
+                        }
                         foreach (sketcherMinimizerAtom* a, m->_atoms) {
-                            if (a->charge == 0)
+                            if (a->charge == 0) {
                                 continue;
-                            if (a->_generalUseVisited)
+                            }
+                            if (a->_generalUseVisited) {
                                 continue;
+                            }
                             if (a->charge * charge < 0) {
                                 a->_generalUseVisited = true;
                                 placeNextTo = a->coordinates;
@@ -2519,8 +2628,9 @@ void sketcherMinimizer::arrangeMultipleMolecules()
                                 break;
                             }
                         }
-                        if (found)
+                        if (found) {
                             break;
+                        }
                     }
 
                     // explore a grid around placeNextTo to find a suitable
@@ -2543,8 +2653,9 @@ void sketcherMinimizer::arrangeMultipleMolecules()
         }
         vector<sketcherMinimizerAtom*> ligandAtoms;
         foreach (sketcherMinimizerAtom* a, _atoms)
-            if (a->m_isLigand)
+            if (a->m_isLigand) {
                 ligandAtoms.push_back(a);
+            }
         placeResidues(ligandAtoms);
     }
 }
@@ -2603,8 +2714,9 @@ sketcherMinimizer::getAllTerminalBonds(sketcherMinimizerFragment* fragment)
 {
     vector<sketcherMinimizerBond*> bonds;
     for (auto bond : fragment->getBonds()) {
-        if (bond->isResidueInteraction())
+        if (bond->isResidueInteraction()) {
             continue;
+        }
         if (bond->startAtom->neighbors.size() == 1 ||
             bond->endAtom->neighbors.size() == 1) {
             bonds.push_back(bond);
@@ -2632,15 +2744,17 @@ sketcherMinimizer::findDirectionsToAlignWith(
     vector<sketcherMinimizerBond*> parentEndBonds =
         getAllTerminalBonds(fragment->getParent());
     for (auto bond : parentEndBonds) {
-        if (bond->endAtom->fragment == fragment)
+        if (bond->endAtom->fragment == fragment) {
             continue;
+        }
         sketcherMinimizerPointF direction =
             origin -
             (bond->startAtom->coordinates + bond->endAtom->coordinates) * 0.5;
         direction.normalize();
         float score = 1.f;
-        if (bond->bondOrder == 2)
+        if (bond->bondOrder == 2) {
             score *= SCORE_MULTIPLIER_FOR_DOUBLE_BONDS;
+        }
         if ((bond->startAtom->neighbors.size() == 1 &&
              bond->startAtom->atomicNumber != 6) ||
             (bond->endAtom->neighbors.size() == 1 &&
@@ -2667,11 +2781,13 @@ float sketcherMinimizer::testAlignment(
     const std::pair<sketcherMinimizerPointF, float>& templat)
 {
     float dot = sketcherMinimizerMaths::dotProduct(direction, templat.first);
-    if (dot < 0)
+    if (dot < 0) {
         dot = 0;
+    }
     float score = dot * dot;
-    if (dot > 1 - SKETCHER_EPSILON)
+    if (dot > 1 - SKETCHER_EPSILON) {
         score += 1000;
+    }
     score *= templat.second;
     return score;
 }
@@ -2688,8 +2804,9 @@ sketcherMinimizerPointF sketcherMinimizer::scoreDirections(
     vector<sketcherMinimizerBond*> terminalBonds =
         getAllTerminalBonds(fragment);
     for (auto bond : terminalBonds) {
-        if (bond->startAtom->fragment != fragment)
+        if (bond->startAtom->fragment != fragment) {
             continue;
+        }
         sketcherMinimizerPointF bondDirectionPlain =
             (fragment->_coordinates[bond->startAtom] +
              fragment->_coordinates[bond->endAtom]) *
@@ -2701,8 +2818,9 @@ sketcherMinimizerPointF sketcherMinimizer::scoreDirections(
         bondDirectionPlain.rotate(sine, cosine);
         bondDirectionInverted.rotate(sine, cosine);
         float scoreModifier = 1.f;
-        if (bond->bondOrder == 2)
+        if (bond->bondOrder == 2) {
             scoreModifier *= SCORE_MULTIPLIER_FOR_DOUBLE_BONDS;
+        }
         if ((bond->startAtom->neighbors.size() == 1 &&
              bond->startAtom->atomicNumber != 6) ||
             (bond->endAtom->neighbors.size() == 1 &&
@@ -2749,8 +2867,9 @@ void sketcherMinimizer::alignWithParentDirection(
 {
     // deciding which "side" the fragment will be drawn, rotating 180° around
     // the axis of its bond to parent
-    if (f->fixed)
+    if (f->fixed) {
         return;
+    }
     bool invert = (f->constrained
                        ? alignWithParentDirectionConstrained(f, position, angle)
                        : alignWithParentDirectionUnconstrained(f, angle));
@@ -2807,8 +2926,9 @@ sketcherMinimizer::getBond(const sketcherMinimizerAtom* a1,
                            const sketcherMinimizerAtom* a2)
 {
     for (unsigned int i = 0; i < a1->neighbors.size(); i++) {
-        if (a1->neighbors[i] == a2)
+        if (a1->neighbors[i] == a2) {
             return a1->bonds[i];
+        }
     }
     return nullptr;
 }
@@ -2831,8 +2951,9 @@ sketcherMinimizer::pickBestAtom(vector<sketcherMinimizerAtom*>& atoms)
                 candidates.push_back(a);
             }
         }
-        if (candidates.size() == 1)
+        if (candidates.size() == 1) {
             return candidates[0];
+        }
         oldCandidates = candidates;
         candidates.clear();
     }
@@ -2850,8 +2971,9 @@ sketcherMinimizer::pickBestAtom(vector<sketcherMinimizerAtom*>& atoms)
                 candidates.push_back(a);
             }
         }
-        if (candidates.size() == 1)
+        if (candidates.size() == 1) {
             return candidates[0];
+        }
         oldCandidates = candidates;
         candidates.clear();
     }
@@ -2868,8 +2990,9 @@ sketcherMinimizer::pickBestAtom(vector<sketcherMinimizerAtom*>& atoms)
                 candidates.push_back(a);
             }
         }
-        if (candidates.size() == 1)
+        if (candidates.size() == 1) {
             return candidates[0];
+        }
         oldCandidates = candidates;
         candidates.clear();
     }
@@ -2902,8 +3025,9 @@ void sketcherMinimizer::fixAtoms(const vector<bool>& fixed)
 {
     if (fixed.size() == _referenceAtoms.size()) {
         for (unsigned int i = 0; i < fixed.size(); i++) {
-            if (fixed[i])
+            if (fixed[i]) {
                 _referenceAtoms[i]->fixed = true;
+            }
         }
     } else {
         cerr << "warning, wrong size of vector for fixed atoms. Ignoring"
@@ -2936,8 +3060,9 @@ void sketcherMinimizer::findClosestAtomToResidues(
         }
         static_cast<sketcherMinimizerResidue*>(r)->m_closestLigandAtom =
             closestA;
-        if (!r->m_isClashing)
+        if (!r->m_isClashing) {
             r->m_isClashing = (squareD < RESIDUE_CLASH_DISTANCE_SQUARED);
+        }
     }
     foreach (sketcherMinimizerBond* b, _bonds) {
         if (b->startAtom->isResidue()) {
@@ -3071,10 +3196,12 @@ void sketcherMinimizer::svd(float* a, float* U, float* Sig, float* V)
     S[3] = roundToTwoDecimalDigits(S[3]);
 
     float sign1 = 1.f, sign2 = 1.f;
-    if (S[0] < 0.f)
+    if (S[0] < 0.f) {
         sign1 = -1.f;
-    if (S[3] < 0.f)
+    }
+    if (S[3] < 0.f) {
         sign2 = -1.f;
+    }
     float C[4];
 
     C[0] = sign1;
@@ -3097,14 +3224,16 @@ bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
                                 sketcherMinimizerMolecule* templ,
                                 vector<unsigned int>& mapping)
 {
-    if (atoms.size() != templ->_atoms.size())
+    if (atoms.size() != templ->_atoms.size()) {
         return false;
+    }
     vector<int> molScores, tempScores;
     int molIter = morganScores(atoms, bonds, molScores);
     int templateIter = morganScores(templ->_atoms, templ->_bonds, tempScores);
 
-    if (molIter != templateIter)
+    if (molIter != templateIter) {
         return false;
+    }
 
     size_t size = atoms.size();
     vector<bool> matrix(size * size, false);
@@ -3136,13 +3265,14 @@ bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
         if (bond->bondOrder == 2) {
 
             sketcherMinimizerBond* b = bond;
-            if (b->m_ignoreZE)
+            if (b->m_ignoreZE) {
                 continue;
+            }
 
             bool ok = false;
-            if (b->rings.size() == 0)
+            if (b->rings.size() == 0) {
                 ok = true;
-            else {
+            } else {
                 ok = true;
                 for (auto& ring : b->rings) {
                     if (ring->_atoms.size() < MACROCYCLE) {
@@ -3150,16 +3280,18 @@ bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
                     }
                 }
             }
-            if (!ok)
+            if (!ok) {
                 continue;
+            }
             sketcherMinimizerAtom* startA = b->startAtomCIPFirstNeighbor();
             sketcherMinimizerAtom* endA = b->endAtomCIPFirstNeighbor();
 
             sketcherMinimizerAtom* startN = nullptr;
             sketcherMinimizerAtom* endN = nullptr;
             for (unsigned int i = 0; i < b->startAtom->neighbors.size(); i++) {
-                if (b->startAtom->neighbors[i] == b->endAtom)
+                if (b->startAtom->neighbors[i] == b->endAtom) {
                     continue;
+                }
                 bool found = false;
                 for (auto atom : atoms) {
                     if (atom == b->startAtom->neighbors[i]) {
@@ -3173,8 +3305,9 @@ bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
                 }
             }
             for (unsigned int i = 0; i < b->endAtom->neighbors.size(); i++) {
-                if (b->endAtom->neighbors[i] == b->startAtom)
+                if (b->endAtom->neighbors[i] == b->startAtom) {
                     continue;
+                }
                 bool found = false;
                 for (auto atom : atoms) {
                     if (atom == b->endAtom->neighbors[i]) {
@@ -3190,10 +3323,12 @@ bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
 
             if (startN && endN && startA && endA) {
                 bool isCis = b->isZ;
-                if (startN != startA)
+                if (startN != startA) {
                     isCis = !isCis;
-                if (endN != endA)
+                }
+                if (endN != endA) {
                     isCis = !isCis;
+                }
                 vector<size_t> chain;
                 chain.push_back(startN->_generalUseN);
                 chain.push_back(b->startAtom->_generalUseN);
@@ -3235,13 +3370,15 @@ bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
     bool found = false;
     vector<unsigned int> solution;
     for (unsigned int i = 0; i < size; i++) {
-        if (!matrix[i])
+        if (!matrix[i]) {
             continue;
+        }
         checkIdentity(solution, i, matrix, templateCoordinates, molBonds,
                       templateBonds, molCisTransChains, molIsCis, size, found,
                       mapping);
-        if (found)
+        if (found) {
             break;
+        }
     }
     return found;
 }
@@ -3281,10 +3418,12 @@ void sketcherMinimizer::checkIdentity(
         }
     } else {
         for (unsigned int i = 0; i < size; i++) {
-            if (found)
+            if (found) {
                 break;
-            if (!(matrix[solution.size() * size + i]))
+            }
+            if (!(matrix[solution.size() * size + i])) {
                 continue;
+            }
             bool check = true;
             for (unsigned int ss : solution) {
                 if (ss == i) {
@@ -3306,15 +3445,17 @@ void sketcherMinimizer::checkIdentity(
                             break;
                         }
                     }
-                    if (check == false)
+                    if (check == false) {
                         break;
+                    }
                 }
             }
 
-            if (check)
+            if (check) {
                 checkIdentity(solution, i, matrix, templateCoordinates,
                               molBonds, templateBonds, molCisTransChains,
                               molIsCis, size, found, mapping);
+            }
         }
     }
 }
@@ -3391,8 +3532,9 @@ static void loadTemplate(const string& filename,
 void sketcherMinimizer::loadTemplates()
 {
     static int loaded = 0;
-    if (loaded || m_templates.getTemplates().size())
+    if (loaded || m_templates.getTemplates().size()) {
         return;
+    }
     string filename = getTempFileProjDir() + "templates.mae";
 
     loadTemplate(filename, m_templates.getTemplates());
@@ -3408,8 +3550,9 @@ int sketcherMinimizer::morganScores(const vector<sketcherMinimizerAtom*>& atoms,
                                     vector<int>& oldScores)
 {
     // assumes that atom[i]->_generalUseN = i
-    if (atoms.size() < 2)
+    if (atoms.size() < 2) {
         return 0;
+    }
     oldScores = vector<int>(atoms.size(), 1);
     vector<int> newScores(atoms.size(), 0);
     vector<int> orderedScores;
@@ -3431,15 +3574,17 @@ int sketcherMinimizer::morganScores(const vector<sketcherMinimizerAtom*>& atoms,
         stable_sort(orderedScores.begin(), orderedScores.end());
         newTies = 0;
         for (j = 1; j < orderedScores.size(); j++) {
-            if (orderedScores[j] == orderedScores[j - 1])
+            if (orderedScores[j] == orderedScores[j - 1]) {
                 newTies++;
+            }
         }
         if (newTies < oldTies) {
             goOn = true;
             oldTies = newTies;
             oldScores = newScores;
-        } else
+        } else {
             goOn = false;
+        }
     } while (goOn);
     return n;
 }

--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -90,8 +90,8 @@ void sketcherMinimizer::canonicalOrdering(sketcherMinimizerMolecule* minMol)
             minMol->_atoms[i]->_generalUseN = i;
             minMol->_atoms[i]->_generalUseVisited = false;
         }
-        for (unsigned int i = 0; i < minMol->_bonds.size(); i++) {
-            minMol->_bonds[i]->_SSSRVisited = false;
+        for (auto& _bond : minMol->_bonds) {
+            _bond->_SSSRVisited = false;
         }
         bool found = true;
         do {
@@ -162,40 +162,37 @@ void sketcherMinimizer::initialize(
     _referenceAtoms = minMol->_atoms;
     _referenceBonds = minMol->_bonds;
 
-    for (unsigned int bb = 0; bb < minMol->_bonds.size(); bb++) {
-        if (minMol->_bonds[bb]->skip)
+    for (auto& _bond : minMol->_bonds) {
+        if (_bond->skip)
             continue;
-        if (minMol->_bonds[bb]->bondOrder == 1 ||
-            minMol->_bonds[bb]->bondOrder == 2) {
+        if (_bond->bondOrder == 1 || _bond->bondOrder == 2) {
             if (sketcherMinimizerAtom::isMetal(
-                    minMol->_bonds[bb]->startAtom->atomicNumber) ||
-                sketcherMinimizerAtom::isMetal(
-                    minMol->_bonds[bb]->endAtom->atomicNumber)) {
-                minMol->_bonds[bb]->bondOrder = 0;
+                    _bond->startAtom->atomicNumber) ||
+                sketcherMinimizerAtom::isMetal(_bond->endAtom->atomicNumber)) {
+                _bond->bondOrder = 0;
             }
         }
     }
 
-    for (unsigned int bb = 0; bb < minMol->_bonds.size(); bb++) {
-        if (minMol->_bonds[bb]->skip)
+    for (auto& _bond : minMol->_bonds) {
+        if (_bond->skip)
             continue;
-        if (minMol->_bonds[bb]->bondOrder == 0) {
-            m_proximityRelations.push_back(minMol->_bonds[bb]);
-        } else if (minMol->_bonds[bb]->isResidueInteraction()) {
-            if (!minMol->_bonds[bb]->startAtom->isResidue() &&
-                !minMol->_bonds[bb]->endAtom->isResidue())
-                m_proximityRelations.push_back(minMol->_bonds[bb]);
+        if (_bond->bondOrder == 0) {
+            m_proximityRelations.push_back(_bond);
+        } else if (_bond->isResidueInteraction()) {
+            if (!_bond->startAtom->isResidue() && !_bond->endAtom->isResidue())
+                m_proximityRelations.push_back(_bond);
         }
     }
-    for (unsigned int bb = 0; bb < m_extraBonds.size(); bb++) {
-        if (m_extraBonds[bb]->skip)
+    for (auto& m_extraBond : m_extraBonds) {
+        if (m_extraBond->skip)
             continue;
-        if (m_extraBonds[bb]->bondOrder == 0) {
-            m_proximityRelations.push_back(m_extraBonds[bb]);
-        } else if (m_extraBonds[bb]->isResidueInteraction()) {
-            if (!m_extraBonds[bb]->startAtom->isResidue() &&
-                !m_extraBonds[bb]->endAtom->isResidue())
-                m_proximityRelations.push_back(m_extraBonds[bb]);
+        if (m_extraBond->bondOrder == 0) {
+            m_proximityRelations.push_back(m_extraBond);
+        } else if (m_extraBond->isResidueInteraction()) {
+            if (!m_extraBond->startAtom->isResidue() &&
+                !m_extraBond->endAtom->isResidue())
+                m_proximityRelations.push_back(m_extraBond);
         }
     }
 
@@ -307,33 +304,33 @@ void sketcherMinimizer::flagCrossAtoms()
 
 void sketcherMinimizer::clear()
 {
-    for (unsigned int i = 0; i < _referenceAtoms.size(); i++) {
-        delete _referenceAtoms[i];
+    for (auto& _referenceAtom : _referenceAtoms) {
+        delete _referenceAtom;
     }
     _referenceAtoms.clear();
     _residues.clear();
 
-    for (unsigned int i = 0; i < _referenceBonds.size(); i++) {
-        delete _referenceBonds[i];
+    for (auto& _referenceBond : _referenceBonds) {
+        delete _referenceBond;
     }
 
     _referenceBonds.clear();
 
-    for (unsigned int i = 0; i < m_extraBonds.size(); i++) {
-        delete m_extraBonds[i];
+    for (auto& m_extraBond : m_extraBonds) {
+        delete m_extraBond;
     }
 
     m_extraBonds.clear();
 
-    for (unsigned int i = 0; i < _fragments.size(); i++) {
-        delete _fragments[i];
+    for (auto& _fragment : _fragments) {
+        delete _fragment;
     }
 
     _fragments.clear();
 
-    for (unsigned int i = 0; i < _molecules.size(); i++) {
+    for (auto& _molecule : _molecules) {
 
-        delete _molecules[i];
+        delete _molecule;
     }
 
     _molecules.clear();
@@ -382,7 +379,7 @@ void sketcherMinimizer::splitIntoMolecules(
         }
 
     } else {
-        sketcherMinimizerMolecule* newMol = new sketcherMinimizerMolecule;
+        auto* newMol = new sketcherMinimizerMolecule;
         for (unsigned int i = 0; i < mol->_rings.size(); i++) {
 
             if (!mol->_rings[i]->_atoms[0]->_generalUseVisited) {
@@ -425,12 +422,12 @@ sketcherMinimizer::sameRing(const sketcherMinimizerAtom* at1,
                             const sketcherMinimizerAtom* at3)
 {
     if (!at1->rings.size())
-        return NULL;
+        return nullptr;
     if (!at2->rings.size())
-        return NULL;
+        return nullptr;
     if (!at3->rings.size())
-        return NULL;
-    sketcherMinimizerRing* r = 0;
+        return nullptr;
+    sketcherMinimizerRing* r = nullptr;
     foreach (sketcherMinimizerRing* ring, at1->rings) {
         if (ring->isMacrocycle())
             continue;
@@ -479,10 +476,10 @@ void sketcherMinimizer::assignPseudoZ()
         foreach (sketcherMinimizerAtom* a, mol->_atoms) {
             a->_generalUseVisited = false;
         }
-        sketcherMinimizerAtom* lastAtom = NULL;
+        sketcherMinimizerAtom* lastAtom = nullptr;
         bool finished = false;
         while (!finished) {
-            lastAtom = NULL;
+            lastAtom = nullptr;
             foreach (sketcherMinimizerAtom* a, mol->_atoms) {
                 if (!a->_generalUseVisited) {
                     lastAtom = a;
@@ -720,7 +717,7 @@ void sketcherMinimizer::addToVector(float weight, float angle,
     for (unsigned int i = 0; i < angles.size(); i++) {
         if (angles[i].second < angle - SKETCHER_EPSILON) {
             if (i == angles.size() - 1) {
-                angles.push_back(pair<float, float>(weight, angle));
+                angles.emplace_back(weight, angle);
                 break;
             }
         } else if (angles[i].second - angle < SKETCHER_EPSILON &&
@@ -734,7 +731,7 @@ void sketcherMinimizer::addToVector(float weight, float angle,
         }
     }
     if (!angles.size())
-        angles.push_back(pair<float, float>(weight, angle));
+        angles.emplace_back(weight, angle);
 }
 
 /* if a peptide chain is present rotate the molecule so it's horizontal */
@@ -775,7 +772,7 @@ void sketcherMinimizer::bestRotation()
         float lastAngle;
         unsigned int i = 0, j = 0;
         float weight = 1.f;
-        float increment = static_cast<float>(M_PI / 6);
+        auto increment = static_cast<float>(M_PI / 6);
         foreach (sketcherMinimizerAtom* a, mol->_atoms) {
             if (a->rings.size())
                 continue;
@@ -897,9 +894,7 @@ void sketcherMinimizer::bestRotation()
                     }
                 }
                 foreach (sketcherMinimizerRing* r, rings) {
-                    for (unsigned int i = 0; i < r->fusionAtoms.size(); i++) {
-                        vector<sketcherMinimizerAtom*> fusionAts =
-                            r->fusionAtoms[i];
+                    for (auto fusionAts : r->fusionAtoms) {
                         if (fusionAts.size() == 2) {
                             sketcherMinimizerPointF p =
                                 fusionAts[0]->coordinates -
@@ -971,11 +966,11 @@ void sketcherMinimizer::placeResiduesProteinOnlyModeCircleStyle(
 {
     size_t totalResiduesNumber = _residues.size() + chains.size();
 
-    float angle = static_cast<float>(2.f * M_PI / totalResiduesNumber);
+    auto angle = static_cast<float>(2.f * M_PI / totalResiduesNumber);
     const float residueRadius = 30.f;
-    const float circumference =
+    const auto circumference =
         static_cast<float>(totalResiduesNumber * residueRadius * 2);
-    const float radius = static_cast<float>(circumference * 0.5 / M_PI);
+    const auto radius = static_cast<float>(circumference * 0.5 / M_PI);
     int i = 0;
     for (auto chain : chains) {
         ++i; // gap between chains
@@ -1006,9 +1001,9 @@ sketcherMinimizer::computeChainsStartingPositionsMetaMol(
 {
     map<std::string, sketcherMinimizerAtom*> molMap;
 
-    sketcherMinimizerMolecule* metaMol = new sketcherMinimizerMolecule;
+    auto* metaMol = new sketcherMinimizerMolecule;
     for (auto chainPair : chains) {
-        sketcherMinimizerAtom* a = new sketcherMinimizerAtom;
+        auto* a = new sketcherMinimizerAtom;
         a->molecule = metaMol;
         metaMol->_atoms.push_back(a);
         molMap[chainPair.first] = a;
@@ -1019,12 +1014,10 @@ sketcherMinimizer::computeChainsStartingPositionsMetaMol(
             for (auto interaction : residue->residueInteractions) {
                 if (interaction->startAtom->isResidue() &&
                     interaction->endAtom->isResidue()) {
-                    sketcherMinimizerResidue* r1 =
-                        static_cast<sketcherMinimizerResidue*>(
-                            interaction->startAtom);
-                    sketcherMinimizerResidue* r2 =
-                        static_cast<sketcherMinimizerResidue*>(
-                            interaction->endAtom);
+                    auto* r1 = static_cast<sketcherMinimizerResidue*>(
+                        interaction->startAtom);
+                    auto* r2 = static_cast<sketcherMinimizerResidue*>(
+                        interaction->endAtom);
                     if (r1->chain != r2->chain) {
                         // add a bond to the metaMol if it doesn't exist already
                         sketcherMinimizerAtom* at1 = molMap[r1->chain];
@@ -1038,8 +1031,7 @@ sketcherMinimizer::computeChainsStartingPositionsMetaMol(
                             }
                         }
                         if (!found) {
-                            sketcherMinimizerBond* newBond =
-                                new sketcherMinimizerBond;
+                            auto* newBond = new sketcherMinimizerBond;
                             newBond->startAtom = at1;
                             newBond->endAtom = at2;
                             metaMol->_bonds.push_back(newBond);
@@ -1113,7 +1105,7 @@ std::vector<sketcherMinimizerResidue*> sketcherMinimizer::orderResiduesOfChains(
             finalVec.push_back(topResidue);
             residueQueue.pop();
             for (auto partner : topResidue->residueInteractionPartners) {
-                sketcherMinimizerResidue* partnerRes =
+                auto* partnerRes =
                     static_cast<sketcherMinimizerResidue*>(partner);
                 if (visitedResidues.find(partnerRes) == visitedResidues.end()) {
                     residueQueue.push(partnerRes);
@@ -1140,7 +1132,7 @@ void sketcherMinimizer::placeResiduesProteinOnlyModeLIDStyle(
     auto residues = orderResiduesOfChains(chains);
     for (auto res : residues) {
         int partnersAlreadySet = 0;
-        sketcherMinimizerResidue* firstPartner = NULL;
+        sketcherMinimizerResidue* firstPartner = nullptr;
         for (auto partner : res->residueInteractionPartners) {
             if (partner->coordinatesSet) {
                 ++partnersAlreadySet;
@@ -1252,7 +1244,7 @@ float sketcherMinimizer::getResidueDistance(
     sketcherMinimizerResidue* lastRes = nullptr;
     for (auto res : SSE) {
         if (lastRes) {
-            float result = static_cast<float>(res->resnum - lastRes->resnum);
+            auto result = static_cast<float>(res->resnum - lastRes->resnum);
             /* if the gap is more than 1, make the distance a bit smaller for
              * aesthetic reasons */
             result = static_cast<float>(1 + (result - 1) * 0.8);
@@ -1338,8 +1330,7 @@ void sketcherMinimizer::placeSSE(const vector<sketcherMinimizerResidue*>& SSE,
                 continue;
             float score =
                 scoreSSEPosition(SSE, shape, shapeN, penalties, f, increment);
-            scoredSolutions.push_back(
-                pair<float, Solution>(score, Solution(f, increment)));
+            scoredSolutions.emplace_back(score, Solution(f, increment));
         }
     }
     auto bestResult =
@@ -1566,8 +1557,8 @@ vector<sketcherMinimizerPointF> sketcherMinimizer::shapeAroundLigand(int crownN)
     vector<sketcherMinimizerPointF> returnValue;
     if (result.size() > 0) {
         for (unsigned int i = 0; i < result.at(0).size(); i += 2) {
-            returnValue.push_back(sketcherMinimizerPointF(
-                result.at(0).at(i), result.at(0).at(i + 1)));
+            returnValue.emplace_back(result.at(0).at(i),
+                                     result.at(0).at(i + 1));
         }
     }
     return returnValue;
@@ -1699,9 +1690,9 @@ sketcherMinimizer::exploreMolPosition(sketcherMinimizerMolecule* mol,
             distanceFromAtoms = bondLength * 1.8;
         float dist = distanceFromAtoms;
 
-        for (unsigned int pc = 0; pc < pointstoTest.size(); pc++) {
+        for (const auto& pc : pointstoTest) {
             noClash = true;
-            v = pointstoTest[pc];
+            v = pc;
             foreach (sketcherMinimizerAtom* at, mol->_atoms) {
                 sketcherMinimizerPointF placeNextTo = at->coordinates + v;
                 foreach (sketcherMinimizerMolecule* m, _molecules) {
@@ -1804,9 +1795,9 @@ sketcherMinimizerPointF sketcherMinimizer::exploreGridAround(
 
         sketcherMinimizerPointF directionNormal(-direction.y(), direction.x());
         directionNormal.normalize();
-        for (unsigned int pc = 0; pc < pointstoTest.size(); pc++) {
+        for (const auto& pc : pointstoTest) {
             noClash = true;
-            sketcherMinimizerPointF point = pointstoTest[pc] - centerOfGrid;
+            sketcherMinimizerPointF point = pc - centerOfGrid;
             placeNextTo = point.y() * direction + point.x() * directionNormal +
                           centerOfGrid;
             foreach (sketcherMinimizerMolecule* m, _molecules) {
@@ -1896,8 +1887,8 @@ vector<proximityData> sketcherMinimizer::buildProximityDataVector(
             metaAtom->neighbors.size(), sketcherMinimizerPointF(0.f, 0.f));
         vector<int> counters(metaAtom->neighbors.size(), 0);
         foreach (sketcherMinimizerBond* pr, mol->m_proximityRelations) {
-            sketcherMinimizerAtom* otherMetaAtom = NULL;
-            sketcherMinimizerAtom* targetAtom = NULL;
+            sketcherMinimizerAtom* otherMetaAtom = nullptr;
+            sketcherMinimizerAtom* targetAtom = nullptr;
             if (pr->startAtom->molecule == mol &&
                 !(pr->endAtom->molecule == mol)) {
                 otherMetaAtom = molMap[pr->endAtom->molecule];
@@ -2003,9 +1994,7 @@ void sketcherMinimizer::translateMoleculesWithProximityRelations(
         if (!cleverPlacing)
             counterN++;
 
-        for (unsigned int m = 0; m < proximityMols.size(); m++) {
-            sketcherMinimizerMolecule* mol = proximityMols[m];
-
+        for (auto mol : proximityMols) {
             bool residue = false;
             if (mol->_atoms.size() == 1)
                 if (mol->_atoms[0]->isResidue())
@@ -2050,8 +2039,7 @@ void sketcherMinimizer::translateMoleculesWithProximityRelations(
             }
         }
         if (cleverPlacing) { // replace single terminal atoms
-            for (unsigned int m = 0; m < proximityMols.size(); m++) {
-                sketcherMinimizerMolecule* mol = proximityMols[m];
+            for (auto mol : proximityMols) {
                 if (mol->_atoms.size() == 1) {
                     sketcherMinimizerAtom* metaAtom = molMap[mol];
                     if (metaAtom->neighbors.size() == 1) {
@@ -2120,10 +2108,10 @@ void sketcherMinimizer::placeMoleculesWithProximityRelations(
 {
     map<sketcherMinimizerMolecule*, sketcherMinimizerAtom*> molMap;
 
-    sketcherMinimizerMolecule* metaMol = new sketcherMinimizerMolecule;
+    auto* metaMol = new sketcherMinimizerMolecule;
     foreach (sketcherMinimizerMolecule* mol, _molecules) {
         if (mol->m_proximityRelations.size()) {
-            sketcherMinimizerAtom* a = new sketcherMinimizerAtom;
+            auto* a = new sketcherMinimizerAtom;
             a->molecule = metaMol;
             metaMol->_atoms.push_back(a);
             molMap[mol] = a;
@@ -2143,7 +2131,7 @@ void sketcherMinimizer::placeMoleculesWithProximityRelations(
             }
         }
         if (!found) {
-            sketcherMinimizerBond* newBond = new sketcherMinimizerBond;
+            auto* newBond = new sketcherMinimizerBond;
             newBond->startAtom = at1;
             newBond->endAtom = at2;
 
@@ -2214,7 +2202,7 @@ void sketcherMinimizer::placeMoleculesWithProximityRelations(
                 mol->isPlaced = true;
             } else {
                 sketcherMinimizerMolecule* parent = getParent[mol];
-                if (parent != NULL)
+                if (parent != nullptr)
                     placeMolResidueLigandStyle(mol, parent);
             }
             foreach (sketcherMinimizerBond* b, mol->m_proximityRelations) {
@@ -2261,7 +2249,7 @@ void sketcherMinimizer::placeMolResidueLigandStyle(
     sketcherMinimizerPointF cent = mol->center();
 
     foreach (sketcherMinimizerBond* b, mol->m_proximityRelations) {
-        sketcherMinimizerAtom *at = NULL, *parentAt = NULL;
+        sketcherMinimizerAtom *at = nullptr, *parentAt = nullptr;
         if (b->startAtom->molecule == parent) {
             parentAt = b->startAtom;
             at = b->endAtom;
@@ -2269,13 +2257,12 @@ void sketcherMinimizer::placeMolResidueLigandStyle(
             at = b->startAtom;
             parentAt = b->endAtom;
         }
-        if (at == NULL || parentAt == NULL)
+        if (at == nullptr || parentAt == nullptr)
             continue;
         n++;
         sketcherMinimizerPointF paddV = parentAt->getSingleAdditionVector();
         if (b->isResidueInteraction()) {
-            sketcherMinimizerResidueInteraction* ri =
-                static_cast<sketcherMinimizerResidueInteraction*>(b);
+            auto* ri = static_cast<sketcherMinimizerResidueInteraction*>(b);
             if (ri->startAtom->molecule == parent &&
                 ri->m_otherStartAtoms.size()) {
                 paddV = sketcherMinimizerAtom::getSingleAdditionVector(
@@ -2304,7 +2291,7 @@ void sketcherMinimizer::placeMolResidueLigandStyle(
 
         auto signedAngle = sketcherMinimizerMaths::signedAngle(
             startingPos - parentV, sketcherMinimizerPointF(0, 0), -additionV);
-        float angle = static_cast<float>(signedAngle / 180 * M_PI);
+        auto angle = static_cast<float>(signedAngle / 180 * M_PI);
         float s = sin(angle);
         float c = cos(angle);
 
@@ -2362,8 +2349,8 @@ void sketcherMinimizer::flipIfCrossingInteractions(
                     pr1->startAtom->coordinates, pr1->endAtom->coordinates,
                     pr2->startAtom->coordinates, pr2->endAtom->coordinates)) {
                 /* mirror the coordinates */
-                sketcherMinimizerAtom* p1 = NULL;
-                sketcherMinimizerAtom* p2 = NULL;
+                sketcherMinimizerAtom* p1 = nullptr;
+                sketcherMinimizerAtom* p2 = nullptr;
                 if (pr1->startAtom->molecule == mol)
                     p1 = pr1->startAtom;
                 else if (pr1->endAtom->molecule == mol)
@@ -2405,8 +2392,8 @@ void sketcherMinimizer::flipIfCrossingInteractions(
 
 void sketcherMinimizer::arrangeMultipleMolecules()
 {
-    for (unsigned int i = 0; i < _residues.size(); i++) { // replace residues
-        _residues[i]->coordinatesSet = false;
+    for (auto& _residue : _residues) { // replace residues
+        _residue->coordinatesSet = false;
     }
     if (_molecules.size() > 1) {
         // find centers for molecules bound by proximity relations
@@ -2670,8 +2657,7 @@ sketcherMinimizer::findDirectionsToAlignWith(
                 score *= 100;
             }
         }
-        chainDirs.push_back(
-            std::pair<sketcherMinimizerPointF, float>(direction, score));
+        chainDirs.emplace_back(direction, score);
     }
     return chainDirs;
 }
@@ -2824,7 +2810,7 @@ sketcherMinimizer::getBond(const sketcherMinimizerAtom* a1,
         if (a1->neighbors[i] == a2)
             return a1->bonds[i];
     }
-    return NULL;
+    return nullptr;
 }
 
 sketcherMinimizerAtom*
@@ -2933,7 +2919,7 @@ void sketcherMinimizer::findClosestAtomToResidues(
 
     foreach (sketcherMinimizerAtom* r, _residues) {
         float squareD = 9999999.f;
-        sketcherMinimizerAtom* closestA = NULL;
+        sketcherMinimizerAtom* closestA = nullptr;
         foreach (sketcherMinimizerAtom* a, atoms) {
             if (!a->isResidue()) {
                 float diffx = a->m_x3D - r->m_x3D;
@@ -3025,7 +3011,7 @@ void sketcherMinimizer::svd(float* a, float* U, float* Sig, float* V)
     Su[2] = a[2] * a1[0] + a[3] * a1[2];
     Su[3] = a[2] * a1[1] + a[3] * a1[3];
 
-    float phi = static_cast<float>(0.5 * atan2(Su[1] + Su[2], Su[0] - Su[3]));
+    auto phi = static_cast<float>(0.5 * atan2(Su[1] + Su[2], Su[0] - Su[3]));
     float cphi = cos(phi);
     cphi = roundToTwoDecimalDigits(cphi);
     float sphi = sin(phi);
@@ -3042,7 +3028,7 @@ void sketcherMinimizer::svd(float* a, float* U, float* Sig, float* V)
     Sw[2] = a1[2] * a[0] + a1[3] * a[2];
     Sw[3] = a1[2] * a[1] + a1[3] * a[3];
 
-    float theta = static_cast<float>(0.5 * atan2(Sw[1] + Sw[2], Sw[0] - Sw[3]));
+    auto theta = static_cast<float>(0.5 * atan2(Sw[1] + Sw[2], Sw[0] - Sw[3]));
     float ctheta = cos(theta);
     float stheta = sin(theta);
 
@@ -3146,10 +3132,10 @@ bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
     for (unsigned int ta = 0; ta < size; ta++) {
         templateCoordinates.push_back(templ->_atoms[ta]->coordinates);
     }
-    for (unsigned int mb = 0; mb < bonds.size(); mb++) {
-        if (bonds[mb]->bondOrder == 2) {
+    for (auto bond : bonds) {
+        if (bond->bondOrder == 2) {
 
-            sketcherMinimizerBond* b = bonds[mb];
+            sketcherMinimizerBond* b = bond;
             if (b->m_ignoreZE)
                 continue;
 
@@ -3158,8 +3144,8 @@ bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
                 ok = true;
             else {
                 ok = true;
-                for (unsigned int rr = 0; rr < b->rings.size(); rr++) {
-                    if (b->rings[rr]->_atoms.size() < MACROCYCLE) {
+                for (auto& ring : b->rings) {
+                    if (ring->_atoms.size() < MACROCYCLE) {
                         ok = false;
                     }
                 }
@@ -3169,14 +3155,14 @@ bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
             sketcherMinimizerAtom* startA = b->startAtomCIPFirstNeighbor();
             sketcherMinimizerAtom* endA = b->endAtomCIPFirstNeighbor();
 
-            sketcherMinimizerAtom* startN = NULL;
-            sketcherMinimizerAtom* endN = NULL;
+            sketcherMinimizerAtom* startN = nullptr;
+            sketcherMinimizerAtom* endN = nullptr;
             for (unsigned int i = 0; i < b->startAtom->neighbors.size(); i++) {
                 if (b->startAtom->neighbors[i] == b->endAtom)
                     continue;
                 bool found = false;
-                for (unsigned int aa = 0; aa < atoms.size(); aa++) {
-                    if (atoms[aa] == b->startAtom->neighbors[i]) {
+                for (auto atom : atoms) {
+                    if (atom == b->startAtom->neighbors[i]) {
                         startN = b->startAtom->neighbors[i];
                         found = true;
                         break;
@@ -3190,8 +3176,8 @@ bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
                 if (b->endAtom->neighbors[i] == b->startAtom)
                     continue;
                 bool found = false;
-                for (unsigned int aa = 0; aa < atoms.size(); aa++) {
-                    if (atoms[aa] == b->endAtom->neighbors[i]) {
+                for (auto atom : atoms) {
+                    if (atom == b->endAtom->neighbors[i]) {
                         endN = b->endAtom->neighbors[i];
                         found = true;
                         break;
@@ -3220,9 +3206,9 @@ bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
         }
     }
     // assuming that _generalUseN is set as the index of each atom
-    for (unsigned int mb = 0; mb < bonds.size(); mb++) {
-        size_t in1 = bonds[mb]->startAtom->_generalUseN;
-        size_t in2 = bonds[mb]->endAtom->_generalUseN;
+    for (auto bond : bonds) {
+        size_t in1 = bond->startAtom->_generalUseN;
+        size_t in2 = bond->endAtom->_generalUseN;
 
         if (in1 < in2) {
             molBonds[in2].push_back(in1);
@@ -3230,9 +3216,9 @@ bool sketcherMinimizer::compare(const vector<sketcherMinimizerAtom*>& atoms,
             molBonds[in1].push_back(in2);
         }
     }
-    for (unsigned int tb = 0; tb < templ->_bonds.size(); tb++) {
-        size_t in1 = templ->_bonds[tb]->startAtom->_generalUseN;
-        size_t in2 = templ->_bonds[tb]->endAtom->_generalUseN;
+    for (auto& _bond : templ->_bonds) {
+        size_t in1 = _bond->startAtom->_generalUseN;
+        size_t in2 = _bond->endAtom->_generalUseN;
         if (in1 < in2) {
             templateBonds[in2].push_back(in1);
         } else {
@@ -3272,7 +3258,7 @@ void sketcherMinimizer::checkIdentity(
         // check double bonds stereo
         bool doubleBondsStereoOk = true;
 
-        for (unsigned int i = 0; i < molCisTransChains.size(); i++) {
+        for (size_t i = 0; i < molCisTransChains.size(); i++) {
             sketcherMinimizerPointF p1 =
                 templateCoordinates[solution[molCisTransChains[i][0]]];
             sketcherMinimizerPointF p2 =
@@ -3300,26 +3286,22 @@ void sketcherMinimizer::checkIdentity(
             if (!(matrix[solution.size() * size + i]))
                 continue;
             bool check = true;
-            for (unsigned int ss = 0; ss < solution.size(); ss++) {
-                if (solution[ss] == i) {
+            for (unsigned int ss : solution) {
+                if (ss == i) {
                     check = false;
                     break;
                 }
             }
             if (check) {
-                for (unsigned int bi = 0; bi < molBonds[solution.size()].size();
-                     bi++) {
+                for (const auto& molBond : molBonds[solution.size()]) {
                     check = false;
-                    size_t high = i;
-                    size_t low = solution[molBonds[solution.size()][bi]];
+                    unsigned int high = i;
+                    unsigned int low = solution[molBond];
                     if (low > high) {
-                        size_t swap = low;
-                        low = high;
-                        high = swap;
+                        std::swap(low, high);
                     }
-                    for (unsigned int ch = 0; ch < templateBonds[high].size();
-                         ch++) {
-                        if (templateBonds[high][ch] == low) {
+                    for (auto ch : templateBonds[high]) {
+                        if (ch == low) {
                             check = true;
                             break;
                         }
@@ -3368,9 +3350,9 @@ static void loadTemplate(const string& filename,
         // normalize bond length and set _generalUseN on atoms.
         vector<float> dds;
         vector<int> ns;
-        for (unsigned int i = 0; i < mol->_bonds.size(); i++) {
-            sketcherMinimizerPointF v = mol->_bonds[i]->startAtom->coordinates -
-                                        mol->_bonds[i]->endAtom->coordinates;
+        for (auto& _bond : mol->_bonds) {
+            sketcherMinimizerPointF v =
+                _bond->startAtom->coordinates - _bond->endAtom->coordinates;
             float dd = v.x() * v.x() + v.y() * v.y();
             bool found = false;
             for (unsigned int j = 0; j < dds.size(); j++) {

--- a/sketcherMinimizer.h
+++ b/sketcherMinimizer.h
@@ -75,7 +75,7 @@ class CoordgenTemplates
     void setTemplateDir(std::string&& dir)
     {
         m_templateDir = std::move(dir);
-        if (dir.back() != '/') {
+        if (m_templateDir.back() != '/') {
             m_templateDir += "/";
         }
     }

--- a/sketcherMinimizer.h
+++ b/sketcherMinimizer.h
@@ -54,7 +54,7 @@ typedef struct {
 class CoordgenTemplates
 {
   public:
-    CoordgenTemplates() {}
+    CoordgenTemplates() = default;
     ~CoordgenTemplates()
     {
         for (auto molecule : m_templates) {
@@ -298,7 +298,7 @@ class EXPORT_COORDGEN sketcherMinimizer
         const sketcherMinimizerPointF& centerOfGrid, unsigned int levels,
         float gridD, float dx = 0.f, float dy = 0.f,
         float distanceFromAtoms = -1.f, bool watermap = false,
-        sketcherMinimizerResidue* residueForInteractions = NULL,
+        sketcherMinimizerResidue* residueForInteractions = nullptr,
         const sketcherMinimizerPointF& direction = sketcherMinimizerPointF(0,
                                                                            1));
 

--- a/sketcherMinimizerAtom.cpp
+++ b/sketcherMinimizerAtom.cpp
@@ -97,17 +97,16 @@ std::ostream& operator<<(std::ostream& os, const CIPAtom& a)
            << (*a.scores)[a.allParents[i]] << ")";
         if ((*a.medals)[a.allParents[i]].size()) {
             cerr << "<";
-            for (size_t ii = 0; ii < (*a.medals)[a.allParents[i]].size();
-                 ii++) {
-                cerr << (*a.medals)[a.allParents[i]][ii] << "|";
+            for (int ii : (*a.medals)[a.allParents[i]]) {
+                cerr << ii << "|";
             }
             cerr << ">";
         }
         cerr << "   ";
     }
     os << "-";
-    for (size_t i = 0; i < a.theseAtoms.size(); i++) {
-        os << "    " << a.theseAtoms[i].first;
+    for (const auto& theseAtom : a.theseAtoms) {
+        os << "    " << theseAtom.first;
     }
     return os;
 }
@@ -169,13 +168,13 @@ bool CIPAtom::isBetter(CIPAtom& rhs,
     return false;
 }
 
-sketcherMinimizerAtom::~sketcherMinimizerAtom(){};
+sketcherMinimizerAtom::~sketcherMinimizerAtom() = default;
 
 sketcherMinimizerAtom::sketcherMinimizerAtom()
     : crossLayout(false), fixed(false), constrained(false), rigid(false),
       isSharedAndInner(false), atomicNumber(6), charge(0), _valence(-10),
       _generalUseN(-1), _generalUseN2(-1), m_chmN(-1),
-      _generalUseVisited(false), _generalUseVisited2(false), fragment(NULL),
+      _generalUseVisited(false), _generalUseVisited2(false), fragment(nullptr),
       needsCheckForClashes(false), visited(false), coordinatesSet(false),
       isR(true), hasStereochemistrySet(false), _hasRingChirality(false)
 {
@@ -200,9 +199,9 @@ sketcherMinimizerAtom::shareARing(const sketcherMinimizerAtom* atom1,
     /* return a ring shared by the two atoms. return a non-macrocycle if
      * possible */
     if (!atom1->rings.size())
-        return NULL;
+        return nullptr;
     if (!atom2->rings.size())
-        return NULL;
+        return nullptr;
 
     foreach (sketcherMinimizerRing* ring, atom1->rings) {
         if (ring->isMacrocycle())
@@ -218,7 +217,7 @@ sketcherMinimizerAtom::shareARing(const sketcherMinimizerAtom* atom1,
                 return ring;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 int sketcherMinimizerAtom::findHsNumber() const
@@ -227,8 +226,8 @@ int sketcherMinimizerAtom::findHsNumber() const
     if (valence == -10)
         valence = expectedValence(atomicNumber); // valence is not yet set
     int nBondOrders = 0;
-    for (size_t i = 0; i < bonds.size(); ++i) {
-        nBondOrders += bonds[i]->bondOrder;
+    for (auto bond : bonds) {
+        nBondOrders += bond->bondOrder;
     }
     if (atomicNumber == 16) { // sulfite & sulfate
         int nOs = 0;
@@ -408,9 +407,9 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
 
         vector<sketcherMinimizerAtomPriority> atomPriorities,
             orderedAtomPriorities;
-        for (unsigned int i = 0; i < orderedNeighs.size(); i++) {
+        for (auto& orderedNeigh : orderedNeighs) {
             sketcherMinimizerAtomPriority p;
-            p.a = orderedNeighs[i];
+            p.a = orderedNeigh;
             atomPriorities.push_back(p);
         }
         if (atomPriorities.size() == 3) {
@@ -466,7 +465,7 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
                     atomPriorities.erase(atomPriorities.begin());
                 }
             }
-            sketcherMinimizerAtom* mainAtom = NULL;
+            sketcherMinimizerAtom* mainAtom = nullptr;
             if (four) {
                 if (atomPriorities[0].a == orderedAtomPriorities[0].a)
                     mainAtom = atomPriorities[0].a;
@@ -565,8 +564,7 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
         }
 
         else {
-            for (unsigned int i = 0; i < bonds.size(); i++) {
-                sketcherMinimizerBond* b = bonds[i];
+            for (auto b : bonds) {
                 b->hasStereochemistryDisplay = false;
             }
         }
@@ -628,7 +626,6 @@ bool sketcherMinimizerAtom::setAbsoluteStereoFromChiralityInfo()
         return true;
     readStereochemistry(); // to set m_RSPriorities
     auto RSpriorities = m_RSPriorities;
-    ;
     if (RSpriorities.size() < 3) {
         cerr << "CHMMol-> sketcher stereo error: wrong number for RSpriorities"
              << endl;
@@ -757,8 +754,8 @@ void sketcherMinimizerAtom::orderAtomPriorities(
     vector<float> weights(4);
     for (unsigned int i = 0; i < 4; i++) {
         queue<sketcherMinimizerAtom*> q;
-        for (unsigned int j = 0; j < center->molecule->_atoms.size(); j++) {
-            center->molecule->_atoms[j]->_generalUseVisited = false;
+        for (auto& _atom : center->molecule->_atoms) {
+            _atom->_generalUseVisited = false;
         }
 
         q.push(atomPriorities[i].a);
@@ -770,8 +767,7 @@ void sketcherMinimizerAtom::orderAtomPriorities(
             counter++;
             sketcherMinimizerAtom* at = q.front();
             q.pop();
-            for (unsigned int ni = 0; ni < at->neighbors.size(); ni++) {
-                sketcherMinimizerAtom* n = at->neighbors[ni];
+            for (auto n : at->neighbors) {
                 if (!n->_generalUseVisited) {
                     q.push(n);
                     n->_generalUseVisited = true;
@@ -854,8 +850,8 @@ bool sketcherMinimizerAtom::setCIPPriorities(
     vector<sketcherMinimizerAtomPriority>& atomPriorities,
     sketcherMinimizerAtom* center)
 {
-    for (unsigned int i = 0; i < atomPriorities.size(); i++) {
-        atomPriorities[i].priority = 3;
+    for (auto& atomPrioritie : atomPriorities) {
+        atomPrioritie.priority = 3;
     }
     if (atomPriorities.size() != 4) {
         //    cerr << "coordgen: stereo error. (wrong number of atom priorities:
@@ -877,10 +873,10 @@ bool sketcherMinimizerAtom::setCIPPriorities(
     }
     vector<bool> found(4, false);
 
-    for (unsigned int i = 0; i < atomPriorities.size(); i++) {
-        if (found[atomPriorities[i].priority])
+    for (auto& atomPrioritie : atomPriorities) {
+        if (found[atomPrioritie.priority])
             return false; // two atoms have the same priority
-        found[atomPriorities[i].priority] = true;
+        found[atomPrioritie.priority] = true;
     }
     return true;
 }
@@ -912,13 +908,13 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
 
     vector<CIPAtom> AN1, AN2;
 
-    map<sketcherMinimizerAtom *, int> score1,
+    map<sketcherMinimizerAtom*, int> score1,
         score2; // used to keep track if a parent atom has been found to have
                 // priority over another
-    map<sketcherMinimizerAtom *, vector<int>> medals1,
+    map<sketcherMinimizerAtom*, vector<int>> medals1,
         medals2; // marks if an atom is a parent of the atoms being evaluated in
                  // the current iteration
-    map<sketcherMinimizerAtom *, int> visited1,
+    map<sketcherMinimizerAtom*, int> visited1,
         visited2; // marks at which iteration this atom was evaluated
 
     visited1[center] = 1;
@@ -926,18 +922,18 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
     visited1[at1] = 2;
     visited2[at2] = 2;
 
-    vector<pair<int, sketcherMinimizerAtom *>> v1, v2;
-    v1.push_back(pair<int, sketcherMinimizerAtom*>(at1->atomicNumber, at1));
-    v2.push_back(pair<int, sketcherMinimizerAtom*>(at2->atomicNumber, at2));
+    vector<pair<int, sketcherMinimizerAtom*>> v1, v2;
+    v1.emplace_back(at1->atomicNumber, at1);
+    v2.emplace_back(at2->atomicNumber, at2);
 
-    vector<sketcherMinimizerAtom *> parents1, parents2;
+    vector<sketcherMinimizerAtom*> parents1, parents2;
     parents1.push_back(center);
     parents1.push_back(at1);
     parents2.push_back(center);
     parents2.push_back(at2);
 
-    AN1.push_back(CIPAtom(v1, center, parents1, &score1, &medals1, &visited1));
-    AN2.push_back(CIPAtom(v2, center, parents2, &score2, &medals2, &visited2));
+    AN1.emplace_back(v1, center, parents1, &score1, &medals1, &visited1);
+    AN2.emplace_back(v2, center, parents2, &score2, &medals2, &visited2);
 
     int level = 1;
 
@@ -975,7 +971,7 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
         AN1 = sketcherMinimizerAtom::expandOneLevel(AN1);
         AN2 = sketcherMinimizerAtom::expandOneLevel(AN2);
     }
-    return 0;
+    return nullptr;
 }
 
 void sketcherMinimizerAtom::chooseFirstAndSortAccordingly(vector<CIPAtom>& V)
@@ -996,8 +992,8 @@ void sketcherMinimizerAtom::chooseFirstAndSortAccordingly(vector<CIPAtom>& V)
         copyV.erase(copyV.begin() + bestI);
         V.push_back(newBest);
 
-        for (unsigned int i = 0; i < newBest.allParents.size(); i++) {
-            friendsMask[newBest.allParents[i]] |= (1 << copyV.size());
+        for (auto allParent : newBest.allParents) {
+            friendsMask[allParent] |= (1 << copyV.size());
         }
     }
 }
@@ -1008,26 +1004,25 @@ vector<CIPAtom> sketcherMinimizerAtom::expandOneLevel(vector<CIPAtom>& oldV)
 
     map<sketcherMinimizerAtom*, bool> visitedThisRound;
     vector<CIPAtom> newV;
-    for (unsigned int an = 0; an < oldV.size(); an++) {
-        for (unsigned int aa = 0; aa < oldV[an].theseAtoms.size(); aa++) {
-            sketcherMinimizerAtom* a = oldV[an].theseAtoms[aa].second;
-            if (a == NULL)
+    for (auto& an : oldV) {
+        for (unsigned int aa = 0; aa < an.theseAtoms.size(); aa++) {
+            sketcherMinimizerAtom* a = an.theseAtoms[aa].second;
+            if (a == nullptr)
                 continue; // dummy atom
             //    if (visitedThisRound[a]) continue; // a is present twice
             //    because closing a ring and has already been dealt with
             visitedThisRound[a] = true;
-            map<sketcherMinimizerAtom*, int>* visited = oldV[an].visited;
-            map<sketcherMinimizerAtom*, vector<int>>* medals = oldV[an].medals;
-            map<sketcherMinimizerAtom*, int>* scores = oldV[an].scores;
+            map<sketcherMinimizerAtom*, int>* visited = an.visited;
+            map<sketcherMinimizerAtom*, vector<int>>* medals = an.medals;
+            map<sketcherMinimizerAtom*, int>* scores = an.scores;
 
-            vector<sketcherMinimizerAtom*> allParents = oldV[an].allParents;
+            vector<sketcherMinimizerAtom*> allParents = an.allParents;
             allParents.push_back(a);
             vector<pair<int, sketcherMinimizerAtom*>> theseAts;
 
             for (unsigned int n = 0; n < a->bonds.size(); n++) {
                 sketcherMinimizerAtom* neigh = a->neighbors[n];
-                if (neigh !=
-                    oldV[an].parent) { // if n is not the direct parent of a
+                if (neigh != an.parent) { // if n is not the direct parent of a
                     bool ghost =
                         (neigh->atomicNumber == 1 ||
                          ((*visited)[neigh] &&
@@ -1035,12 +1030,12 @@ vector<CIPAtom> sketcherMinimizerAtom::expandOneLevel(vector<CIPAtom>& oldV)
                               (*visited)[a] + 1) // closing a ring to an atom
                                                  // already visited in a
                                                  // previous cycle
-                         );
-                    theseAts.push_back(pair<int, sketcherMinimizerAtom*>(
+                        );
+                    theseAts.emplace_back(
                         neigh->atomicNumber,
-                        ghost ? ((sketcherMinimizerAtom*) NULL)
-                              : neigh)); // put a ghost for hydrogens and atoms
-                                         // closing a ring
+                        ghost ? ((sketcherMinimizerAtom*) nullptr)
+                              : neigh); // put a ghost for hydrogens and atoms
+                                        // closing a ring
                     if (!ghost) {
                         (*visited)[neigh] = (*visited)[a] + 1;
                     }
@@ -1048,27 +1043,25 @@ vector<CIPAtom> sketcherMinimizerAtom::expandOneLevel(vector<CIPAtom>& oldV)
                 if (a->bonds[n]->bondOrder == 2) { // put ghosts for multiple
                                                    // order bonds, even to the
                                                    // parent
-                    theseAts.push_back(pair<int, sketcherMinimizerAtom*>(
-                        neigh->atomicNumber, (sketcherMinimizerAtom*) NULL));
+                    theseAts.emplace_back(neigh->atomicNumber,
+                                          (sketcherMinimizerAtom*) nullptr);
                 }
 
                 else if (a->bonds[n]->bondOrder == 3) {
-                    theseAts.push_back(pair<int, sketcherMinimizerAtom*>(
-                        neigh->atomicNumber, (sketcherMinimizerAtom*) NULL));
-                    theseAts.push_back(pair<int, sketcherMinimizerAtom*>(
-                        neigh->atomicNumber, (sketcherMinimizerAtom*) NULL));
+                    theseAts.emplace_back(neigh->atomicNumber,
+                                          (sketcherMinimizerAtom*) nullptr);
+                    theseAts.emplace_back(neigh->atomicNumber,
+                                          (sketcherMinimizerAtom*) nullptr);
                 }
             }
 
             for (int counter = 0; counter < a->_implicitHs;
                  counter++) { // put ghosts for implicit Hs
-                theseAts.push_back(pair<int, sketcherMinimizerAtom*>(
-                    1, (sketcherMinimizerAtom*) NULL));
+                theseAts.emplace_back(1, (sketcherMinimizerAtom*) nullptr);
             }
             stable_sort(theseAts.begin(), theseAts.end());
             reverse(theseAts.begin(), theseAts.end());
-            newV.push_back(
-                CIPAtom(theseAts, a, allParents, scores, medals, visited));
+            newV.emplace_back(theseAts, a, allParents, scores, medals, visited);
         }
     }
     return newV;
@@ -1096,15 +1089,15 @@ void sketcherMinimizerAtom::assignMedals(vector<CIPAtom>& v)
                 medalLvl--;
             }
         }
-        for (unsigned int pC = 0; pC < v[i].allParents.size(); pC++) {
-            vector<int> medalsV = (*medals)[v[i].allParents[pC]];
+        for (auto allParent : v[i].allParents) {
+            vector<int> medalsV = (*medals)[allParent];
             while (medalsV.size() < medalLvl)
                 medalsV.push_back(0);
             if (medalsV.size() > medalLvl)
                 medalsV[medalLvl] = medalsV[medalLvl] + 1;
             else
                 medalsV.push_back(1);
-            (*medals)[v[i].allParents[pC]] = medalsV;
+            (*medals)[allParent] = medalsV;
         }
         medalLvl++;
     }
@@ -1133,9 +1126,9 @@ void sketcherMinimizerAtom::finalizeScores(vector<CIPAtom>& v)
             }
         }
         /* write the score */
-        for (unsigned int pC = 0; pC < v[i].allParents.size(); pC++) {
-            if ((*scores)[v[i].allParents[pC]] == 0)
-                (*scores)[v[i].allParents[pC]] = score;
+        for (auto allParent : v[i].allParents) {
+            if ((*scores)[allParent] == 0)
+                (*scores)[allParent] = score;
         }
         score++;
     }
@@ -1149,7 +1142,7 @@ sketcherMinimizerAtom::bondTo(sketcherMinimizerAtom* at) const
         if (neighbors[i] == at)
             return bonds[i];
     }
-    return NULL;
+    return nullptr;
 }
 
 bool sketcherMinimizerAtom::isResidue() const
@@ -1211,12 +1204,12 @@ int sketcherMinimizerAtom::readStereochemistry(
     }
 
     float totalAngle = 0;
-    for (unsigned int ai = 0; ai < angles.size(); ai++)
-        totalAngle += angles[ai];
+    for (float angle : angles)
+        totalAngle += angle;
     angles.push_back(360.f - totalAngle);
 
     bool semiplane = false;
-    sketcherMinimizerAtom* centralAtom = NULL;
+    sketcherMinimizerAtom* centralAtom = nullptr;
     if (angles.size() == 3) {
         for (unsigned int i = 0; i < angles.size(); i++) {
             if (angles[i] > 180.f) {
@@ -1318,9 +1311,9 @@ int sketcherMinimizerAtom::readStereochemistry(
     }
 
     vector<sketcherMinimizerAtomPriority> atomPriorities;
-    for (unsigned int i = 0; i < orderedNeighs.size(); i++) {
+    for (auto& orderedNeigh : orderedNeighs) {
         sketcherMinimizerAtomPriority p;
-        p.a = orderedNeighs[i];
+        p.a = orderedNeigh;
         atomPriorities.push_back(p);
     }
     if (atomPriorities.size() != 4)
@@ -1363,11 +1356,10 @@ int sketcherMinimizerAtom::readStereochemistry(
         if (!readOnly)
             _hasRingChirality = false;
     }
-    for (unsigned int nn = 0; nn < neighbors.size(); nn++) {
-        sketcherMinimizerAtom* n = neighbors[nn];
-        for (unsigned int i = 0; i < atomPriorities.size(); i++) {
-            if (atomPriorities[i].a == n) {
-                m_RSPriorities.push_back(atomPriorities[i].priority);
+    for (auto n : neighbors) {
+        for (auto& atomPrioritie : atomPriorities) {
+            if (atomPrioritie.a == n) {
+                m_RSPriorities.push_back(atomPrioritie.priority);
                 break;
             }
         }
@@ -1458,11 +1450,11 @@ sketcherMinimizerPointF sketcherMinimizerAtom::getSingleAdditionVector() const
     sketcherMinimizerPointF out(0.f, 0.f);
     float totalf = 0.f;
     if (neighbors.size()) {
-        for (unsigned int i = 0; i < neighbors.size(); i++) {
+        for (auto neighbor : neighbors) {
             float f = 1.f;
-            if (sketcherMinimizer::sameRing(this, neighbors[i]))
+            if (sketcherMinimizer::sameRing(this, neighbor))
                 f = 4.f;
-            out += f * (neighbors[i]->coordinates - coordinates);
+            out += f * (neighbor->coordinates - coordinates);
             totalf += f;
         }
         out /= totalf;

--- a/sketcherMinimizerAtom.cpp
+++ b/sketcherMinimizerAtom.cpp
@@ -29,44 +29,57 @@ bool CIPAtom::operator<(const CIPAtom& rhs) const
     assert(allParents.size() == rhs.allParents.size());
     for (size_t i = 0; i < allParents.size(); i++) {
 
-        if (allParents[i]->atomicNumber > rhs.allParents[i]->atomicNumber)
+        if (allParents[i]->atomicNumber > rhs.allParents[i]->atomicNumber) {
             return true;
-        if (allParents[i]->atomicNumber < rhs.allParents[i]->atomicNumber)
+        }
+        if (allParents[i]->atomicNumber < rhs.allParents[i]->atomicNumber) {
             return false;
+        }
 
-        if ((*scores)[allParents[i]] < (*rhs.scores)[rhs.allParents[i]])
+        if ((*scores)[allParents[i]] < (*rhs.scores)[rhs.allParents[i]]) {
             return true;
-        if ((*scores)[allParents[i]] > (*rhs.scores)[rhs.allParents[i]])
+        }
+        if ((*scores)[allParents[i]] > (*rhs.scores)[rhs.allParents[i]]) {
             return false;
+        }
 
         vector<int> meds = (*medals)[allParents[i]];
         vector<int> meds2 = (*rhs.medals)[rhs.allParents[i]];
         size_t s = (meds.size() < meds2.size()) ? meds.size() : meds2.size();
 
         for (size_t mm = 0; mm < s; mm++) {
-            if (meds[mm] > meds2[mm])
+            if (meds[mm] > meds2[mm]) {
                 return true;
-            if (meds[mm] < meds2[mm])
+            }
+            if (meds[mm] < meds2[mm]) {
                 return false;
+            }
         }
-        if (meds.size() > meds2.size())
+        if (meds.size() > meds2.size()) {
             return true;
-        if (meds2.size() > meds.size())
+        }
+        if (meds2.size() > meds.size()) {
             return false;
+        }
     }
     size_t siz = theseAtoms.size();
-    if (rhs.theseAtoms.size() < siz)
+    if (rhs.theseAtoms.size() < siz) {
         siz = rhs.theseAtoms.size();
-    for (size_t i = 0; i < siz; i++) {
-        if (theseAtoms[i].first > rhs.theseAtoms[i].first)
-            return true;
-        if (theseAtoms[i].first < rhs.theseAtoms[i].first)
-            return false;
     }
-    if (theseAtoms.size() > rhs.theseAtoms.size())
+    for (size_t i = 0; i < siz; i++) {
+        if (theseAtoms[i].first > rhs.theseAtoms[i].first) {
+            return true;
+        }
+        if (theseAtoms[i].first < rhs.theseAtoms[i].first) {
+            return false;
+        }
+    }
+    if (theseAtoms.size() > rhs.theseAtoms.size()) {
         return true;
-    if (theseAtoms.size() < rhs.theseAtoms.size())
+    }
+    if (theseAtoms.size() < rhs.theseAtoms.size()) {
         return false;
+    }
 
     return false;
 }
@@ -75,16 +88,20 @@ bool CIPAtom::operator==(const CIPAtom& rhs) const
 {
     assert(allParents.size() == rhs.allParents.size());
     for (size_t i = 0; i < allParents.size(); i++) {
-        if (allParents[i]->atomicNumber != rhs.allParents[i]->atomicNumber)
+        if (allParents[i]->atomicNumber != rhs.allParents[i]->atomicNumber) {
             return false;
-        if ((*scores)[allParents[i]] != (*rhs.scores)[rhs.allParents[i]])
+        }
+        if ((*scores)[allParents[i]] != (*rhs.scores)[rhs.allParents[i]]) {
             return false;
+        }
     }
-    if (theseAtoms.size() != rhs.theseAtoms.size())
+    if (theseAtoms.size() != rhs.theseAtoms.size()) {
         return false;
+    }
     for (size_t i = 0; i < theseAtoms.size(); i++) {
-        if (theseAtoms[i].first != rhs.theseAtoms[i].first)
+        if (theseAtoms[i].first != rhs.theseAtoms[i].first) {
             return false;
+        }
     }
     return true;
 }
@@ -121,49 +138,64 @@ bool CIPAtom::isBetter(CIPAtom& rhs,
     assert(allParents.size() == rhs.allParents.size());
     for (size_t i = 0; i < allParents.size(); i++) {
 
-        if ((*m)[allParents[i]] > (*m)[rhs.allParents[i]])
+        if ((*m)[allParents[i]] > (*m)[rhs.allParents[i]]) {
             return true;
-        if ((*m)[allParents[i]] < (*m)[rhs.allParents[i]])
+        }
+        if ((*m)[allParents[i]] < (*m)[rhs.allParents[i]]) {
             return false;
+        }
 
-        if (allParents[i]->atomicNumber > rhs.allParents[i]->atomicNumber)
+        if (allParents[i]->atomicNumber > rhs.allParents[i]->atomicNumber) {
             return true;
-        if (allParents[i]->atomicNumber < rhs.allParents[i]->atomicNumber)
+        }
+        if (allParents[i]->atomicNumber < rhs.allParents[i]->atomicNumber) {
             return false;
+        }
 
-        if ((*scores)[allParents[i]] < (*rhs.scores)[rhs.allParents[i]])
+        if ((*scores)[allParents[i]] < (*rhs.scores)[rhs.allParents[i]]) {
             return true;
-        if ((*scores)[allParents[i]] > (*rhs.scores)[rhs.allParents[i]])
+        }
+        if ((*scores)[allParents[i]] > (*rhs.scores)[rhs.allParents[i]]) {
             return false;
+        }
 
         vector<int> meds = (*medals)[allParents[i]];
         vector<int> meds2 = (*rhs.medals)[rhs.allParents[i]];
         size_t s = (meds.size() < meds2.size()) ? meds.size() : meds2.size();
 
         for (size_t mm = 0; mm < s; mm++) {
-            if (meds[mm] > meds2[mm])
+            if (meds[mm] > meds2[mm]) {
                 return true;
-            if (meds[mm] < meds2[mm])
+            }
+            if (meds[mm] < meds2[mm]) {
                 return false;
+            }
         }
-        if (meds.size() > meds2.size())
+        if (meds.size() > meds2.size()) {
             return true;
-        if (meds2.size() > meds.size())
+        }
+        if (meds2.size() > meds.size()) {
             return false;
+        }
     }
     size_t siz = theseAtoms.size();
-    if (rhs.theseAtoms.size() < siz)
+    if (rhs.theseAtoms.size() < siz) {
         siz = rhs.theseAtoms.size();
-    for (size_t i = 0; i < siz; i++) {
-        if (theseAtoms[i].first > rhs.theseAtoms[i].first)
-            return true;
-        if (theseAtoms[i].first < rhs.theseAtoms[i].first)
-            return false;
     }
-    if (theseAtoms.size() > rhs.theseAtoms.size())
+    for (size_t i = 0; i < siz; i++) {
+        if (theseAtoms[i].first > rhs.theseAtoms[i].first) {
+            return true;
+        }
+        if (theseAtoms[i].first < rhs.theseAtoms[i].first) {
+            return false;
+        }
+    }
+    if (theseAtoms.size() > rhs.theseAtoms.size()) {
         return true;
-    if (theseAtoms.size() < rhs.theseAtoms.size())
+    }
+    if (theseAtoms.size() < rhs.theseAtoms.size()) {
         return false;
+    }
 
     return false;
 }
@@ -198,23 +230,28 @@ sketcherMinimizerAtom::shareARing(const sketcherMinimizerAtom* atom1,
 {
     /* return a ring shared by the two atoms. return a non-macrocycle if
      * possible */
-    if (!atom1->rings.size())
+    if (!atom1->rings.size()) {
         return nullptr;
-    if (!atom2->rings.size())
+    }
+    if (!atom2->rings.size()) {
         return nullptr;
+    }
 
     foreach (sketcherMinimizerRing* ring, atom1->rings) {
-        if (ring->isMacrocycle())
+        if (ring->isMacrocycle()) {
             continue;
+        }
         foreach (sketcherMinimizerRing* ring2, atom2->rings) {
-            if (ring == ring2)
+            if (ring == ring2) {
                 return ring;
+            }
         }
     }
     foreach (sketcherMinimizerRing* ring, atom1->rings) {
         foreach (sketcherMinimizerRing* ring2, atom2->rings) {
-            if (ring == ring2)
+            if (ring == ring2) {
                 return ring;
+            }
         }
     }
     return nullptr;
@@ -223,8 +260,9 @@ sketcherMinimizerAtom::shareARing(const sketcherMinimizerAtom* atom1,
 int sketcherMinimizerAtom::findHsNumber() const
 {
     int valence = _valence;
-    if (valence == -10)
+    if (valence == -10) {
         valence = expectedValence(atomicNumber); // valence is not yet set
+    }
     int nBondOrders = 0;
     for (auto bond : bonds) {
         nBondOrders += bond->bondOrder;
@@ -232,20 +270,24 @@ int sketcherMinimizerAtom::findHsNumber() const
     if (atomicNumber == 16) { // sulfite & sulfate
         int nOs = 0;
         for (size_t i = 0; i < neighbors.size(); ++i) {
-            if (neighbors[i]->atomicNumber == 8 && bonds[i]->bondOrder == 2)
+            if (neighbors[i]->atomicNumber == 8 && bonds[i]->bondOrder == 2) {
                 ++nOs;
+            }
         }
-        if ((nOs) < 3)
+        if ((nOs) < 3) {
             valence += nOs * 2;
+        }
     }
     if (atomicNumber == 15) { // P
         int nOs = 0;
         for (size_t i = 0; i < neighbors.size(); ++i) {
-            if (neighbors[i]->atomicNumber == 8 && bonds[i]->bondOrder == 2)
+            if (neighbors[i]->atomicNumber == 8 && bonds[i]->bondOrder == 2) {
                 ++nOs;
+            }
         }
-        if (nOs < 2)
+        if (nOs < 2) {
             valence += nOs * 2;
+        }
     }
     int out = valence - nBondOrders + charge;
     if (out < 0) {
@@ -320,8 +362,9 @@ sketcherMinimizerAtom::clockwiseOrderedNeighbors() const
             float newAngle = sketcherMinimizerMaths::signedAngle(
                 lastPoppedAtom->coordinates, coordinates,
                 neighs[i]->coordinates);
-            if (newAngle < 0)
+            if (newAngle < 0) {
                 newAngle += 360;
+            }
             if (newAngle < smallestAngle) {
                 smallestAngle = newAngle;
                 lastPoppedIndex = i;
@@ -342,8 +385,9 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
 
     assert(neighbors.size() == bonds.size());
 
-    if (!hasStereochemistrySet)
+    if (!hasStereochemistrySet) {
         return;
+    }
     size_t n = neighbors.size();
     if (n != 3 && n != 4) {
         hasStereochemistrySet = false;
@@ -383,8 +427,9 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
                     sketcherMinimizerPointF(coordinates.x(), coordinates.y()),
                     sketcherMinimizerPointF(neighs[i]->coordinates.x(),
                                             neighs[i]->coordinates.y()));
-                if (newAngle < 0)
+                if (newAngle < 0) {
                     newAngle += 360;
+                }
                 if (newAngle < smallestAngle) {
                     smallestAngle = newAngle;
                     lastPoppedIndex = i;
@@ -398,8 +443,9 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
             bbonds.erase(bbonds.begin() + lastPoppedIndex);
         }
         if ((atomicNumber == 7 || atomicNumber == 16) && _implicitHs == 0 &&
-            orderedBonds.size() == 3)
+            orderedBonds.size() == 3) {
             dummy = &dummyLP;
+        }
 
         bool four = true;
         float totalAngle = std::accumulate(angles.begin(), angles.end(), 0.f);
@@ -467,10 +513,12 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
             }
             sketcherMinimizerAtom* mainAtom = nullptr;
             if (four) {
-                if (atomPriorities[0].a == orderedAtomPriorities[0].a)
+                if (atomPriorities[0].a == orderedAtomPriorities[0].a) {
                     mainAtom = atomPriorities[0].a;
-                if (atomPriorities[3].a == orderedAtomPriorities[0].a)
+                }
+                if (atomPriorities[3].a == orderedAtomPriorities[0].a) {
                     mainAtom = atomPriorities[3].a;
+                }
             }
             bool invert = false;
             sketcherMinimizerBond* b1 = bondTo(atomPriorities[0].a);
@@ -479,13 +527,15 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
                     (!sketcherMinimizer::sameRing(this, atomPriorities[0].a) &&
                      !atomPriorities[0].a->hasStereochemistrySet)) {
                     bool reverse = false;
-                    if (b1->startAtom != this)
+                    if (b1->startAtom != this) {
                         reverse = true;
+                    }
                     b1->isWedge = !invert;
                     b1->hasStereochemistryDisplay = true;
                     b1->isReversed = reverse;
-                } else
+                } else {
                     b1->hasStereochemistryDisplay = false;
+                }
             }
             if (four) {
                 sketcherMinimizerBond* b2 = bondTo(atomPriorities[3].a);
@@ -495,13 +545,15 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
                                                       atomPriorities[3].a) &&
                          !atomPriorities[3].a->hasStereochemistrySet)) {
                         bool reverse = false;
-                        if (b2->startAtom != this)
+                        if (b2->startAtom != this) {
                             reverse = true;
+                        }
                         b2->isWedge = invert;
                         b2->hasStereochemistryDisplay = true;
                         b2->isReversed = reverse;
-                    } else
+                    } else {
                         b2->hasStereochemistryDisplay = false;
+                    }
                 }
             }
 
@@ -532,13 +584,15 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
                          !atomPriorities[0].a->hasStereochemistrySet)) {
                         //          cerr << "and setting it "<<endl;
                         bool reverse = false;
-                        if (b1->startAtom != this)
+                        if (b1->startAtom != this) {
                             reverse = true;
+                        }
                         b1->isWedge = !invert;
                         b1->hasStereochemistryDisplay = true;
                         b1->isReversed = reverse;
-                    } else
+                    } else {
                         b1->hasStereochemistryDisplay = false;
+                    }
                 }
 
                 if (four) {
@@ -550,13 +604,15 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
                                  this, atomPriorities[3].a) &&
                              !atomPriorities[3].a->hasStereochemistrySet)) {
                             bool reverse = false;
-                            if (b2->startAtom != this)
+                            if (b2->startAtom != this) {
                                 reverse = true;
+                            }
                             b2->isWedge = invert;
                             b2->hasStereochemistryDisplay = true;
                             b2->isReversed = reverse;
-                        } else
+                        } else {
                             b2->hasStereochemistryDisplay = false;
+                        }
                     }
                 }
             }
@@ -600,8 +656,9 @@ sketcherMinimizerAtom::getRelativeStereo(sketcherMinimizerAtom* lookingFrom,
         }
     }
     vector<int> can(4);
-    for (unsigned int i = 0; i < 4; i++)
+    for (unsigned int i = 0; i < 4; i++) {
         can[i] = i;
+    }
     /*
      this represents a molecule with
      atom1 (priority 0 - highest)
@@ -614,16 +671,18 @@ sketcherMinimizerAtom::getRelativeStereo(sketcherMinimizerAtom* lookingFrom,
      */
     bool match = sketcherMinimizerAtom::matchCIPSequence(priorities, can);
     bool isClockWise = (match ? !isR : isR);
-    if (isClockWise)
+    if (isClockWise) {
         return sketcherMinimizerAtomChiralityInfo::clockwise;
+    }
     return sketcherMinimizerAtomChiralityInfo::counterClockwise;
 }
 
 bool sketcherMinimizerAtom::setAbsoluteStereoFromChiralityInfo()
 {
     auto info = m_chiralityInfo;
-    if (info.direction == sketcherMinimizerAtomChiralityInfo::unspecified)
+    if (info.direction == sketcherMinimizerAtomChiralityInfo::unspecified) {
         return true;
+    }
     readStereochemistry(); // to set m_RSPriorities
     auto RSpriorities = m_RSPriorities;
     if (RSpriorities.size() < 3) {
@@ -684,15 +743,19 @@ bool sketcherMinimizerAtom::setAbsoluteStereoFromChiralityInfo()
     bool invert = false;
 
     vector<int> can(4);
-    for (unsigned int i = 0; i < 4; i++)
+    for (unsigned int i = 0; i < 4; i++) {
         can[i] = i;
-    if (!sketcherMinimizerAtom::matchCIPSequence(priorities, can))
+    }
+    if (!sketcherMinimizerAtom::matchCIPSequence(priorities, can)) {
         invert = !invert;
+    }
     bool isRBool = true;
-    if (info.direction == sketcherMinimizerAtomChiralityInfo::clockwise)
+    if (info.direction == sketcherMinimizerAtomChiralityInfo::clockwise) {
         isRBool = false;
-    if (invert)
+    }
+    if (invert) {
         isRBool = !isRBool;
+    }
     isR = isRBool;
     hasStereochemistrySet = true;
     return true;
@@ -701,19 +764,21 @@ bool sketcherMinimizerAtom::setAbsoluteStereoFromChiralityInfo()
 bool sketcherMinimizerAtom::matchCIPSequence(vector<int>& v1, vector<int>& v2)
 
 {
-    if (v1.size() < v2.size())
+    if (v1.size() < v2.size()) {
         v1.push_back(3);
-    else if (v2.size() < v1.size())
+    } else if (v2.size() < v1.size()) {
         v2.push_back(3);
+    }
 
     int outofPlaceNs = 0;
     for (unsigned int i = 0; i < v1.size(); i++) {
-        if (v1[i] != v2[i])
+        if (v1[i] != v2[i]) {
             outofPlaceNs++;
+        }
     }
-    if (outofPlaceNs == 2)
+    if (outofPlaceNs == 2) {
         return false;
-    else if (outofPlaceNs == 4) {
+    } else if (outofPlaceNs == 4) {
         int n1 = v1[0];
         int index2 = 0;
         for (unsigned int j = 0; j < v2.size(); j++) {
@@ -722,8 +787,9 @@ bool sketcherMinimizerAtom::matchCIPSequence(vector<int>& v1, vector<int>& v2)
                 break;
             }
         }
-        if (v1[index2] != v2[0])
+        if (v1[index2] != v2[0]) {
             return false;
+        }
     }
     return true;
 }
@@ -738,8 +804,9 @@ void sketcherMinimizerAtom::setCoordinates(sketcherMinimizerPointF coords)
 bool sketcherMinimizerAtom::hasNoStereoActiveBonds() const
 {
     for (auto bond : bonds) {
-        if (bond->isStereo())
+        if (bond->isStereo()) {
             return false;
+        }
     }
     return true;
 }
@@ -777,31 +844,41 @@ void sketcherMinimizerAtom::orderAtomPriorities(
         weights[i] = static_cast<float>(counter);
         sketcherMinimizerBond* b = center->bondTo(atomPriorities[i].a);
         if (b) {
-            if (b->bondOrder == 2)
+            if (b->bondOrder == 2) {
                 weights[i] -=
                     0.25; // so that =O get lower priority than -OH in phosphate
-            if (center->atomicNumber == 16 && b->bondOrder == 2)
+            }
+            if (center->atomicNumber == 16 && b->bondOrder == 2) {
                 weights[i] += 2000; // forcing the wedge away from double bond
-                                    // in sulphoxide
+            }
+            // in sulphoxide
 
-            if (sketcherMinimizer::sameRing(b->startAtom, b->endAtom))
+            if (sketcherMinimizer::sameRing(b->startAtom, b->endAtom)) {
                 weights[i] +=
                     500; // force same ring atoms to be in position 3 and 4
+            }
         }
-        if (atomPriorities[i].a->atomicNumber == 6)
+        if (atomPriorities[i].a->atomicNumber == 6) {
             weights[i] += 0.5; // carbons get priority over other heavy atoms
-        if (atomPriorities[i].a->atomicNumber == 1)
+        }
+        if (atomPriorities[i].a->atomicNumber == 1) {
             weights[i] -= 0.5;
-        if (atomPriorities[i].a->isSharedAndInner && !center->isSharedAndInner)
+        }
+        if (atomPriorities[i].a->isSharedAndInner &&
+            !center->isSharedAndInner) {
             weights[i] -= 2000; // forced bond to shared and inner
+        }
 
-        if (center->crossLayout)
-            if (atomPriorities[i].a->neighbors.size() > 1)
+        if (center->crossLayout) {
+            if (atomPriorities[i].a->neighbors.size() > 1) {
                 weights[i] += 200;
+            }
+        }
         if (/* atomPriorities[i].a->isStereogenic && */ atomPriorities[i]
-                .a->hasStereochemistrySet)
+                .a->hasStereochemistrySet) {
             weights[i] += 10000; // to avoid problems with wedges when 2
-                                 // stereocenters are near
+        }
+        // stereocenters are near
         for (unsigned int j = 0; j < atomPriorities[i].a->bonds.size(); j++) {
             if (atomPriorities[i].a->bonds[j]->bondOrder == 2) {
                 weights[i] += 100;
@@ -865,17 +942,19 @@ bool sketcherMinimizerAtom::setCIPPriorities(
             sketcherMinimizerAtom* res =
                 CIPPriority(atomPriorities[i].a, atomPriorities[j].a, center);
 
-            if (res == atomPriorities[i].a)
+            if (res == atomPriorities[i].a) {
                 atomPriorities[i].priority--;
-            else if (res == atomPriorities[j].a)
+            } else if (res == atomPriorities[j].a) {
                 atomPriorities[j].priority--;
+            }
         }
     }
     vector<bool> found(4, false);
 
     for (auto& atomPrioritie : atomPriorities) {
-        if (found[atomPrioritie.priority])
+        if (found[atomPrioritie.priority]) {
             return false; // two atoms have the same priority
+        }
         found[atomPrioritie.priority] = true;
     }
     return true;
@@ -893,16 +972,18 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
     assert(at1);
     assert(at2);
 
-    if (at1->atomicNumber > at2->atomicNumber)
+    if (at1->atomicNumber > at2->atomicNumber) {
         return at1;
-    else if (at2->atomicNumber > at1->atomicNumber)
+    } else if (at2->atomicNumber > at1->atomicNumber) {
         return at2;
+    }
     if (center->_hasRingChirality && !center->m_ignoreRingChirality) {
         if (sketcherMinimizer::sameRing(center, at1, at2)) {
-            if (at1->_generalUseN > at2->_generalUseN)
+            if (at1->_generalUseN > at2->_generalUseN) {
                 return at1;
-            else
+            } else {
                 return at2;
+            }
         }
     }
 
@@ -953,20 +1034,25 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
         sketcherMinimizerAtom::finalizeScores(AN2);
 
         size_t nn = AN1.size();
-        if (AN2.size() < nn)
+        if (AN2.size() < nn) {
             nn = AN2.size();
-
-        for (size_t i = 0; i < nn; ++i) {
-            if (AN1[i] < AN2[i])
-                return at1;
-            if (AN2[i] < AN1[i])
-                return at2;
         }
 
-        if (AN1.size() > AN2.size())
+        for (size_t i = 0; i < nn; ++i) {
+            if (AN1[i] < AN2[i]) {
+                return at1;
+            }
+            if (AN2[i] < AN1[i]) {
+                return at2;
+            }
+        }
+
+        if (AN1.size() > AN2.size()) {
             return at1;
-        if (AN2.size() > AN1.size())
+        }
+        if (AN2.size() > AN1.size()) {
             return at2;
+        }
 
         AN1 = sketcherMinimizerAtom::expandOneLevel(AN1);
         AN2 = sketcherMinimizerAtom::expandOneLevel(AN2);
@@ -976,8 +1062,9 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
 
 void sketcherMinimizerAtom::chooseFirstAndSortAccordingly(vector<CIPAtom>& V)
 {
-    if (V.size() < 2)
+    if (V.size() < 2) {
         return;
+    }
     vector<CIPAtom> copyV = V;
     V.clear();
     map<sketcherMinimizerAtom*, unsigned int> friendsMask;
@@ -1007,8 +1094,9 @@ vector<CIPAtom> sketcherMinimizerAtom::expandOneLevel(vector<CIPAtom>& oldV)
     for (auto& an : oldV) {
         for (unsigned int aa = 0; aa < an.theseAtoms.size(); aa++) {
             sketcherMinimizerAtom* a = an.theseAtoms[aa].second;
-            if (a == nullptr)
+            if (a == nullptr) {
                 continue; // dummy atom
+            }
             //    if (visitedThisRound[a]) continue; // a is present twice
             //    because closing a ring and has already been dealt with
             visitedThisRound[a] = true;
@@ -1070,8 +1158,9 @@ vector<CIPAtom> sketcherMinimizerAtom::expandOneLevel(vector<CIPAtom>& oldV)
 void sketcherMinimizerAtom::assignMedals(vector<CIPAtom>& v)
 {
 
-    if (v.size() < 1)
+    if (v.size() < 1) {
         return;
+    }
     map<sketcherMinimizerAtom*, vector<int>>* medals = v[0].medals;
 
     vector<bool> isEqualToPrevious(v.size());
@@ -1091,12 +1180,14 @@ void sketcherMinimizerAtom::assignMedals(vector<CIPAtom>& v)
         }
         for (auto allParent : v[i].allParents) {
             vector<int> medalsV = (*medals)[allParent];
-            while (medalsV.size() < medalLvl)
+            while (medalsV.size() < medalLvl) {
                 medalsV.push_back(0);
-            if (medalsV.size() > medalLvl)
+            }
+            if (medalsV.size() > medalLvl) {
                 medalsV[medalLvl] = medalsV[medalLvl] + 1;
-            else
+            } else {
                 medalsV.push_back(1);
+            }
             (*medals)[allParent] = medalsV;
         }
         medalLvl++;
@@ -1106,8 +1197,9 @@ void sketcherMinimizerAtom::assignMedals(vector<CIPAtom>& v)
 void sketcherMinimizerAtom::finalizeScores(vector<CIPAtom>& v)
 {
 
-    if (v.size() < 1)
+    if (v.size() < 1) {
         return;
+    }
     vector<bool> isEqualToPrevious(v.size());
     for (unsigned int i = 1; i < v.size();
          i++) { // need to be done before assigning the scores because they are
@@ -1127,8 +1219,9 @@ void sketcherMinimizerAtom::finalizeScores(vector<CIPAtom>& v)
         }
         /* write the score */
         for (auto allParent : v[i].allParents) {
-            if ((*scores)[allParent] == 0)
+            if ((*scores)[allParent] == 0) {
                 (*scores)[allParent] = score;
+            }
         }
         score++;
     }
@@ -1139,8 +1232,9 @@ sketcherMinimizerBond*
 sketcherMinimizerAtom::bondTo(sketcherMinimizerAtom* at) const
 {
     for (unsigned int i = 0; i < neighbors.size(); i++) {
-        if (neighbors[i] == at)
+        if (neighbors[i] == at) {
             return bonds[i];
+        }
     }
     return nullptr;
 }
@@ -1157,8 +1251,9 @@ int sketcherMinimizerAtom::readStereochemistry(
         _hasRingChirality = false;
         m_isStereogenic = false;
     }
-    if (!canBeChiral())
+    if (!canBeChiral()) {
         return 0;
+    }
     //    if (neighbors.size () != 4 && neighbors.size () != 3) return 0;
 
     sketcherMinimizerAtom dummyH;
@@ -1188,8 +1283,9 @@ int sketcherMinimizerAtom::readStereochemistry(
             float newAngle = sketcherMinimizerMaths::signedAngle(
                 lastPoppedAtom->coordinates, coordinates,
                 neighs[i]->coordinates);
-            if (newAngle < 0)
+            if (newAngle < 0) {
                 newAngle += 360;
+            }
             if (newAngle < smallestAngle) {
                 smallestAngle = newAngle;
                 lastPoppedIndex = i;
@@ -1204,8 +1300,9 @@ int sketcherMinimizerAtom::readStereochemistry(
     }
 
     float totalAngle = 0;
-    for (float angle : angles)
+    for (float angle : angles) {
         totalAngle += angle;
+    }
     angles.push_back(360.f - totalAngle);
 
     bool semiplane = false;
@@ -1232,18 +1329,23 @@ int sketcherMinimizerAtom::readStereochemistry(
     for (unsigned int i = 0; i < orderedBonds.size(); i++) {
         if (orderedBonds[i]->hasStereochemistryDisplay) {
             if (!orderedBonds[i]->isReversed &&
-                orderedBonds[i]->startAtom != this)
+                orderedBonds[i]->startAtom != this) {
                 continue;
-            if (orderedBonds[i]->isReversed && orderedBonds[i]->endAtom != this)
+            }
+            if (orderedBonds[i]->isReversed &&
+                orderedBonds[i]->endAtom != this) {
                 continue;
+            }
 
             bool wedge = orderedBonds[i]->isWedge;
 
-            if (orderedBonds[i]->isReversed)
+            if (orderedBonds[i]->isReversed) {
                 wedge = !wedge;
+            }
 
-            if (orderedBonds[i]->startAtom != this)
+            if (orderedBonds[i]->startAtom != this) {
                 wedge = !wedge;
+            }
 
             if (wedge) {
                 if (wedgeN == -1) {
@@ -1263,9 +1365,9 @@ int sketcherMinimizerAtom::readStereochemistry(
 
     int startIndex = 0;
     bool invert = false;
-    if (dashedN == -1 && wedgeN == -1)
+    if (dashedN == -1 && wedgeN == -1) {
         giveUp = true;
-    else if (dashedN == -1) {
+    } else if (dashedN == -1) {
         startIndex = wedgeN;
 
     } else if (wedgeN == -1) {
@@ -1273,8 +1375,9 @@ int sketcherMinimizerAtom::readStereochemistry(
         invert = true;
 
     } else {
-        if (orderedBonds.size() == 3)
+        if (orderedBonds.size() == 3) {
             return 0;
+        }
         if (wedgeN - dashedN == 1 || wedgeN - dashedN == -3) {
             startIndex = wedgeN;
 
@@ -1316,8 +1419,9 @@ int sketcherMinimizerAtom::readStereochemistry(
         p.a = orderedNeigh;
         atomPriorities.push_back(p);
     }
-    if (atomPriorities.size() != 4)
+    if (atomPriorities.size() != 4) {
         return 0;
+    }
 
     vector<int> canonical;
     canonical.push_back(0);
@@ -1329,32 +1433,37 @@ int sketcherMinimizerAtom::readStereochemistry(
     bool isStereocenter = setCIPPriorities(atomPriorities, this);
 
     if (!isStereocenter) {
-        if (!readOnly)
+        if (!readOnly) {
             if (!m_ignoreRingChirality) {
                 _hasRingChirality = true;
                 isStereocenter = setCIPPriorities(atomPriorities, this);
             }
+        }
     }
 
     if (!isStereocenter) {
-        if (!readOnly)
+        if (!readOnly) {
             _hasRingChirality = false;
+        }
     }
 
-    if (!isStereocenter)
+    if (!isStereocenter) {
         giveUp = true;
-    else {
-        if (!readOnly)
+    } else {
+        if (!readOnly) {
             m_isStereogenic = true;
+        }
     }
     if (totalSubstituentsN < 4 && (atomicNumber != 7 && atomicNumber != 16)) {
-        if (!readOnly)
+        if (!readOnly) {
             m_isStereogenic = false;
+        }
     }
 
     if (!m_isStereogenic) {
-        if (!readOnly)
+        if (!readOnly) {
             _hasRingChirality = false;
+        }
     }
     for (auto n : neighbors) {
         for (auto& atomPrioritie : atomPriorities) {
@@ -1365,36 +1474,42 @@ int sketcherMinimizerAtom::readStereochemistry(
         }
     }
 
-    if (!matchCIPSequence(canonical, m_RSPriorities))
+    if (!matchCIPSequence(canonical, m_RSPriorities)) {
         m_clockwiseInvert = true;
-    else
+    } else {
         m_clockwiseInvert = false;
+    }
 
     if (!giveUp) {
         int outofPlaceAtoms = 0;
         for (unsigned int i = 0; i < atomPriorities.size(); i++) {
             //  cerr <<i<<"    "<<atomPriorities[i].a->atomicNumber<<endl;
             int n = startIndex + i;
-            if (n > 3)
+            if (n > 3) {
                 n -= 4;
-            if (atomPriorities[n].priority != i)
+            }
+            if (atomPriorities[n].priority != i) {
                 outofPlaceAtoms++;
+            }
         }
-        if (outofPlaceAtoms == 2)
+        if (outofPlaceAtoms == 2) {
             invert = !invert;
-        else if (outofPlaceAtoms == 4) {
+        } else if (outofPlaceAtoms == 4) {
             int n2 = atomPriorities[startIndex].priority + startIndex;
-            if (n2 > 3)
+            if (n2 > 3) {
                 n2 -= 4;
-            if (atomPriorities[n2].priority != 0)
+            }
+            if (atomPriorities[n2].priority != 0) {
                 invert = !invert; // if I swapped position 0 with another will
-                                  // that settle both atoms?
+            }
+            // that settle both atoms?
         }
 
-        if (invert)
+        if (invert) {
             return -1;
-        else
+        } else {
             return 1;
+        }
     }
     return 0;
 }
@@ -1411,10 +1526,12 @@ bool sketcherMinimizerAtom::canBeChiral() const
             return true;
         }
     }
-    if (neighbors.size() != 3 && neighbors.size() != 4)
+    if (neighbors.size() != 3 && neighbors.size() != 4) {
         return false;
-    if ((neighbors.size() + _implicitHs != 4))
+    }
+    if ((neighbors.size() + _implicitHs != 4)) {
         return false;
+    }
 
     return true;
 }
@@ -1437,10 +1554,11 @@ sketcherMinimizerPointF sketcherMinimizerAtom::getSingleAdditionVector(
             }
         }
     }
-    if (n > 0)
+    if (n > 0) {
         out /= n;
-    else
+    } else {
         return sketcherMinimizerPointF(50, 0);
+    }
     out *= -1;
     return out;
 }
@@ -1452,8 +1570,9 @@ sketcherMinimizerPointF sketcherMinimizerAtom::getSingleAdditionVector() const
     if (neighbors.size()) {
         for (auto neighbor : neighbors) {
             float f = 1.f;
-            if (sketcherMinimizer::sameRing(this, neighbor))
+            if (sketcherMinimizer::sameRing(this, neighbor)) {
                 f = 4.f;
+            }
             out += f * (neighbor->coordinates - coordinates);
             totalf += f;
         }
@@ -1465,51 +1584,73 @@ sketcherMinimizerPointF sketcherMinimizerAtom::getSingleAdditionVector() const
 
 bool sketcherMinimizerAtom::isMetal(const unsigned int atomicNumber)
 {
-    if (atomicNumber >= 3 && atomicNumber <= 4)
+    if (atomicNumber >= 3 && atomicNumber <= 4) {
         return true;
-    if (atomicNumber >= 11 && atomicNumber <= 12)
+    }
+    if (atomicNumber >= 11 && atomicNumber <= 12) {
         return true;
-    if (atomicNumber >= 19 && atomicNumber <= 20)
+    }
+    if (atomicNumber >= 19 && atomicNumber <= 20) {
         return true;
-    if (atomicNumber >= 37 && atomicNumber <= 38)
+    }
+    if (atomicNumber >= 37 && atomicNumber <= 38) {
         return true;
-    if (atomicNumber >= 55 && atomicNumber <= 56)
+    }
+    if (atomicNumber >= 55 && atomicNumber <= 56) {
         return true;
-    if (atomicNumber >= 87 && atomicNumber <= 88)
+    }
+    if (atomicNumber >= 87 && atomicNumber <= 88) {
         return true;
+    }
 
-    if (atomicNumber >= 21 && atomicNumber <= 30)
+    if (atomicNumber >= 21 && atomicNumber <= 30) {
         return true;
-    if (atomicNumber >= 39 && atomicNumber <= 48)
+    }
+    if (atomicNumber >= 39 && atomicNumber <= 48) {
         return true;
-    if (atomicNumber >= 72 && atomicNumber <= 80)
+    }
+    if (atomicNumber >= 72 && atomicNumber <= 80) {
         return true;
-    if (atomicNumber >= 104 && atomicNumber <= 112)
+    }
+    if (atomicNumber >= 104 && atomicNumber <= 112) {
         return true;
-    if (atomicNumber >= 57 && atomicNumber <= 71)
+    }
+    if (atomicNumber >= 57 && atomicNumber <= 71) {
         return true; // lanthanoids
-    if (atomicNumber >= 89 && atomicNumber <= 103)
+    }
+    if (atomicNumber >= 89 && atomicNumber <= 103) {
         return true; // actinoids
-    if (atomicNumber == 13)
+    }
+    if (atomicNumber == 13) {
         return true;
-    if (atomicNumber == 31)
+    }
+    if (atomicNumber == 31) {
         return true;
-    if (atomicNumber == 49)
+    }
+    if (atomicNumber == 49) {
         return true;
-    if (atomicNumber == 81)
+    }
+    if (atomicNumber == 81) {
         return true;
-    if (atomicNumber == 32)
+    }
+    if (atomicNumber == 32) {
         return true;
-    if (atomicNumber == 50)
+    }
+    if (atomicNumber == 50) {
         return true;
-    if (atomicNumber == 82)
+    }
+    if (atomicNumber == 82) {
         return true;
-    if (atomicNumber == 51)
+    }
+    if (atomicNumber == 51) {
         return true;
-    if (atomicNumber == 83)
+    }
+    if (atomicNumber == 83) {
         return true;
-    if (atomicNumber == 84)
+    }
+    if (atomicNumber == 84) {
         return true;
+    }
     return false;
 }
 

--- a/sketcherMinimizerAtom.cpp
+++ b/sketcherMinimizerAtom.cpp
@@ -912,13 +912,13 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
 
     vector<CIPAtom> AN1, AN2;
 
-    map<sketcherMinimizerAtom*, int> score1,
+    map<sketcherMinimizerAtom *, int> score1,
         score2; // used to keep track if a parent atom has been found to have
                 // priority over another
-    map<sketcherMinimizerAtom*, vector<int>> medals1,
+    map<sketcherMinimizerAtom *, vector<int>> medals1,
         medals2; // marks if an atom is a parent of the atoms being evaluated in
                  // the current iteration
-    map<sketcherMinimizerAtom*, int> visited1,
+    map<sketcherMinimizerAtom *, int> visited1,
         visited2; // marks at which iteration this atom was evaluated
 
     visited1[center] = 1;
@@ -926,11 +926,11 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
     visited1[at1] = 2;
     visited2[at2] = 2;
 
-    vector<pair<int, sketcherMinimizerAtom*>> v1, v2;
+    vector<pair<int, sketcherMinimizerAtom *>> v1, v2;
     v1.push_back(pair<int, sketcherMinimizerAtom*>(at1->atomicNumber, at1));
     v2.push_back(pair<int, sketcherMinimizerAtom*>(at2->atomicNumber, at2));
 
-    vector<sketcherMinimizerAtom*> parents1, parents2;
+    vector<sketcherMinimizerAtom *> parents1, parents2;
     parents1.push_back(center);
     parents1.push_back(at1);
     parents2.push_back(center);
@@ -1035,7 +1035,7 @@ vector<CIPAtom> sketcherMinimizerAtom::expandOneLevel(vector<CIPAtom>& oldV)
                               (*visited)[a] + 1) // closing a ring to an atom
                                                  // already visited in a
                                                  // previous cycle
-                        );
+                         );
                     theseAts.push_back(pair<int, sketcherMinimizerAtom*>(
                         neigh->atomicNumber,
                         ghost ? ((sketcherMinimizerAtom*) NULL)

--- a/sketcherMinimizerAtom.h
+++ b/sketcherMinimizerAtom.h
@@ -175,8 +175,9 @@ class EXPORT_COORDGEN sketcherMinimizerAtom
     bool isNeighborOf(sketcherMinimizerAtom* at2) const
     {
         for (auto& neighbor : at2->neighbors) {
-            if (neighbor == this)
+            if (neighbor == this) {
                 return true;
+            }
         }
         return false;
     }

--- a/sketcherMinimizerAtom.h
+++ b/sketcherMinimizerAtom.h
@@ -174,8 +174,8 @@ class EXPORT_COORDGEN sketcherMinimizerAtom
     /* return true if this and at2 share a bond */
     bool isNeighborOf(sketcherMinimizerAtom* at2) const
     {
-        for (unsigned int i = 0; i < at2->neighbors.size(); i++) {
-            if (at2->neighbors[i] == this)
+        for (auto& neighbor : at2->neighbors) {
+            if (neighbor == this)
                 return true;
         }
         return false;

--- a/sketcherMinimizerAtom.h
+++ b/sketcherMinimizerAtom.h
@@ -144,7 +144,10 @@ class EXPORT_COORDGEN sketcherMinimizerAtom
      * stereochemistry */
     bool hasNoStereoActiveBonds() const;
 
-    const sketcherMinimizerPointF& getCoordinates() const { return coordinates; }
+    const sketcherMinimizerPointF& getCoordinates() const
+    {
+        return coordinates;
+    }
     int getAtomicNumber() const { return atomicNumber; }
 
     void setAtomicNumber(int number) { atomicNumber = number; }

--- a/sketcherMinimizerBendInteraction.h
+++ b/sketcherMinimizerBendInteraction.h
@@ -29,8 +29,8 @@ class sketcherMinimizerBendInteraction : public sketcherMinimizerInteraction
         k2 = 0.05f;
         //    multipleSnap = false;
         isRing = false;
-    };
-    virtual ~sketcherMinimizerBendInteraction(){};
+    }
+    ~sketcherMinimizerBendInteraction() override = default;
 
     /* calculate energy associated with the current state */
     void energy(float& e) override

--- a/sketcherMinimizerBendInteraction.h
+++ b/sketcherMinimizerBendInteraction.h
@@ -46,35 +46,37 @@ class sketcherMinimizerBendInteraction : public sketcherMinimizerInteraction
     {
         float a = angle();
 
-        if (a < 0)
+        if (a < 0) {
             a = -a;
+        }
         float target = restV;
-        if (target > 180)
+        if (target > 180) {
             target = 360 - target; // this is needed when the angle function is
-                                   // based on cos and only works in [0, 180[ .
-                                   // not needed if using atan2
-                                   /*    if (multipleSnap) {
-                                           vector <int > targets;
-                                           targets .push_back(60);
-                                           targets .push_back(90);
-                                           targets .push_back(120);
-                                       //    targets .push_back(150);
-                           
-                                           target = targets [0];
-                                           float distance = target - a;
-                                           if (distance < 0) distance =  -distance;
-                                           for (unsigned int i =1; i < targets.size (); i++) {
-                                               float newtarget = targets [i];
-                                               float newdistance = newtarget - a;
-                                               if (newdistance < 0) newdistance = - newdistance;
-                                               if (newdistance < distance) {
-                                                   target = newtarget;
-                                                   distance = newdistance;
-                                               }
-                                           }
-                           
-                                       }
-                                        */
+        }
+        // based on cos and only works in [0, 180[ .
+        // not needed if using atan2
+        /*    if (multipleSnap) {
+                vector <int > targets;
+                targets .push_back(60);
+                targets .push_back(90);
+                targets .push_back(120);
+            //    targets .push_back(150);
+
+                target = targets [0];
+                float distance = target - a;
+                if (distance < 0) distance =  -distance;
+                for (unsigned int i =1; i < targets.size (); i++) {
+                    float newtarget = targets [i];
+                    float newdistance = newtarget - a;
+                    if (newdistance < 0) newdistance = - newdistance;
+                    if (newdistance < distance) {
+                        target = newtarget;
+                        distance = newdistance;
+                    }
+                }
+
+            }
+             */
         float dA = target - a;
         energy(totalE);
         float x1 = atom1->coordinates.x();
@@ -96,18 +98,22 @@ class sketcherMinimizerBendInteraction : public sketcherMinimizerInteraction
         sketcherMinimizerPointF n1(v1y, -v1x);
         sketcherMinimizerPointF n2(v2y, -v2x);
 
-        if ((n1.x() * v3x + n1.y() * v3y) > 0)
+        if ((n1.x() * v3x + n1.y() * v3y) > 0) {
             n1 *= -1; // dot product n1 v3
-        if ((n2.x() * v3x + n2.y() * v3y) < 0)
+        }
+        if ((n2.x() * v3x + n2.y() * v3y) < 0) {
             n2 *= -1; // dot product n2 v3
+        }
 
         float q1 = sqrt(n1.x() * n1.x() + n1.y() * n1.y());
-        if (q1 < SKETCHER_EPSILON)
+        if (q1 < SKETCHER_EPSILON) {
             q1 = SKETCHER_EPSILON;
+        }
 
         float q2 = sqrt(n2.x() * n2.x() + n2.y() * n2.y());
-        if (q2 < SKETCHER_EPSILON)
+        if (q2 < SKETCHER_EPSILON) {
             q2 = SKETCHER_EPSILON;
+        }
 
         n1 /= q1;
         n2 /= q2;
@@ -134,14 +140,16 @@ class sketcherMinimizerBendInteraction : public sketcherMinimizerInteraction
         float v2y = y3 - y2;
 
         float d = sqrt(v1x * v1x + v1y * v1y) * sqrt(v2x * v2x + v2y * v2y);
-        if (d < SKETCHER_EPSILON)
+        if (d < SKETCHER_EPSILON) {
             d = SKETCHER_EPSILON;
+        }
         float cosine = (v1x * v2x + v1y * v2y) / d;
 
-        if (cosine < -1)
+        if (cosine < -1) {
             cosine = -1;
-        else if (cosine > 1)
+        } else if (cosine > 1) {
             cosine = 1;
+        }
         return float((acos(cosine)) * 180 / M_PI);
     }
     sketcherMinimizerAtom* atom3;

--- a/sketcherMinimizerBond.cpp
+++ b/sketcherMinimizerBond.cpp
@@ -15,7 +15,7 @@ using namespace std;
 sketcherMinimizerAtom* sketcherMinimizerBond::startAtomCIPFirstNeighbor() const
 {
     if (bondOrder != 2)
-        return NULL;
+        return nullptr;
     sketcherMinimizerAtom* a = startAtom;
     if (a->neighbors.size() == 2) {
         if (a->neighbors[0] == endAtom)
@@ -31,15 +31,15 @@ sketcherMinimizerAtom* sketcherMinimizerBond::startAtomCIPFirstNeighbor() const
         if (ats.size() == 2)
             return sketcherMinimizerAtom::CIPPriority(ats[0], ats[1],
                                                       startAtom);
-        return NULL;
+        return nullptr;
     } else
-        return NULL;
+        return nullptr;
 }
 
 sketcherMinimizerAtom* sketcherMinimizerBond::endAtomCIPFirstNeighbor() const
 {
     if (bondOrder != 2)
-        return NULL;
+        return nullptr;
     sketcherMinimizerAtom* a = endAtom;
     if (a->neighbors.size() == 2) {
         if (a->neighbors[0] == startAtom)
@@ -54,9 +54,9 @@ sketcherMinimizerAtom* sketcherMinimizerBond::endAtomCIPFirstNeighbor() const
         }
         if (ats.size() == 2)
             return sketcherMinimizerAtom::CIPPriority(ats[0], ats[1], endAtom);
-        return NULL;
+        return nullptr;
     } else
-        return NULL;
+        return nullptr;
 }
 
 void sketcherMinimizerBond::setAbsoluteStereoFromStereoInfo()
@@ -93,10 +93,10 @@ bool sketcherMinimizerBond::checkStereoChemistry() const
     if (isInSmallRing())
         return true;
     sketcherMinimizerAtom* firstCIPNeighborStart = startAtomCIPFirstNeighbor();
-    if (firstCIPNeighborStart == NULL)
+    if (firstCIPNeighborStart == nullptr)
         return true;
     sketcherMinimizerAtom* firstCIPNeighborEnd = endAtomCIPFirstNeighbor();
-    if (firstCIPNeighborEnd == NULL)
+    if (firstCIPNeighborEnd == nullptr)
         return true;
     return (sketcherMinimizerMaths::sameSide(
                 firstCIPNeighborStart->getCoordinates(),

--- a/sketcherMinimizerBond.cpp
+++ b/sketcherMinimizerBond.cpp
@@ -14,49 +14,59 @@ using namespace std;
 
 sketcherMinimizerAtom* sketcherMinimizerBond::startAtomCIPFirstNeighbor() const
 {
-    if (bondOrder != 2)
+    if (bondOrder != 2) {
         return nullptr;
+    }
     sketcherMinimizerAtom* a = startAtom;
     if (a->neighbors.size() == 2) {
-        if (a->neighbors[0] == endAtom)
+        if (a->neighbors[0] == endAtom) {
             return a->neighbors[1];
-        else
+        } else {
             return a->neighbors[0];
+        }
     } else if (a->neighbors.size() == 3) {
         std::vector<sketcherMinimizerAtom*> ats;
         foreach (sketcherMinimizerAtom* n, a->neighbors) {
-            if (n != endAtom)
+            if (n != endAtom) {
                 ats.push_back(n);
+            }
         }
-        if (ats.size() == 2)
+        if (ats.size() == 2) {
             return sketcherMinimizerAtom::CIPPriority(ats[0], ats[1],
                                                       startAtom);
+        }
         return nullptr;
-    } else
+    } else {
         return nullptr;
+    }
 }
 
 sketcherMinimizerAtom* sketcherMinimizerBond::endAtomCIPFirstNeighbor() const
 {
-    if (bondOrder != 2)
+    if (bondOrder != 2) {
         return nullptr;
+    }
     sketcherMinimizerAtom* a = endAtom;
     if (a->neighbors.size() == 2) {
-        if (a->neighbors[0] == startAtom)
+        if (a->neighbors[0] == startAtom) {
             return a->neighbors[1];
-        else
+        } else {
             return a->neighbors[0];
+        }
     } else if (a->neighbors.size() == 3) {
         std::vector<sketcherMinimizerAtom*> ats;
         foreach (sketcherMinimizerAtom* n, a->neighbors) {
-            if (n != startAtom)
+            if (n != startAtom) {
                 ats.push_back(n);
+            }
         }
-        if (ats.size() == 2)
+        if (ats.size() == 2) {
             return sketcherMinimizerAtom::CIPPriority(ats[0], ats[1], endAtom);
+        }
         return nullptr;
-    } else
+    } else {
         return nullptr;
+    }
 }
 
 void sketcherMinimizerBond::setAbsoluteStereoFromStereoInfo()
@@ -76,8 +86,9 @@ void sketcherMinimizerBond::setAbsoluteStereoFromStereoInfo()
             }
             bool settingIsZ =
                 (m_stereo.stereo == sketcherMinimizerBondStereoInfo::cis);
-            if (invert)
+            if (invert) {
                 settingIsZ = !settingIsZ;
+            }
             isZ = settingIsZ;
         }
     }
@@ -88,16 +99,20 @@ void sketcherMinimizerBond::setAbsoluteStereoFromStereoInfo()
 
 bool sketcherMinimizerBond::checkStereoChemistry() const
 {
-    if (!isStereo())
+    if (!isStereo()) {
         return true;
-    if (isInSmallRing())
+    }
+    if (isInSmallRing()) {
         return true;
+    }
     sketcherMinimizerAtom* firstCIPNeighborStart = startAtomCIPFirstNeighbor();
-    if (firstCIPNeighborStart == nullptr)
+    if (firstCIPNeighborStart == nullptr) {
         return true;
+    }
     sketcherMinimizerAtom* firstCIPNeighborEnd = endAtomCIPFirstNeighbor();
-    if (firstCIPNeighborEnd == nullptr)
+    if (firstCIPNeighborEnd == nullptr) {
         return true;
+    }
     return (sketcherMinimizerMaths::sameSide(
                 firstCIPNeighborStart->getCoordinates(),
                 firstCIPNeighborEnd->getCoordinates(),
@@ -108,8 +123,9 @@ bool sketcherMinimizerBond::checkStereoChemistry() const
 bool sketcherMinimizerBond::isInSmallRing() const
 {
     for (auto ring : rings) {
-        if (!ring->isMacrocycle())
+        if (!ring->isMacrocycle()) {
             return true;
+        }
     }
     return false;
 }
@@ -117,8 +133,9 @@ bool sketcherMinimizerBond::isInSmallRing() const
 bool sketcherMinimizerBond::isInMacrocycle() const
 {
     for (auto ring : rings) {
-        if (ring->isMacrocycle())
+        if (ring->isMacrocycle()) {
             return true;
+        }
     }
     return false;
 }
@@ -131,14 +148,18 @@ bool sketcherMinimizerBond::isTerminal() const
 
 bool sketcherMinimizerBond::isInterFragment() const
 {
-    if (getStartAtom()->getBonds().size() == 1)
+    if (getStartAtom()->getBonds().size() == 1) {
         return false;
-    if (getEndAtom()->getBonds().size() == 1)
+    }
+    if (getEndAtom()->getBonds().size() == 1) {
         return false;
-    if (sketcherMinimizerAtom::shareARing(getStartAtom(), getEndAtom()))
+    }
+    if (sketcherMinimizerAtom::shareARing(getStartAtom(), getEndAtom())) {
         return false;
-    if (isStereo())
+    }
+    if (isStereo()) {
         return false;
+    }
     return true;
 }
 
@@ -167,8 +188,9 @@ bool sketcherMinimizerBond::isStereo() const
     }
     sketcherMinimizerRing* ring =
         sketcherMinimizerAtom::shareARing(getStartAtom(), getEndAtom());
-    if (ring && !ring->isMacrocycle())
+    if (ring && !ring->isMacrocycle()) {
         return false;
+    }
     return true;
 }
 

--- a/sketcherMinimizerBond.h
+++ b/sketcherMinimizerBond.h
@@ -28,10 +28,7 @@ struct sketcherMinimizerBondStereoInfo {
 class EXPORT_COORDGEN sketcherMinimizerBond
 {
   public:
-    sketcherMinimizerBond()
-        : startAtom(nullptr), endAtom(nullptr), _SSSRParent(nullptr), rings()
-    {
-    }
+    sketcherMinimizerBond() : rings() {}
     sketcherMinimizerBond(sketcherMinimizerAtom* at1,
                           sketcherMinimizerAtom* at2)
         : sketcherMinimizerBond()
@@ -43,8 +40,8 @@ class EXPORT_COORDGEN sketcherMinimizerBond
     virtual ~sketcherMinimizerBond() = default;
 
     virtual bool isResidueInteraction() { return false; }
-    sketcherMinimizerAtom* startAtom;
-    sketcherMinimizerAtom* endAtom;
+    sketcherMinimizerAtom* startAtom = nullptr;
+    sketcherMinimizerAtom* endAtom = nullptr;
     sketcherMinimizerAtom* getStartAtom() const { return startAtom; }
     sketcherMinimizerAtom* getEndAtom() const { return endAtom; }
 
@@ -101,9 +98,8 @@ class EXPORT_COORDGEN sketcherMinimizerBond
     int bondOrder{1};
     bool skip{false};
     bool isZEActive{false}; // does it have  a Z and E form?
-    bool isZ{
-        false}; // used for double bonds to distinguish Z from E form. bonds
-                // default to E
+    bool isZ{false}; // used for double bonds to distinguish Z from E form.
+                     // bonds default to E
 
     int m_chmN =
         -1; // idx of the corresponding ChmAtom if molecule comes from 3d
@@ -116,7 +112,7 @@ class EXPORT_COORDGEN sketcherMinimizerBond
     bool _SSSRVisited{false};
     bool _SSSRParentAtStart{true};
     bool m_ignoreZE{false};
-    sketcherMinimizerBond* _SSSRParent;
+    sketcherMinimizerBond* _SSSRParent{nullptr};
     std::vector<sketcherMinimizerRing*> rings;
 };
 

--- a/sketcherMinimizerBond.h
+++ b/sketcherMinimizerBond.h
@@ -29,11 +29,7 @@ class EXPORT_COORDGEN sketcherMinimizerBond
 {
   public:
     sketcherMinimizerBond()
-        : startAtom(NULL), endAtom(NULL), bondOrder(1), skip(false),
-          isZEActive(false), isZ(false), isWedge(false), isReversed(false),
-          hasStereochemistryDisplay(false), _SSSRVisited(false),
-          _SSSRParentAtStart(true), m_ignoreZE(false), _SSSRParent(NULL),
-          rings()
+        : startAtom(nullptr), endAtom(nullptr), _SSSRParent(nullptr), rings()
     {
     }
     sketcherMinimizerBond(sketcherMinimizerAtom* at1,
@@ -44,7 +40,7 @@ class EXPORT_COORDGEN sketcherMinimizerBond
         endAtom = at2;
     }
 
-    virtual ~sketcherMinimizerBond(){};
+    virtual ~sketcherMinimizerBond() = default;
 
     virtual bool isResidueInteraction() { return false; }
     sketcherMinimizerAtom* startAtom;
@@ -102,23 +98,24 @@ class EXPORT_COORDGEN sketcherMinimizerBond
     /* return true if the E/Z stereochemistry as read from the atoms coordinates
      * matches the label */
     bool checkStereoChemistry() const;
-    int bondOrder;
-    bool skip;
-    bool isZEActive; // does it have  a Z and E form?
-    bool isZ; // used for double bonds to distinguish Z from E form. bonds
-              // default to E
+    int bondOrder{1};
+    bool skip{false};
+    bool isZEActive{false}; // does it have  a Z and E form?
+    bool isZ{
+        false}; // used for double bonds to distinguish Z from E form. bonds
+                // default to E
 
     int m_chmN =
         -1; // idx of the corresponding ChmAtom if molecule comes from 3d
 
     sketcherMinimizerBondStereoInfo m_stereo;
 
-    bool isWedge;
-    bool isReversed;
-    bool hasStereochemistryDisplay;
-    bool _SSSRVisited;
-    bool _SSSRParentAtStart;
-    bool m_ignoreZE;
+    bool isWedge{false};
+    bool isReversed{false};
+    bool hasStereochemistryDisplay{false};
+    bool _SSSRVisited{false};
+    bool _SSSRParentAtStart{true};
+    bool m_ignoreZE{false};
     sketcherMinimizerBond* _SSSRParent;
     std::vector<sketcherMinimizerRing*> rings;
 };

--- a/sketcherMinimizerClashInteraction.h
+++ b/sketcherMinimizerClashInteraction.h
@@ -10,8 +10,8 @@
 #define sketcherMINIMIZERCLASHMINIMIZERINTERACTION
 
 #include "sketcherMinimizerInteraction.h"
-#include <iostream>
 #include "sketcherMinimizerMaths.h"
+#include <iostream>
 
 /* forcefield clash */
 class sketcherMinimizerClashInteraction : public sketcherMinimizerInteraction
@@ -26,8 +26,8 @@ class sketcherMinimizerClashInteraction : public sketcherMinimizerInteraction
         restV = 900;
 
         k2 = 0.1f;
-    };
-    virtual ~sketcherMinimizerClashInteraction(){};
+    }
+    ~sketcherMinimizerClashInteraction() override = default;
 
     /* calculate the energy of the clash */
     void energy(float& e) override

--- a/sketcherMinimizerClashInteraction.h
+++ b/sketcherMinimizerClashInteraction.h
@@ -32,9 +32,8 @@ class sketcherMinimizerClashInteraction : public sketcherMinimizerInteraction
     /* calculate the energy of the clash */
     void energy(float& e) override
     {
-        squaredDistance =
-            sketcherMinimizerMaths::squaredDistancePointSegment(
-                atom2->coordinates, atom1->coordinates, atom3->coordinates);
+        squaredDistance = sketcherMinimizerMaths::squaredDistancePointSegment(
+            atom2->coordinates, atom1->coordinates, atom3->coordinates);
         if (squaredDistance > restV) {
             return;
         }
@@ -71,7 +70,8 @@ class sketcherMinimizerClashInteraction : public sketcherMinimizerInteraction
 
     float k2;
     sketcherMinimizerAtom* atom3;
-private:
+
+  private:
     float squaredDistance;
 };
 

--- a/sketcherMinimizerClashInteraction.h
+++ b/sketcherMinimizerClashInteraction.h
@@ -48,10 +48,12 @@ class sketcherMinimizerClashInteraction : public sketcherMinimizerInteraction
     void score(float& totalE, bool skipForce = false) override
     {
         energy(totalE);
-        if (skipForce)
+        if (skipForce) {
             return;
-        if (squaredDistance > restV)
+        }
+        if (squaredDistance > restV) {
             return;
+        }
 
         sketcherMinimizerPointF atomP = atom2->coordinates;
         sketcherMinimizerPointF bondP1 = atom1->coordinates;

--- a/sketcherMinimizerClashInteraction.h
+++ b/sketcherMinimizerClashInteraction.h
@@ -35,12 +35,14 @@ class sketcherMinimizerClashInteraction : public sketcherMinimizerInteraction
         squaredDistance =
             sketcherMinimizerMaths::squaredDistancePointSegment(
                 atom2->coordinates, atom1->coordinates, atom3->coordinates);
-        if (squaredDistance > restV)
+        if (squaredDistance > restV) {
             return;
+        }
 
         float dr = restV - squaredDistance;
-        if (dr > 0)
+        if (dr > 0) {
             e += 0.5f * k * k2 * dr;
+        }
     };
 
     /* calculate the forces of the clash and apply them */

--- a/sketcherMinimizerConstraintInteraction.h
+++ b/sketcherMinimizerConstraintInteraction.h
@@ -22,22 +22,22 @@ class sketcherMinimizerConstraintInteraction
         : sketcherMinimizerInteraction(at1, at1), origin(std::move(position))
     {
         k = CONSTRAINT_SCALE;
-    };
-    virtual ~sketcherMinimizerConstraintInteraction(){};
+    }
+    ~sketcherMinimizerConstraintInteraction() override = default;
 
     /* calculate the energy of the interaction */
     void energy(float& e) override
     {
         e += k * sketcherMinimizerMaths::squaredDistance(atom1->coordinates,
                                                          origin);
-    };
+    }
 
     /* calculate the forces and apply them */
     void score(float& totalE, bool = false) override
     {
         energy(totalE);
         return;
-    };
+    }
 
   private:
     sketcherMinimizerPointF origin;

--- a/sketcherMinimizerEZConstrainInteraction.h
+++ b/sketcherMinimizerEZConstrainInteraction.h
@@ -28,7 +28,7 @@ class sketcherMinimizerEZConstrainInteraction
         m_isZ = isZ;
         m_forceMovement = false;
     };
-    virtual ~sketcherMinimizerEZConstrainInteraction(){};
+    ~sketcherMinimizerEZConstrainInteraction() override = default;
 
     /* calculate the energy of the interaction */
     void energy(float& e) override

--- a/sketcherMinimizerFragment.cpp
+++ b/sketcherMinimizerFragment.cpp
@@ -30,7 +30,9 @@ CoordgenFragmentDOF::CoordgenFragmentDOF(sketcherMinimizerFragment* fragment)
 {
 }
 
-CoordgenFragmentDOF::~CoordgenFragmentDOF() {}
+CoordgenFragmentDOF::~CoordgenFragmentDOF()
+{
+}
 
 short unsigned int CoordgenFragmentDOF::getCurrentState()
 {

--- a/sketcherMinimizerFragment.cpp
+++ b/sketcherMinimizerFragment.cpp
@@ -30,9 +30,7 @@ CoordgenFragmentDOF::CoordgenFragmentDOF(sketcherMinimizerFragment* fragment)
 {
 }
 
-CoordgenFragmentDOF::~CoordgenFragmentDOF()
-{
-}
+CoordgenFragmentDOF::~CoordgenFragmentDOF() = default;
 
 short unsigned int CoordgenFragmentDOF::getCurrentState()
 {
@@ -93,7 +91,7 @@ float CoordgenFlipFragmentDOF::getCurrentPenalty() const
 
 int CoordgenFlipFragmentDOF::numberOfStates() const
 {
-    if (m_fragment->getParent() == NULL)
+    if (m_fragment->getParent() == nullptr)
         return 1;
     return 2;
 }
@@ -133,7 +131,7 @@ int CoordgenScaleFragmentDOF::tier() const
 void CoordgenScaleFragmentDOF::apply() const
 {
     if (m_currentState != 0) {
-        float scale = static_cast<float>(pow(1.4, (m_currentState + 1) / 2));
+        auto scale = static_cast<float>(pow(1.4, (m_currentState + 1) / 2));
         if (m_currentState % 2 == 0) {
             scale = 1 / scale;
         }
@@ -207,7 +205,7 @@ int CoordgenChangeParentBondLengthFragmentDOF::tier() const
 void CoordgenChangeParentBondLengthFragmentDOF::apply() const
 {
     if (m_currentState != 0) {
-        float scale = static_cast<float>(pow(1.6, (m_currentState + 1) / 2));
+        auto scale = static_cast<float>(pow(1.6, (m_currentState + 1) / 2));
         if (m_currentState % 2 == 0) {
             scale = 1 / scale;
         }
@@ -234,7 +232,7 @@ CoordgenRotateFragmentDOF::CoordgenRotateFragmentDOF(
 
 int CoordgenRotateFragmentDOF::numberOfStates() const
 {
-    if (m_fragment->getParent() == NULL)
+    if (m_fragment->getParent() == nullptr)
         return 1;
     return 5;
 }
@@ -247,7 +245,7 @@ int CoordgenRotateFragmentDOF::tier() const
 void CoordgenRotateFragmentDOF::apply() const
 {
     if (m_currentState != 0) {
-        float angle =
+        auto angle =
             static_cast<float>(M_PI / 180 * 15 * ((m_currentState + 1) / 2));
         if (m_currentState % 2 == 0) {
             angle = -angle;
@@ -358,8 +356,9 @@ float CoordgenFlipRingDOF::getCurrentPenalty() const
 
 sketcherMinimizerFragment::sketcherMinimizerFragment()
     : fixed(false), isTemplated(false), constrained(false), isChain(false),
-      _bondToParent(NULL), longestChainFromHere(0.f), numberOfChildrenAtoms(0),
-      numberOfChildrenAtomsRank(0.f), m_parent(NULL)
+      _bondToParent(nullptr), longestChainFromHere(0.f),
+      numberOfChildrenAtoms(0), numberOfChildrenAtomsRank(0.f),
+      m_parent(nullptr)
 {
     m_dofs.push_back(new CoordgenFlipFragmentDOF(this));
     //    m_dofs.push_back(new CoordgenScaleFragmentDOF(this));
@@ -387,23 +386,23 @@ std::vector<CoordgenFragmentDOF*> sketcherMinimizerFragment::getDofs()
 unsigned int sketcherMinimizerFragment::totalWeight() const
 {
     int n = 0;
-    for (unsigned int i = 0; i < m_atoms.size(); i++)
-        n += m_atoms[i]->atomicNumber + m_atoms[i]->_implicitHs;
+    for (auto m_atom : m_atoms)
+        n += m_atom->atomicNumber + m_atom->_implicitHs;
     return n;
 }
 unsigned int sketcherMinimizerFragment::countDoubleBonds() const
 {
     int n = 0;
-    for (unsigned int i = 0; i < m_bonds.size(); i++)
-        if (m_bonds[i]->bondOrder == 2)
+    for (auto m_bond : m_bonds)
+        if (m_bond->bondOrder == 2)
             ++n;
     return n;
 }
 unsigned int sketcherMinimizerFragment::countHeavyAtoms() const
 {
     int n = 0;
-    for (unsigned int i = 0; i < m_atoms.size(); i++)
-        if (m_atoms[i]->atomicNumber != 6)
+    for (auto m_atom : m_atoms)
+        if (m_atom->atomicNumber != 6)
             ++n;
     return n;
 }

--- a/sketcherMinimizerFragment.cpp
+++ b/sketcherMinimizerFragment.cpp
@@ -91,8 +91,9 @@ float CoordgenFlipFragmentDOF::getCurrentPenalty() const
 
 int CoordgenFlipFragmentDOF::numberOfStates() const
 {
-    if (m_fragment->getParent() == nullptr)
+    if (m_fragment->getParent() == nullptr) {
         return 1;
+    }
     return 2;
 }
 
@@ -118,8 +119,9 @@ CoordgenScaleFragmentDOF::CoordgenScaleFragmentDOF(
 
 int CoordgenScaleFragmentDOF::numberOfStates() const
 {
-    if (m_fragment->getRings().size() == 0)
+    if (m_fragment->getRings().size() == 0) {
         return 1;
+    }
     return 5;
 }
 
@@ -232,8 +234,9 @@ CoordgenRotateFragmentDOF::CoordgenRotateFragmentDOF(
 
 int CoordgenRotateFragmentDOF::numberOfStates() const
 {
-    if (m_fragment->getParent() == nullptr)
+    if (m_fragment->getParent() == nullptr) {
         return 1;
+    }
     return 5;
 }
 
@@ -321,8 +324,9 @@ CoordgenFlipRingDOF::CoordgenFlipRingDOF(
       m_pivotAtom2(*(fusionAtoms.rbegin())),
       m_penalty(std::abs(int(ring->size() - 2 * fusionAtoms.size() + 2)))
 {
-    for (auto atom : ring->getAtoms())
+    for (auto atom : ring->getAtoms()) {
         addAtom(atom);
+    }
 }
 
 int CoordgenFlipRingDOF::numberOfStates() const
@@ -386,24 +390,29 @@ std::vector<CoordgenFragmentDOF*> sketcherMinimizerFragment::getDofs()
 unsigned int sketcherMinimizerFragment::totalWeight() const
 {
     int n = 0;
-    for (auto m_atom : m_atoms)
+    for (auto m_atom : m_atoms) {
         n += m_atom->atomicNumber + m_atom->_implicitHs;
+    }
     return n;
 }
 unsigned int sketcherMinimizerFragment::countDoubleBonds() const
 {
     int n = 0;
-    for (auto m_bond : m_bonds)
-        if (m_bond->bondOrder == 2)
+    for (auto m_bond : m_bonds) {
+        if (m_bond->bondOrder == 2) {
             ++n;
+        }
+    }
     return n;
 }
 unsigned int sketcherMinimizerFragment::countHeavyAtoms() const
 {
     int n = 0;
-    for (auto m_atom : m_atoms)
-        if (m_atom->atomicNumber != 6)
+    for (auto m_atom : m_atoms) {
+        if (m_atom->atomicNumber != 6) {
             ++n;
+        }
+    }
     return n;
 }
 
@@ -411,8 +420,9 @@ unsigned int sketcherMinimizerFragment::countConstrainedAtoms() const
 {
     int n = 0;
     for (auto atom : m_atoms) {
-        if (atom->constrained)
+        if (atom->constrained) {
             ++n;
+        }
     }
     return n;
 }
@@ -421,8 +431,9 @@ unsigned int sketcherMinimizerFragment::countFixedAtoms() const
 {
     int n = 0;
     for (auto atom : m_atoms) {
-        if (atom->fixed)
+        if (atom->fixed) {
             ++n;
+        }
     }
     return n;
 }
@@ -467,8 +478,9 @@ void sketcherMinimizerFragment::storeCoordinateInformation()
         angle = atan2(_bondToParent->startAtom->coordinates.y() - origin.y(),
                       -_bondToParent->startAtom->coordinates.x() + origin.x());
     } else {
-        if (!constrained && !fixed)
+        if (!constrained && !fixed) {
             origin = m_atoms[0]->getCoordinates();
+        }
     }
 
     float cosine = cos(-angle);

--- a/sketcherMinimizerFragment.h
+++ b/sketcherMinimizerFragment.h
@@ -76,10 +76,10 @@ class CoordgenRotateFragmentDOF : public CoordgenFragmentDOF
 {
   public:
     CoordgenRotateFragmentDOF(sketcherMinimizerFragment* fragment);
-    int numberOfStates() const;
-    int tier() const;
-    void apply() const;
-    float getCurrentPenalty() const;
+    int numberOfStates() const override;
+    int tier() const override;
+    void apply() const override;
+    float getCurrentPenalty() const override;
 };
 
 /*
@@ -89,10 +89,10 @@ class CoordgenFlipFragmentDOF : public CoordgenFragmentDOF
 {
   public:
     CoordgenFlipFragmentDOF(sketcherMinimizerFragment* fragment);
-    int numberOfStates() const;
-    int tier() const;
-    void apply() const;
-    float getCurrentPenalty() const;
+    int numberOfStates() const override;
+    int tier() const override;
+    void apply() const override;
+    float getCurrentPenalty() const override;
 };
 
 /*
@@ -102,10 +102,10 @@ class CoordgenScaleAtomsDOF : public CoordgenFragmentDOF
 {
   public:
     CoordgenScaleAtomsDOF(sketcherMinimizerAtom* pivotAtom);
-    int numberOfStates() const;
-    int tier() const;
-    void apply() const;
-    float getCurrentPenalty() const;
+    int numberOfStates() const override;
+    int tier() const override;
+    void apply() const override;
+    float getCurrentPenalty() const override;
 
   private:
     sketcherMinimizerAtom* m_pivotAtom;
@@ -118,10 +118,10 @@ class CoordgenScaleFragmentDOF : public CoordgenFragmentDOF
 {
   public:
     CoordgenScaleFragmentDOF(sketcherMinimizerFragment* fragment);
-    int numberOfStates() const;
-    int tier() const;
-    void apply() const;
-    float getCurrentPenalty() const;
+    int numberOfStates() const override;
+    int tier() const override;
+    void apply() const override;
+    float getCurrentPenalty() const override;
 };
 
 /*
@@ -132,10 +132,10 @@ class CoordgenChangeParentBondLengthFragmentDOF : public CoordgenFragmentDOF
   public:
     CoordgenChangeParentBondLengthFragmentDOF(
         sketcherMinimizerFragment* fragment);
-    int numberOfStates() const;
-    int tier() const;
-    void apply() const;
-    float getCurrentPenalty() const;
+    int numberOfStates() const override;
+    int tier() const override;
+    void apply() const override;
+    float getCurrentPenalty() const override;
 };
 
 /*
@@ -148,10 +148,10 @@ class CoordgenInvertBondDOF : public CoordgenFragmentDOF
   public:
     CoordgenInvertBondDOF(sketcherMinimizerAtom* pivotAtom,
                           sketcherMinimizerAtom* boundAtom);
-    int numberOfStates() const;
-    int tier() const;
-    void apply() const;
-    float getCurrentPenalty() const;
+    int numberOfStates() const override;
+    int tier() const override;
+    void apply() const override;
+    float getCurrentPenalty() const override;
 
   private:
     sketcherMinimizerAtom* m_pivotAtom;
@@ -165,10 +165,10 @@ class CoordgenFlipRingDOF : public CoordgenFragmentDOF
   public:
     CoordgenFlipRingDOF(sketcherMinimizerRing* ring,
                         const std::vector<sketcherMinimizerAtom*>& fusionAtoms);
-    int numberOfStates() const;
-    int tier() const;
-    void apply() const;
-    float getCurrentPenalty() const;
+    int numberOfStates() const override;
+    int tier() const override;
+    void apply() const override;
+    float getCurrentPenalty() const override;
 
   private:
     sketcherMinimizerAtom* m_pivotAtom1;

--- a/sketcherMinimizerInteraction.h
+++ b/sketcherMinimizerInteraction.h
@@ -24,7 +24,7 @@ class sketcherMinimizerInteraction
         restV = 50;
         // minimizationPhase = 0;
     };
-    virtual ~sketcherMinimizerInteraction(){};
+    virtual ~sketcherMinimizerInteraction() = default;
 
     /* return energy associated with it */
     virtual void energy(float& e)

--- a/sketcherMinimizerInteraction.h
+++ b/sketcherMinimizerInteraction.h
@@ -38,10 +38,11 @@ class sketcherMinimizerInteraction
     virtual void score(float& totalE, bool = false)
     {
         sketcherMinimizerPointF l = atom1->coordinates - atom2->coordinates;
-        if (l.x() > 0 && l.x() < SKETCHER_EPSILON)
+        if (l.x() > 0 && l.x() < SKETCHER_EPSILON) {
             l.setX(SKETCHER_EPSILON);
-        else if (l.x() < 0 && l.x() > -SKETCHER_EPSILON)
+        } else if (l.x() < 0 && l.x() > -SKETCHER_EPSILON) {
             l.setX(-SKETCHER_EPSILON);
+        }
         float delta = 0.05f;
         float e1 = 0.f;
         float e2 = 0.f;

--- a/sketcherMinimizerMarchingSquares.cpp
+++ b/sketcherMinimizerMarchingSquares.cpp
@@ -14,9 +14,7 @@
 
 using namespace std;
 
-sketcherMinimizerMarchingSquares::sketcherMinimizerMarchingSquares()
-{
-}
+sketcherMinimizerMarchingSquares::sketcherMinimizerMarchingSquares() = default;
 
 sketcherMinimizerMarchingSquares::~sketcherMinimizerMarchingSquares()
 {
@@ -45,7 +43,7 @@ void sketcherMinimizerMarchingSquares::initialize(float minx, float maxx,
     m_YN = static_cast<unsigned int>((dy / y_interval) + 2);
     m_grid.clear();
     m_grid.resize(m_XN * m_YN, 0.f);
-    m_lastRowPoints.resize(m_XN, NULL);
+    m_lastRowPoints.resize(m_XN, nullptr);
 }
 
 float sketcherMinimizerMarchingSquares::getNodeValue(unsigned int x,
@@ -72,11 +70,11 @@ void sketcherMinimizerMarchingSquares::setValue(float v, unsigned int x,
 void sketcherMinimizerMarchingSquares::clear()
 {
 
-    for (unsigned int i = 0; i < m_points.size(); i++)
-        delete m_points[i];
+    for (auto& m_point : m_points)
+        delete m_point;
     m_points.clear();
-    for (unsigned int i = 0; i < m_sides.size(); i++)
-        delete m_sides[i];
+    for (auto& m_side : m_sides)
+        delete m_side;
     m_sides.clear();
 
     m_grid.clear();
@@ -115,8 +113,7 @@ void sketcherMinimizerMarchingSquares::addSide(
     sketcherMinimizerMarchingSquaresPoint* p1,
     sketcherMinimizerMarchingSquaresPoint* p2)
 {
-    sketcherMinimizerMarchingSquaresSide* side =
-        new sketcherMinimizerMarchingSquaresSide;
+    auto* side = new sketcherMinimizerMarchingSquaresSide;
     side->p1 = p1;
     side->p2 = p2;
     if (p1->side1)
@@ -134,9 +131,9 @@ std::vector<float>
 sketcherMinimizerMarchingSquares::getCoordinatesPoints() const
 {
     std::vector<float> out;
-    for (unsigned int i = 0; i < m_points.size(); i++) {
-        out.push_back(m_points[i]->x);
-        out.push_back(m_points[i]->y);
+    for (auto m_point : m_points) {
+        out.push_back(m_point->x);
+        out.push_back(m_point->y);
     }
     return out;
 }
@@ -148,14 +145,14 @@ sketcherMinimizerMarchingSquares::getOrderedCoordinatesPoints() const
     std::vector<std::vector<float>> out;
 
     bool newShape = true;
-    sketcherMinimizerMarchingSquaresPoint* nextPoint = NULL;
+    sketcherMinimizerMarchingSquaresPoint* nextPoint = nullptr;
     while (newShape) {
         newShape = false;
-        nextPoint = NULL;
-        for (unsigned int i = 0; i < m_points.size(); i++) {
-            if (m_points[i]->visited == false) {
+        nextPoint = nullptr;
+        for (auto m_point : m_points) {
+            if (m_point->visited == false) {
                 newShape = true;
-                nextPoint = m_points[i];
+                nextPoint = m_point;
                 break;
             }
         }
@@ -165,13 +162,15 @@ sketcherMinimizerMarchingSquares::getOrderedCoordinatesPoints() const
                 nextPoint->visited = true;
                 newVec.push_back(nextPoint->x);
                 newVec.push_back(nextPoint->y);
-                sketcherMinimizerMarchingSquaresPoint* followingPoint1 = NULL;
+                sketcherMinimizerMarchingSquaresPoint* followingPoint1 =
+                    nullptr;
                 if (nextPoint->side1)
                     followingPoint1 = nextPoint->side1->p1;
                 if (followingPoint1 == nextPoint)
                     followingPoint1 = nextPoint->side1->p2;
 
-                sketcherMinimizerMarchingSquaresPoint* followingPoint2 = NULL;
+                sketcherMinimizerMarchingSquaresPoint* followingPoint2 =
+                    nullptr;
                 if (nextPoint->side2)
                     followingPoint2 = nextPoint->side2->p1;
                 if (followingPoint2 == nextPoint)
@@ -191,7 +190,7 @@ sketcherMinimizerMarchingSquares::getOrderedCoordinatesPoints() const
                         }
 
                 if (!found)
-                    nextPoint = NULL;
+                    nextPoint = nullptr;
             }
             out.push_back(newVec);
         }
@@ -204,7 +203,7 @@ void sketcherMinimizerMarchingSquares::run()
 {
 
     for (unsigned int j = 0; j < m_YN - 1; j++) {
-        m_lastCellRightPoint = NULL;
+        m_lastCellRightPoint = nullptr;
 
         for (unsigned int i = 0; i < m_XN - 1; i++) {
 
@@ -217,8 +216,8 @@ void sketcherMinimizerMarchingSquares::run()
             float TL = m_grid[i + (j + 1) * m_XN];
             float TR = m_grid[i + 1 + (j + 1) * m_XN];
             assert(i < m_lastRowPoints.size());
-            sketcherMinimizerMarchingSquaresPoint* rp = NULL;
-            sketcherMinimizerMarchingSquaresPoint* tp = NULL;
+            sketcherMinimizerMarchingSquaresPoint* rp = nullptr;
+            sketcherMinimizerMarchingSquaresPoint* tp = nullptr;
             sketcherMinimizerMarchingSquaresPoint* lp = m_lastCellRightPoint;
             sketcherMinimizerMarchingSquaresPoint* bp = m_lastRowPoints[i];
 
@@ -245,7 +244,8 @@ void sketcherMinimizerMarchingSquares::run()
                     addSide(bp, rp);
                 }
             } else {
-                sketcherMinimizerMarchingSquaresPoint *p1 = NULL, *p2 = NULL;
+                sketcherMinimizerMarchingSquaresPoint *p1 = nullptr,
+                                                      *p2 = nullptr;
                 if (tp)
                     p1 = tp;
                 if (rp) {
@@ -272,6 +272,6 @@ void sketcherMinimizerMarchingSquares::run()
             m_lastCellRightPoint = rp;
             m_lastRowPoints[i] = tp;
         }
-        m_lastCellRightPoint = NULL;
+        m_lastCellRightPoint = nullptr;
     }
 }

--- a/sketcherMinimizerMarchingSquares.cpp
+++ b/sketcherMinimizerMarchingSquares.cpp
@@ -26,8 +26,9 @@ void sketcherMinimizerMarchingSquares::initialize(float minx, float maxx,
                                                   float x_interval,
                                                   float y_interval)
 {
-    if (y_interval == 0.f)
+    if (y_interval == 0.f) {
         y_interval = x_interval;
+    }
     m_xinterval = x_interval;
     m_yinterval = y_interval;
 
@@ -70,11 +71,13 @@ void sketcherMinimizerMarchingSquares::setValue(float v, unsigned int x,
 void sketcherMinimizerMarchingSquares::clear()
 {
 
-    for (auto& m_point : m_points)
+    for (auto& m_point : m_points) {
         delete m_point;
+    }
     m_points.clear();
-    for (auto& m_side : m_sides)
+    for (auto& m_side : m_sides) {
         delete m_side;
+    }
     m_sides.clear();
 
     m_grid.clear();
@@ -104,8 +107,9 @@ float sketcherMinimizerMarchingSquares::toRealy(float y) const
 float sketcherMinimizerMarchingSquares::interpolate(float v1, float v2) const
 {
     float diff = v2 - v1;
-    if (diff < SKETCHER_EPSILON && diff > -SKETCHER_EPSILON)
+    if (diff < SKETCHER_EPSILON && diff > -SKETCHER_EPSILON) {
         return 0.5;
+    }
     return ((m_threshold - v1) / (v2 - v1));
 }
 
@@ -116,14 +120,16 @@ void sketcherMinimizerMarchingSquares::addSide(
     auto* side = new sketcherMinimizerMarchingSquaresSide;
     side->p1 = p1;
     side->p2 = p2;
-    if (p1->side1)
+    if (p1->side1) {
         p1->side2 = side;
-    else
+    } else {
         p1->side1 = side;
-    if (p2->side1)
+    }
+    if (p2->side1) {
         p2->side2 = side;
-    else
+    } else {
         p2->side1 = side;
+    }
     m_sides.push_back(side);
 }
 
@@ -164,33 +170,41 @@ sketcherMinimizerMarchingSquares::getOrderedCoordinatesPoints() const
                 newVec.push_back(nextPoint->y);
                 sketcherMinimizerMarchingSquaresPoint* followingPoint1 =
                     nullptr;
-                if (nextPoint->side1)
+                if (nextPoint->side1) {
                     followingPoint1 = nextPoint->side1->p1;
-                if (followingPoint1 == nextPoint)
+                }
+                if (followingPoint1 == nextPoint) {
                     followingPoint1 = nextPoint->side1->p2;
+                }
 
                 sketcherMinimizerMarchingSquaresPoint* followingPoint2 =
                     nullptr;
-                if (nextPoint->side2)
+                if (nextPoint->side2) {
                     followingPoint2 = nextPoint->side2->p1;
-                if (followingPoint2 == nextPoint)
+                }
+                if (followingPoint2 == nextPoint) {
                     followingPoint2 = nextPoint->side2->p2;
+                }
 
                 bool found = false;
-                if (followingPoint1)
+                if (followingPoint1) {
                     if (followingPoint1->visited == false) {
                         nextPoint = followingPoint1;
                         found = true;
                     }
-                if (!found)
-                    if (followingPoint2)
+                }
+                if (!found) {
+                    if (followingPoint2) {
                         if (followingPoint2->visited == false) {
                             nextPoint = followingPoint2;
                             found = true;
                         }
+                    }
+                }
 
-                if (!found)
+                if (!found) {
                     nextPoint = nullptr;
+                }
             }
             out.push_back(newVec);
         }
@@ -246,28 +260,33 @@ void sketcherMinimizerMarchingSquares::run()
             } else {
                 sketcherMinimizerMarchingSquaresPoint *p1 = nullptr,
                                                       *p2 = nullptr;
-                if (tp)
+                if (tp) {
                     p1 = tp;
+                }
                 if (rp) {
-                    if (p1)
+                    if (p1) {
                         p2 = rp;
-                    else
+                    } else {
                         p1 = rp;
+                    }
                 }
                 if (bp) {
-                    if (p1)
+                    if (p1) {
                         p2 = bp;
-                    else
+                    } else {
                         p1 = bp;
+                    }
                 }
                 if (lp) {
-                    if (p1)
+                    if (p1) {
                         p2 = lp;
-                    else
+                    } else {
                         p1 = lp;
+                    }
                 }
-                if (p1 && p2)
+                if (p1 && p2) {
                     addSide(p1, p2);
+                }
             }
             m_lastCellRightPoint = rp;
             m_lastRowPoints[i] = tp;

--- a/sketcherMinimizerMarchingSquares.h
+++ b/sketcherMinimizerMarchingSquares.h
@@ -29,8 +29,8 @@ struct sketcherMinimizerMarchingSquaresPoint {
     {
         x = ix;
         y = iy;
-        side1 = NULL;
-        side2 = NULL;
+        side1 = nullptr;
+        side2 = nullptr;
         visited = false;
     }
     float x, y;

--- a/sketcherMinimizerMaths.h
+++ b/sketcherMinimizerMaths.h
@@ -13,7 +13,7 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
-#include <math.h>
+#include <cmath>
 #include <vector>
 
 #define MACROCYCLE 9 // smallest MACROCYCLE
@@ -47,7 +47,7 @@ inline float roundToPrecision(float f, int precision)
 class sketcherMinimizerPointF
 {
   public:
-    sketcherMinimizerPointF() : xp(0.f), yp(0.f) {}
+    sketcherMinimizerPointF() {}
 
     sketcherMinimizerPointF(const sketcherMinimizerPointF& p)
         : xp(p.x()), yp(p.y())
@@ -184,14 +184,14 @@ class sketcherMinimizerPointF
     friend inline const sketcherMinimizerPointF
     operator*(const sketcherMinimizerPointF& p1, T c)
     {
-        float cf = static_cast<float>(c);
+        auto cf = static_cast<float>(c);
         return sketcherMinimizerPointF(p1.xp * cf, p1.yp * cf);
     }
     template <typename T>
     friend inline const sketcherMinimizerPointF
     operator/(const sketcherMinimizerPointF& p1, T c)
     {
-        float cf = static_cast<float>(c);
+        auto cf = static_cast<float>(c);
         return sketcherMinimizerPointF(p1.xp / cf, p1.yp / cf);
     }
 
@@ -204,8 +204,8 @@ class sketcherMinimizerPointF
     //     sketcherMinimizerPointF &, float);
 
   private:
-    float xp;
-    float yp;
+    float xp{0.f};
+    float yp{0.f};
 };
 
 /* return true if the two segments intersect and if a result pointer was given,
@@ -403,7 +403,7 @@ struct sketcherMinimizerMaths {
         if (segmentl < SKETCHER_EPSILON)
             segmentl = SKETCHER_EPSILON;
         float t = (l1.x() * l3.x() + l1.y() * l3.y()) / (segmentl * segmentl);
-        if (returnT != NULL) {
+        if (returnT != nullptr) {
             if (t < 0)
                 *returnT = 0;
             else if (t > 1)
@@ -446,7 +446,7 @@ struct sketcherMinimizerMaths {
                a.size() == rhs.size());
         assert(b[0] != 0.f);
 
-        unsigned int n = (unsigned int) rhs.size();
+        auto n = (unsigned int) rhs.size();
         std::vector<float> u(n);
         std::vector<float> gam(n);
 
@@ -472,7 +472,7 @@ struct sketcherMinimizerMaths {
                                           const std::vector<float>& rhs)
     {
         assert(a.size() == b.size() && a.size() == c.size());
-        unsigned int n = (unsigned int) b.size();
+        auto n = (unsigned int) b.size();
         assert(n > 2);
         float gamma = -b[0]; // Avoid subtraction error in forming bb[0].
         // Set up the diagonal of the modified tridiagonal system.
@@ -528,7 +528,7 @@ struct sketcherMinimizerMaths {
         std::vector<sketcherMinimizerPointF>& secondControlPoints)
     {
 
-        unsigned int n = (unsigned int) knots.size();
+        auto n = (unsigned int) knots.size();
         if (n <= 2) {
             return;
         }

--- a/sketcherMinimizerMaths.h
+++ b/sketcherMinimizerMaths.h
@@ -47,7 +47,7 @@ inline float roundToPrecision(float f, int precision)
 class sketcherMinimizerPointF
 {
   public:
-    sketcherMinimizerPointF() {}
+    sketcherMinimizerPointF() = default;
 
     sketcherMinimizerPointF(const sketcherMinimizerPointF& p)
         : xp(p.x()), yp(p.y())
@@ -81,10 +81,11 @@ class sketcherMinimizerPointF
     float length() const
     {
         float dd = squareLength();
-        if (dd > SKETCHER_EPSILON)
+        if (dd > SKETCHER_EPSILON) {
             return sqrt(dd);
-        else
+        } else {
             return 0;
+        }
     }
 
     /* normalize the vector */
@@ -285,11 +286,13 @@ struct sketcherMinimizerMaths {
         }
         sketcherMinimizerPointF qminusp = q - p;
         float t = crossProduct(qminusp, s) / rxs;
-        if (t < 0 || t > 1)
+        if (t < 0 || t > 1) {
             return false;
+        }
         float u = crossProduct(qminusp, r) / rxs;
-        if (u < 0 || u > 1)
+        if (u < 0 || u > 1) {
             return false;
+        }
         if (result) {
             *result = p + t * r;
         }
@@ -325,14 +328,16 @@ struct sketcherMinimizerMaths {
         float v2y = y3 - y2;
 
         float d = sqrt(v1x * v1x + v1y * v1y) * sqrt(v2x * v2x + v2y * v2y);
-        if (d < SKETCHER_EPSILON)
+        if (d < SKETCHER_EPSILON) {
             d = SKETCHER_EPSILON;
+        }
         float cosine = (v1x * v2x + v1y * v2y) / d;
 
-        if (cosine < -1)
+        if (cosine < -1) {
             cosine = -1;
-        else if (cosine > 1)
+        } else if (cosine > 1) {
             cosine = 1;
+        }
         return float((acos(cosine)) * 180 / M_PI);
     }
 
@@ -400,16 +405,18 @@ struct sketcherMinimizerMaths {
         float segmentl = sqrt(l3.x() * l3.x() + l3.y() * l3.y());
         // float l1l =  sqrt ( l1.x () * l1.x () + l1.y() * l1.y() );
 
-        if (segmentl < SKETCHER_EPSILON)
+        if (segmentl < SKETCHER_EPSILON) {
             segmentl = SKETCHER_EPSILON;
+        }
         float t = (l1.x() * l3.x() + l1.y() * l3.y()) / (segmentl * segmentl);
         if (returnT != nullptr) {
-            if (t < 0)
+            if (t < 0) {
                 *returnT = 0;
-            else if (t > 1)
+            } else if (t > 1) {
                 *returnT = 1;
-            else
+            } else {
                 *returnT = t;
+            }
         }
         float squaredistance = 0.f;
         if (t < 0.f) {
@@ -424,8 +431,9 @@ struct sketcherMinimizerMaths {
             sketcherMinimizerPointF l5 = p - proj;
             squaredistance = l5.x() * l5.x() + l5.y() * l5.y();
         }
-        if (squaredistance < SKETCHER_EPSILON)
+        if (squaredistance < SKETCHER_EPSILON) {
             squaredistance = SKETCHER_EPSILON;
+        }
 
         return squaredistance;
     }
@@ -458,8 +466,9 @@ struct sketcherMinimizerMaths {
             assert(bet != 0.f);
             u[j] = (rhs[j] - a[j] * u[j - 1]) / bet;
         }
-        for (unsigned int j = 1; j < n; j++)
+        for (unsigned int j = 1; j < n; j++) {
             u[n - j - 1] -= gam[n - j] * u[n - j];
+        }
 
         return u;
     }
@@ -479,8 +488,9 @@ struct sketcherMinimizerMaths {
         std::vector<float> bb(n);
         bb[0] = b[0] - gamma;
         bb[n - 1] = b[n - 1] - alpha * beta / gamma;
-        for (unsigned int i = 1; i < n - 1; i++)
+        for (unsigned int i = 1; i < n - 1; i++) {
             bb[i] = b[i];
+        }
         // Solve A · x = rhs.
         std::vector<float> solution = tridiagonalSolve(a, bb, c, rhs);
         std::vector<float> x = solution;
@@ -489,8 +499,9 @@ struct sketcherMinimizerMaths {
         std::vector<float> u(n);
         u[0] = gamma;
         u[n - 1] = alpha;
-        for (unsigned int i = 1; i < n - 1; i++)
+        for (unsigned int i = 1; i < n - 1; i++) {
             u[i] = 0.f;
+        }
         // Solve A · z = u.
         solution = tridiagonalSolve(a, bb, c, u);
         std::vector<float> z = solution;
@@ -500,8 +511,9 @@ struct sketcherMinimizerMaths {
                       (1.f + z[0] + beta * z[n - 1] / gamma);
 
         // Now get the solution vector x.
-        for (unsigned int i = 0; i < n; i++)
+        for (unsigned int i = 0; i < n; i++) {
             x[i] -= float(fact * z[i]);
+        }
         return x;
     }
 
@@ -545,8 +557,9 @@ struct sketcherMinimizerMaths {
         std::vector<float> rhs(n);
         for (unsigned int i = 0; i < n; i++) {
             int j = i + 1;
-            if (j > int(n - 1))
+            if (j > int(n - 1)) {
                 j = 0;
+            }
             rhs[i] = 4 * knots[i].x() + 2 * knots[j].x();
         }
         // Solve the system for X.
@@ -554,8 +567,9 @@ struct sketcherMinimizerMaths {
 
         for (unsigned int i = 0; i < n; i++) {
             int j = i + 1;
-            if (j > int(n - 1))
+            if (j > int(n - 1)) {
                 j = 0;
+            }
             rhs[i] = 4 * knots[i].y() + 2 * knots[j].y();
         }
         // Solve the system for Y.
@@ -619,11 +633,13 @@ struct sketcherMinimizerMaths {
         float d2 = (targetdX * targetdX) + (targetdY * targetdY) +
                    (targetdZ * targetdZ);
 
-        if (d2 > (cutOff + rR) * (cutOff + rR))
+        if (d2 > (cutOff + rR) * (cutOff + rR)) {
             return cutOff;
+        }
 
-        if (d2 < rR * rR)
+        if (d2 < rR * rR) {
             return 0;
+        }
 
         float d = sqrt(d2);
         if (d > SKETCHER_EPSILON) {
@@ -633,15 +649,18 @@ struct sketcherMinimizerMaths {
         }
         float cos = targetdX * directionX + targetdY * directionY +
                     targetdZ * directionZ;
-        if (cos < 0)
+        if (cos < 0) {
             return cutOff;
+        }
         float sin = sqrt(1 - (cos * cos));
         float f = d * sin;
-        if (f > rR)
+        if (f > rR) {
             return cutOff;
+        }
         float result = sqrt(d2 - (f * f)) - sqrt((rR * rR) - (f * f));
-        if (result > cutOff)
+        if (result > cutOff) {
             return cutOff;
+        }
         return result;
     }
 
@@ -649,8 +668,9 @@ struct sketcherMinimizerMaths {
     static float length3D(float x, float y, float z)
     {
         float m = x * x + y * y + z * z;
-        if (m > SKETCHER_EPSILON)
+        if (m > SKETCHER_EPSILON) {
             m = sqrt(m);
+        }
         return m;
     }
 

--- a/sketcherMinimizerMolecule.cpp
+++ b/sketcherMinimizerMolecule.cpp
@@ -49,8 +49,9 @@ sketcherMinimizerMolecule::addNewBond(sketcherMinimizerAtom* at1,
 int sketcherMinimizerMolecule::totalCharge()
 {
     int charge = 0;
-    for (auto& _atom : _atoms)
+    for (auto& _atom : _atoms) {
         charge += _atom->charge;
+    }
     return charge;
 }
 
@@ -65,14 +66,18 @@ void sketcherMinimizerMolecule::boundingBox(sketcherMinimizerPointF& min,
         min = _atoms[0]->coordinates;
         max = _atoms[0]->coordinates;
         for (auto a : _atoms) {
-            if (a->coordinates.x() < min.x())
+            if (a->coordinates.x() < min.x()) {
                 min.setX(a->coordinates.x());
-            if (a->coordinates.y() < min.y())
+            }
+            if (a->coordinates.y() < min.y()) {
                 min.setY(a->coordinates.y());
-            if (a->coordinates.x() > max.x())
+            }
+            if (a->coordinates.x() > max.x()) {
                 max.setX(a->coordinates.x());
-            if (a->coordinates.y() > max.y())
+            }
+            if (a->coordinates.y() > max.y()) {
                 max.setY(a->coordinates.y());
+            }
         }
     }
 }
@@ -89,8 +94,9 @@ bool sketcherMinimizerMolecule::minimizationIsRequired()
 
 sketcherMinimizerPointF sketcherMinimizerMolecule::center()
 {
-    if (!_atoms.size())
+    if (!_atoms.size()) {
         return sketcherMinimizerPointF(0.f, 0.f);
+    }
     sketcherMinimizerPointF c(.0f, .0f);
     for (auto& _atom : _atoms) {
         c += _atom->coordinates;
@@ -136,8 +142,9 @@ void sketcherMinimizerMolecule::assignBondsAndNeighbors(
         }
     }
     for (auto& atom : atoms) {
-        if (atom->_implicitHs == -1)
+        if (atom->_implicitHs == -1) {
             atom->_implicitHs = atom->findHsNumber();
+        }
     }
 }
 
@@ -153,23 +160,25 @@ void sketcherMinimizerMolecule::forceUpdateStruct(
         for (unsigned int j = 0; j < bond->rings.size(); j++) {
             sketcherMinimizerRing* ring = bond->rings[j];
             bool found = false;
-            for (unsigned int k = 0; k < bond->startAtom->rings.size(); k++) {
-                if (bond->startAtom->rings[k] == ring) {
+            for (auto& k : bond->startAtom->rings) {
+                if (k == ring) {
                     found = true;
                     break;
                 }
             }
-            if (!found)
+            if (!found) {
                 bond->startAtom->rings.push_back(ring);
+            }
             found = false;
-            for (unsigned int k = 0; k < bond->endAtom->rings.size(); k++) {
-                if (bond->endAtom->rings[k] == ring) {
+            for (auto& k : bond->endAtom->rings) {
+                if (k == ring) {
                     found = true;
                     break;
                 }
             }
-            if (!found)
+            if (!found) {
                 bond->endAtom->rings.push_back(ring);
+            }
         }
     }
 
@@ -184,8 +193,9 @@ void sketcherMinimizerMolecule::findRings(
     std::vector<sketcherMinimizerBond*>& bonds,
     std::vector<sketcherMinimizerRing*>& rings)
 {
-    for (auto& ring : rings)
+    for (auto& ring : rings) {
         delete ring;
+    }
     rings.clear();
     for (unsigned int i = 0; i < bonds.size(); i++) {
         for (auto& bond : bonds) {
@@ -205,13 +215,15 @@ void sketcherMinimizerMolecule::findRings(
             q.pop();
 
             sketcherMinimizerAtom* pivotAtom = lastBond->endAtom;
-            if (!lastBond->_SSSRParentAtStart)
+            if (!lastBond->_SSSRParentAtStart) {
                 pivotAtom = lastBond->startAtom;
+            }
             for (unsigned int j = 0; j < pivotAtom->bonds.size(); j++) {
                 sketcherMinimizerBond* nextBond = pivotAtom->bonds[j];
                 // sketcherMinimizerAtom *nextAtom = pivotAtom->neighbors[j];
-                if (nextBond == lastBond)
+                if (nextBond == lastBond) {
                     continue;
+                }
                 if (nextBond->_SSSRVisited) {
                     if (nextBond == bond) {
                         addRing(closeRing(lastBond), rings);
@@ -219,8 +231,9 @@ void sketcherMinimizerMolecule::findRings(
                     }
 
                 } else {
-                    if (nextBond->endAtom == pivotAtom)
+                    if (nextBond->endAtom == pivotAtom) {
                         nextBond->_SSSRParentAtStart = false;
+                    }
                     nextBond->_SSSRParent = lastBond;
                     nextBond->_SSSRVisited = true;
                     q.push(nextBond);

--- a/sketcherMinimizerMolecule.cpp
+++ b/sketcherMinimizerMolecule.cpp
@@ -20,7 +20,7 @@ sketcherMinimizerMolecule::sketcherMinimizerMolecule()
 
       hasFixedFragments(false), hasConstrainedFragments(false),
       needToAlignNonRingAtoms(false), needToAlignWholeMolecule(false),
-      isPlaced(false), m_mainFragment(NULL), m_requireMinimization(false){};
+      isPlaced(false), m_mainFragment(nullptr), m_requireMinimization(false){};
 
 sketcherMinimizerMolecule::~sketcherMinimizerMolecule()
 {
@@ -49,8 +49,8 @@ sketcherMinimizerMolecule::addNewBond(sketcherMinimizerAtom* at1,
 int sketcherMinimizerMolecule::totalCharge()
 {
     int charge = 0;
-    for (unsigned int i = 0; i < _atoms.size(); i++)
-        charge += _atoms[i]->charge;
+    for (auto& _atom : _atoms)
+        charge += _atom->charge;
     return charge;
 }
 
@@ -64,8 +64,7 @@ void sketcherMinimizerMolecule::boundingBox(sketcherMinimizerPointF& min,
     if (_atoms.size()) {
         min = _atoms[0]->coordinates;
         max = _atoms[0]->coordinates;
-        for (unsigned int i = 0; i < _atoms.size(); i++) {
-            sketcherMinimizerAtom* a = _atoms[i];
+        for (auto a : _atoms) {
             if (a->coordinates.x() < min.x())
                 min.setX(a->coordinates.x());
             if (a->coordinates.y() < min.y())
@@ -93,8 +92,8 @@ sketcherMinimizerPointF sketcherMinimizerMolecule::center()
     if (!_atoms.size())
         return sketcherMinimizerPointF(0.f, 0.f);
     sketcherMinimizerPointF c(.0f, .0f);
-    for (unsigned int i = 0; i < _atoms.size(); i++) {
-        c += _atoms[i]->coordinates;
+    for (auto& _atom : _atoms) {
+        c += _atom->coordinates;
     }
     return c / _atoms.size();
 }
@@ -103,8 +102,7 @@ void sketcherMinimizerMolecule::assignBondsAndNeighbors(
     std::vector<sketcherMinimizerAtom*>& atoms,
     std::vector<sketcherMinimizerBond*>& bonds)
 {
-    for (unsigned int i = 0; i < atoms.size(); i++) {
-        sketcherMinimizerAtom* atom = atoms[i];
+    for (auto atom : atoms) {
         atom->bonds.clear();
         atom->neighbors.clear();
         atom->residueInteractionPartners.clear();
@@ -112,9 +110,8 @@ void sketcherMinimizerMolecule::assignBondsAndNeighbors(
         atom->rings.clear();
     }
 
-    for (unsigned int i = 0; i < bonds.size(); i++) {
+    for (auto bond : bonds) {
 
-        sketcherMinimizerBond* bond = bonds[i];
         bond->rings.clear();
 
         if (!bond->isResidueInteraction()) {
@@ -138,9 +135,9 @@ void sketcherMinimizerMolecule::assignBondsAndNeighbors(
                 bond->endAtom);
         }
     }
-    for (unsigned int i = 0; i < atoms.size(); i++) {
-        if (atoms[i]->_implicitHs == -1)
-            atoms[i]->_implicitHs = atoms[i]->findHsNumber();
+    for (auto& atom : atoms) {
+        if (atom->_implicitHs == -1)
+            atom->_implicitHs = atom->findHsNumber();
     }
 }
 
@@ -152,34 +149,33 @@ void sketcherMinimizerMolecule::forceUpdateStruct(
     sketcherMinimizerMolecule::assignBondsAndNeighbors(atoms, bonds);
 
     findRings(bonds, rings);
-    for (unsigned int i = 0; i < bonds.size(); i++) {
-        for (unsigned int j = 0; j < bonds[i]->rings.size(); j++) {
-            sketcherMinimizerRing* ring = bonds[i]->rings[j];
+    for (auto& bond : bonds) {
+        for (unsigned int j = 0; j < bond->rings.size(); j++) {
+            sketcherMinimizerRing* ring = bond->rings[j];
             bool found = false;
-            for (unsigned int k = 0; k < bonds[i]->startAtom->rings.size();
-                 k++) {
-                if (bonds[i]->startAtom->rings[k] == ring) {
+            for (unsigned int k = 0; k < bond->startAtom->rings.size(); k++) {
+                if (bond->startAtom->rings[k] == ring) {
                     found = true;
                     break;
                 }
             }
             if (!found)
-                bonds[i]->startAtom->rings.push_back(ring);
+                bond->startAtom->rings.push_back(ring);
             found = false;
-            for (unsigned int k = 0; k < bonds[i]->endAtom->rings.size(); k++) {
-                if (bonds[i]->endAtom->rings[k] == ring) {
+            for (unsigned int k = 0; k < bond->endAtom->rings.size(); k++) {
+                if (bond->endAtom->rings[k] == ring) {
                     found = true;
                     break;
                 }
             }
             if (!found)
-                bonds[i]->endAtom->rings.push_back(ring);
+                bond->endAtom->rings.push_back(ring);
         }
     }
 
-    for (unsigned int i = 0; i < atoms.size(); i++) {
-        for (unsigned int j = 0; j < atoms[i]->rings.size(); j++) {
-            atoms[i]->rings[j]->_atoms.push_back(atoms[i]);
+    for (auto& atom : atoms) {
+        for (unsigned int j = 0; j < atom->rings.size(); j++) {
+            atom->rings[j]->_atoms.push_back(atom);
         }
     }
 }
@@ -188,14 +184,14 @@ void sketcherMinimizerMolecule::findRings(
     std::vector<sketcherMinimizerBond*>& bonds,
     std::vector<sketcherMinimizerRing*>& rings)
 {
-    for (unsigned int i = 0; i < rings.size(); i++)
-        delete rings[i];
+    for (auto& ring : rings)
+        delete ring;
     rings.clear();
     for (unsigned int i = 0; i < bonds.size(); i++) {
-        for (unsigned int ii = 0; ii < bonds.size(); ii++) {
-            bonds[ii]->_SSSRVisited = false;
-            bonds[ii]->_SSSRParent = NULL;
-            bonds[ii]->_SSSRParentAtStart = true;
+        for (auto& bond : bonds) {
+            bond->_SSSRVisited = false;
+            bond->_SSSRParent = nullptr;
+            bond->_SSSRParentAtStart = true;
         }
 
         sketcherMinimizerBond* bond = bonds[i];
@@ -232,8 +228,7 @@ void sketcherMinimizerMolecule::findRings(
             }
         }
     }
-    for (unsigned int i = 0; i < rings.size(); i++) {
-        sketcherMinimizerRing* ring = rings[i];
+    for (auto ring : rings) {
         for (unsigned int j = 0; j < ring->_bonds.size(); j++) {
             sketcherMinimizerBond* bond = ring->_bonds[j];
             bond->rings.push_back(ring);
@@ -244,7 +239,7 @@ void sketcherMinimizerMolecule::findRings(
 sketcherMinimizerRing*
 sketcherMinimizerMolecule::closeRing(sketcherMinimizerBond* bond)
 {
-    sketcherMinimizerRing* ring = new sketcherMinimizerRing();
+    auto* ring = new sketcherMinimizerRing();
     sketcherMinimizerBond* lastBond = bond;
     while (lastBond) {
         ring->_bonds.push_back(lastBond);
@@ -257,8 +252,8 @@ void sketcherMinimizerMolecule::addRing(
     sketcherMinimizerRing* ring, std::vector<sketcherMinimizerRing*>& rings)
 {
     bool found = false;
-    for (unsigned int i = 0; i < rings.size(); i++) {
-        if (rings[i]->sameAs(ring)) {
+    for (auto& i : rings) {
+        if (i->sameAs(ring)) {
             found = true;
             break;
         }

--- a/sketcherMinimizerResidue.cpp
+++ b/sketcherMinimizerResidue.cpp
@@ -12,12 +12,10 @@ using namespace std;
 
 sketcherMinimizerResidue::sketcherMinimizerResidue() : sketcherMinimizerAtom()
 {
-    m_closestLigandAtom = NULL;
+    m_closestLigandAtom = nullptr;
 }
 
-sketcherMinimizerResidue::~sketcherMinimizerResidue()
-{
-}
+sketcherMinimizerResidue::~sketcherMinimizerResidue() = default;
 
 bool sketcherMinimizerResidue::isResidue() const
 {

--- a/sketcherMinimizerResidue.h
+++ b/sketcherMinimizerResidue.h
@@ -17,8 +17,8 @@ class EXPORT_COORDGEN sketcherMinimizerResidue : public sketcherMinimizerAtom
 {
   public:
     sketcherMinimizerResidue();
-    virtual ~sketcherMinimizerResidue();
-    virtual bool isResidue() const;
+    ~sketcherMinimizerResidue() override;
+    bool isResidue() const override;
 
     /* compute coordinates based on the position of the closest ligand atom */
     sketcherMinimizerPointF computeStartingCoordinates(float d = 2.f)
@@ -30,10 +30,10 @@ class EXPORT_COORDGEN sketcherMinimizerResidue : public sketcherMinimizerAtom
         if (residueInteractions.size()) {
             int nn = 0;
             sketcherMinimizerPointF coords(0.f, 0.f);
-            for (unsigned int i = 0; i < residueInteractions.size(); i++) {
-                sketcherMinimizerAtom* n = residueInteractions[i]->endAtom;
+            for (auto& residueInteraction : residueInteractions) {
+                sketcherMinimizerAtom* n = residueInteraction->endAtom;
                 if (n == this)
-                    n = residueInteractions[i]->startAtom;
+                    n = residueInteraction->startAtom;
                 if (!n->isResidue()) {
                     coords += n->getSingleAdditionVector() * d + n->coordinates;
                     nn++;

--- a/sketcherMinimizerResidue.h
+++ b/sketcherMinimizerResidue.h
@@ -24,16 +24,18 @@ class EXPORT_COORDGEN sketcherMinimizerResidue : public sketcherMinimizerAtom
     sketcherMinimizerPointF computeStartingCoordinates(float d = 2.f)
     {
         sketcherMinimizerPointF out = templateCoordinates;
-        if (m_closestLigandAtom)
+        if (m_closestLigandAtom) {
             out = m_closestLigandAtom->getSingleAdditionVector() * d +
                   m_closestLigandAtom->coordinates;
+        }
         if (residueInteractions.size()) {
             int nn = 0;
             sketcherMinimizerPointF coords(0.f, 0.f);
             for (auto& residueInteraction : residueInteractions) {
                 sketcherMinimizerAtom* n = residueInteraction->endAtom;
-                if (n == this)
+                if (n == this) {
                     n = residueInteraction->startAtom;
+                }
                 if (!n->isResidue()) {
                     coords += n->getSingleAdditionVector() * d + n->coordinates;
                     nn++;
@@ -42,8 +44,9 @@ class EXPORT_COORDGEN sketcherMinimizerResidue : public sketcherMinimizerAtom
                     nn++;
                 }
             }
-            if (nn > 0)
+            if (nn > 0) {
                 coords /= float(nn);
+            }
             out = coords;
         }
         return out;

--- a/sketcherMinimizerResidueInteraction.cpp
+++ b/sketcherMinimizerResidueInteraction.cpp
@@ -15,9 +15,8 @@ sketcherMinimizerResidueInteraction::sketcherMinimizerResidueInteraction()
 {
 }
 
-sketcherMinimizerResidueInteraction::~sketcherMinimizerResidueInteraction()
-{
-}
+sketcherMinimizerResidueInteraction::~sketcherMinimizerResidueInteraction() =
+    default;
 
 bool sketcherMinimizerResidueInteraction::isResidueInteraction()
 {

--- a/sketcherMinimizerResidueInteraction.h
+++ b/sketcherMinimizerResidueInteraction.h
@@ -18,8 +18,8 @@ class EXPORT_COORDGEN sketcherMinimizerResidueInteraction
 {
   public:
     sketcherMinimizerResidueInteraction();
-    virtual ~sketcherMinimizerResidueInteraction();
-    virtual bool isResidueInteraction();
+    ~sketcherMinimizerResidueInteraction() override;
+    bool isResidueInteraction() override;
 
     /* get all the atoms involved at the end side of the interaction */
     std::vector<sketcherMinimizerAtom*> getAllEndAtoms();

--- a/sketcherMinimizerRing.cpp
+++ b/sketcherMinimizerRing.cpp
@@ -21,15 +21,13 @@ sketcherMinimizerRing::sketcherMinimizerRing()
     side = false;
 }
 
-sketcherMinimizerRing::~sketcherMinimizerRing()
-{
-}
+sketcherMinimizerRing::~sketcherMinimizerRing() = default;
 
 sketcherMinimizerPointF sketcherMinimizerRing::findCenter()
 {
     sketcherMinimizerPointF o(0.f, 0.f);
-    for (unsigned int i = 0; i < _atoms.size(); i++)
-        o += _atoms[i]->coordinates;
+    for (auto& _atom : _atoms)
+        o += _atom->coordinates;
     o /= _atoms.size();
     return o;
 }
@@ -38,14 +36,13 @@ bool sketcherMinimizerRing::isBenzene()
 {
     if (_atoms.size() != 6)
         return false;
-    for (unsigned int i = 0; i < _atoms.size(); i++)
-        if (_atoms[i]->atomicNumber != 6)
+    for (auto& _atom : _atoms)
+        if (_atom->atomicNumber != 6)
             return false;
-    for (unsigned int i = 0; i < _atoms.size(); i++) {
-        sketcherMinimizerAtom* a = _atoms[i];
+    for (auto a : _atoms) {
         bool found = false;
-        for (unsigned int j = 0; j < a->bonds.size(); j++) {
-            if (a->bonds[j]->bondOrder == 2) {
+        for (auto& bond : a->bonds) {
+            if (bond->bondOrder == 2) {
                 found = true;
                 break;
             }
@@ -63,15 +60,15 @@ bool sketcherMinimizerRing::isAromatic() // not chemically accurate, but good
     size_t bonds = _bonds.size();
     int doubleBonds = 0;
     int NSOCount = 0;
-    for (unsigned int i = 0; i < _bonds.size(); i++) {
-        if (_bonds[i]->bondOrder == 2)
+    for (auto& _bond : _bonds) {
+        if (_bond->bondOrder == 2)
             doubleBonds++;
     }
-    for (unsigned int i = 0; i < _atoms.size(); i++) {
-        int an = _atoms[i]->atomicNumber;
+    for (auto& _atom : _atoms) {
+        int an = _atom->atomicNumber;
         bool doubleBound = false;
-        for (unsigned int b = 0; b < _atoms[i]->bonds.size(); b++)
-            if (_atoms[i]->bonds[b]->bondOrder == 2)
+        for (unsigned int b = 0; b < _atom->bonds.size(); b++)
+            if (_atom->bonds[b]->bondOrder == 2)
                 doubleBound = true;
 
         if (!doubleBound)
@@ -87,22 +84,22 @@ bool sketcherMinimizerRing::isAromatic() // not chemically accurate, but good
 
 bool sketcherMinimizerRing::containsAtom(const sketcherMinimizerAtom* a) const
 {
-    for (unsigned int i = 0; i < _atoms.size(); i++)
-        if (_atoms[i] == a)
+    for (auto _atom : _atoms)
+        if (_atom == a)
             return true;
     return false;
 }
 bool sketcherMinimizerRing::containsBond(sketcherMinimizerBond* b)
 {
-    for (unsigned int i = 0; i < _bonds.size(); i++)
-        if (_bonds[i] == b)
+    for (auto& _bond : _bonds)
+        if (_bond == b)
             return true;
     return false;
 }
 bool sketcherMinimizerRing::isFusedWith(sketcherMinimizerRing* ring)
 {
-    for (unsigned int i = 0; i < fusedWith.size(); i++) {
-        if (fusedWith[i] == ring) {
+    for (auto& i : fusedWith) {
+        if (i == ring) {
             return true;
         }
     }
@@ -124,8 +121,8 @@ bool sketcherMinimizerRing::sameAs(sketcherMinimizerRing* ring)
 {
     if (!(_bonds.size() == ring->_bonds.size()))
         return false;
-    for (unsigned int i = 0; i < _bonds.size(); i++) {
-        if (!ring->containsBond(_bonds[i])) {
+    for (auto& _bond : _bonds) {
+        if (!ring->containsBond(_bond)) {
             return false;
         }
     }
@@ -136,8 +133,7 @@ bool sketcherMinimizerRing::contains(const sketcherMinimizerPointF& p)
 {
 
     int n = 0;
-    for (unsigned int i = 0; i < _bonds.size(); i++) {
-        sketcherMinimizerBond* b = _bonds[i];
+    for (auto b : _bonds) {
         if ((p.y() < b->startAtom->coordinates.y() &&
              p.y() > b->endAtom->coordinates.y()) ||
             (p.y() > b->startAtom->coordinates.y() &&

--- a/sketcherMinimizerRing.cpp
+++ b/sketcherMinimizerRing.cpp
@@ -26,19 +26,23 @@ sketcherMinimizerRing::~sketcherMinimizerRing() = default;
 sketcherMinimizerPointF sketcherMinimizerRing::findCenter()
 {
     sketcherMinimizerPointF o(0.f, 0.f);
-    for (auto& _atom : _atoms)
+    for (auto& _atom : _atoms) {
         o += _atom->coordinates;
+    }
     o /= _atoms.size();
     return o;
 }
 
 bool sketcherMinimizerRing::isBenzene()
 {
-    if (_atoms.size() != 6)
+    if (_atoms.size() != 6) {
         return false;
-    for (auto& _atom : _atoms)
-        if (_atom->atomicNumber != 6)
+    }
+    for (auto& _atom : _atoms) {
+        if (_atom->atomicNumber != 6) {
             return false;
+        }
+    }
     for (auto a : _atoms) {
         bool found = false;
         for (auto& bond : a->bonds) {
@@ -47,8 +51,9 @@ bool sketcherMinimizerRing::isBenzene()
                 break;
             }
         }
-        if (!found)
+        if (!found) {
             return false;
+        }
     }
 
     return true;
@@ -61,39 +66,50 @@ bool sketcherMinimizerRing::isAromatic() // not chemically accurate, but good
     int doubleBonds = 0;
     int NSOCount = 0;
     for (auto& _bond : _bonds) {
-        if (_bond->bondOrder == 2)
+        if (_bond->bondOrder == 2) {
             doubleBonds++;
+        }
     }
     for (auto& _atom : _atoms) {
         int an = _atom->atomicNumber;
         bool doubleBound = false;
-        for (unsigned int b = 0; b < _atom->bonds.size(); b++)
-            if (_atom->bonds[b]->bondOrder == 2)
+        for (auto& bond : _atom->bonds) {
+            if (bond->bondOrder == 2) {
                 doubleBound = true;
+            }
+        }
 
-        if (!doubleBound)
-            if (an == 8 || an == 7 || an == 16)
+        if (!doubleBound) {
+            if (an == 8 || an == 7 || an == 16) {
                 NSOCount++;
+            }
+        }
     }
-    if (bonds == 6 && doubleBonds == 3)
+    if (bonds == 6 && doubleBonds == 3) {
         return true;
-    if (bonds == 5 && doubleBonds == 2 && NSOCount == 1)
+    }
+    if (bonds == 5 && doubleBonds == 2 && NSOCount == 1) {
         return true;
+    }
     return false;
 }
 
 bool sketcherMinimizerRing::containsAtom(const sketcherMinimizerAtom* a) const
 {
-    for (auto _atom : _atoms)
-        if (_atom == a)
+    for (auto _atom : _atoms) {
+        if (_atom == a) {
             return true;
+        }
+    }
     return false;
 }
 bool sketcherMinimizerRing::containsBond(sketcherMinimizerBond* b)
 {
-    for (auto& _bond : _bonds)
-        if (_bond == b)
+    for (auto& _bond : _bonds) {
+        if (_bond == b) {
             return true;
+        }
+    }
     return false;
 }
 bool sketcherMinimizerRing::isFusedWith(sketcherMinimizerRing* ring)
@@ -119,8 +135,9 @@ std::vector<sketcherMinimizerAtom*> sketcherMinimizerRing::getFusionAtomsWith(
 
 bool sketcherMinimizerRing::sameAs(sketcherMinimizerRing* ring)
 {
-    if (!(_bonds.size() == ring->_bonds.size()))
+    if (!(_bonds.size() == ring->_bonds.size())) {
         return false;
+    }
     for (auto& _bond : _bonds) {
         if (!ring->containsBond(_bond)) {
             return false;
@@ -143,13 +160,15 @@ bool sketcherMinimizerRing::contains(const sketcherMinimizerPointF& p)
             if (v.y() > SKETCHER_EPSILON || v.y() < -SKETCHER_EPSILON) {
                 v *= (p.y() - b->startAtom->coordinates.y()) / v.y();
                 v += b->startAtom->coordinates;
-                if (p.x() > v.x())
+                if (p.x() > v.x()) {
                     n++;
+                }
             }
         }
     }
-    if ((n % 2) != 0)
+    if ((n % 2) != 0) {
         return true;
+    }
     return false;
 }
 

--- a/sketcherMinimizerRing.cpp
+++ b/sketcherMinimizerRing.cpp
@@ -21,7 +21,9 @@ sketcherMinimizerRing::sketcherMinimizerRing()
     side = false;
 }
 
-sketcherMinimizerRing::~sketcherMinimizerRing() {}
+sketcherMinimizerRing::~sketcherMinimizerRing()
+{
+}
 
 sketcherMinimizerPointF sketcherMinimizerRing::findCenter()
 {

--- a/sketcherMinimizerStretchInteraction.h
+++ b/sketcherMinimizerStretchInteraction.h
@@ -17,8 +17,10 @@ class sketcherMinimizerStretchInteraction : public sketcherMinimizerInteraction
   public:
     sketcherMinimizerStretchInteraction(sketcherMinimizerAtom* at1,
                                         sketcherMinimizerAtom* at2)
-        : sketcherMinimizerInteraction(at1, at2){};
-    virtual ~sketcherMinimizerStretchInteraction(){};
+        : sketcherMinimizerInteraction(at1, at2)
+    {
+    }
+    ~sketcherMinimizerStretchInteraction() override = default;
 
     /* calculate forces and apply them */
     void score(float& totalE, bool = false) override
@@ -36,7 +38,7 @@ class sketcherMinimizerStretchInteraction : public sketcherMinimizerInteraction
         l *= (k * dr + penaltyForVeryShortBonds * 10);
         atom1->force += l;
         atom2->force -= l;
-    };
+    }
 };
 
 #endif // sketcherMINIMIZERSTRETCHINTERACTION

--- a/sketcherMinimizerStretchInteraction.h
+++ b/sketcherMinimizerStretchInteraction.h
@@ -31,10 +31,12 @@ class sketcherMinimizerStretchInteraction : public sketcherMinimizerInteraction
         float dr = restV - m;
         float shortBondThreshold = restV * 0.4f;
         float penaltyForVeryShortBonds = (shortBondThreshold - m);
-        if (penaltyForVeryShortBonds < 0)
+        if (penaltyForVeryShortBonds < 0) {
             penaltyForVeryShortBonds = 0;
-        if (m > SKETCHER_EPSILON)
+        }
+        if (m > SKETCHER_EPSILON) {
             l /= m;
+        }
         l *= (k * dr + penaltyForVeryShortBonds * 10);
         atom1->force += l;
         atom2->force -= l;

--- a/test/test_coordgen.cpp
+++ b/test/test_coordgen.cpp
@@ -14,8 +14,11 @@ using namespace schrodinger;
 
 const boost::filesystem::path test_samples_path(TEST_SAMPLES_PATH);
 
-namespace {
-std::map<sketcherMinimizerAtom*, int> getReportingIndices(sketcherMinimizerMolecule& mol) {
+namespace
+{
+std::map<sketcherMinimizerAtom*, int>
+getReportingIndices(sketcherMinimizerMolecule& mol)
+{
     std::map<sketcherMinimizerAtom*, int> fakeIndices;
     int index = 0;
     for (auto& atom : mol.getAtoms()) {
@@ -24,9 +27,10 @@ std::map<sketcherMinimizerAtom*, int> getReportingIndices(sketcherMinimizerMolec
     return fakeIndices;
 }
 
-bool areBondsNearIdeal(sketcherMinimizerMolecule& mol, std::map<sketcherMinimizerAtom*, int>& indices)
+bool areBondsNearIdeal(sketcherMinimizerMolecule& mol,
+                       std::map<sketcherMinimizerAtom*, int>& indices)
 {
-    const float targetBondLength = BONDLENGTH*BONDLENGTH;
+    const float targetBondLength = BONDLENGTH * BONDLENGTH;
     const float tolerance = static_cast<float>(targetBondLength * 0.1);
 
     bool passed = true;
@@ -34,19 +38,19 @@ bool areBondsNearIdeal(sketcherMinimizerMolecule& mol, std::map<sketcherMinimize
         auto& startCoordinates = bond->getStartAtom()->getCoordinates();
         auto& endCoordinates = bond->getEndAtom()->getCoordinates();
 
-        const auto sq_distance = sketcherMinimizerMaths::squaredDistance(startCoordinates, endCoordinates);
+        const auto sq_distance = sketcherMinimizerMaths::squaredDistance(
+            startCoordinates, endCoordinates);
         const auto deviation = sq_distance - targetBondLength;
         if (deviation < -tolerance || deviation > tolerance) {
             std::cerr << "Bond" << indices[bond->getStartAtom()] << '-'
-                << indices[bond->getEndAtom()] << " has length "
-                << sq_distance << " (" << targetBondLength << ")\n";
+                      << indices[bond->getEndAtom()] << " has length "
+                      << sq_distance << " (" << targetBondLength << ")\n";
             passed = false;
         }
     }
 
     return passed;
 }
-
 }
 
 BOOST_AUTO_TEST_CASE(SampleTest)

--- a/test/test_coordgen.cpp
+++ b/test/test_coordgen.cpp
@@ -31,7 +31,7 @@ bool areBondsNearIdeal(sketcherMinimizerMolecule& mol,
                        std::map<sketcherMinimizerAtom*, int>& indices)
 {
     const float targetBondLength = BONDLENGTH * BONDLENGTH;
-    const float tolerance = static_cast<float>(targetBondLength * 0.1);
+    const auto tolerance = static_cast<float>(targetBondLength * 0.1);
 
     bool passed = true;
     for (auto& bond : mol.getBonds()) {


### PR DESCRIPTION
Includes:

* Applying Schrodinger's canonical clang-format settings
* Fixed one bug that clang-tidy pointed out (accessing a moved-from string!)
* Running clang-tidy's modernize fixes
* Running clang-tidy's add braces to single line statements fixer

I ran the coordgen tests and am building RDKit and Schrodinger to test there, as well.