### PR TITLE
Allow static builds

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -1,41 +1,42 @@
 steps:
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    sudo chown -R ${USER} ${CONDA}
-    conda config --set always_yes yes --set changeps1 no
-    conda update -q conda
-    conda info -a
-    conda create --name coordgen_build $(compiler) cmake \
-        boost-cpp=$(boost_version) boost=$(boost_version) \
-        libboost=$(boost_version)
-  displayName: Setup build environment
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate coordgen_build
-    export BASE_PATH=$(pwd)
-    mkdir build && cd build && \
-    cmake .. \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCOORDGEN_RIGOROUS_BUILD=ON \
-    -DBoost_NO_SYSTEM_PATHS=ON \
-    -DCMAKE_INCLUDE_PATH="${CONDA_PREFIX}/include" \
-    -DCMAKE_LIBRARY_PATH="${CONDA_PREFIX}/lib" \
-    -DCMAKE_INSTALL_PREFIX=${BASE_PATH}/install
-  displayName: Configure build (Run CMake)
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate coordgen_build
-    cd build
-    make -j $( $(number_of_cores) ) install
-  displayName: Build
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate coordgen_build
-    cd build
-    ctest -j $( $(number_of_cores) ) --output-on-failure -T Test
-  displayName: Run tests
-- task: PublishTestResults@2
-  inputs:
-    testResultsFormat: 'CTest'
-    testResultsFiles: 'build/Testing/*/Test.xml'
-    testRunTitle: $(system.phasedisplayname) CTest Test Run
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      sudo chown -R ${USER} ${CONDA}
+      conda config --set always_yes yes --set changeps1 no
+      conda update -q conda
+      conda info -a
+      conda create --name coordgen_build $(compiler) cmake \
+          boost-cpp=$(boost_version) boost=$(boost_version) \
+          libboost=$(boost_version)
+    displayName: Setup build environment
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      conda activate coordgen_build
+      export BASE_PATH=$(pwd)
+      mkdir build && cd build && \
+      cmake .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCOORDGEN_RIGOROUS_BUILD=ON \
+      -DBoost_NO_SYSTEM_PATHS=ON \
+      -DCMAKE_INCLUDE_PATH="${CONDA_PREFIX}/include" \
+      -DCMAKE_LIBRARY_PATH="${CONDA_PREFIX}/lib" \
+      -DCMAKE_INSTALL_PREFIX="${BASE_PATH}/install" \
+      -DCOORDGEN_BUILD_SHARED_LIBS=$(shared_lib)
+    displayName: Configure build (Run CMake)
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      conda activate coordgen_build
+      cd build
+      make -j $( $(number_of_cores) ) install
+    displayName: Build
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      conda activate coordgen_build
+      cd build
+      ctest -j $( $(number_of_cores) ) --output-on-failure -T Test
+    displayName: Run tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: "CTest"
+      testResultsFiles: "build/Testing/*/Test.xml"
+      testRunTitle: $(system.phasedisplayname) CTest Test Run

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -1,61 +1,62 @@
 steps:
-- bash: |
-    wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX$(target_platform).sdk.tar.xz
-    tar Jxvf MacOSX$(target_platform).sdk.tar.xz
-  displayName: Install MacOSX $(target_platform) SDK
-- script: |
-    echo "Removing homebrew from Azure to avoid conflicts."
-    curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
-    chmod +x ~/uninstall_homebrew
-    ~/uninstall_homebrew -fq
-    rm ~/uninstall_homebrew
-  displayName: Remove homebrew
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    sudo chown -R ${USER} ${CONDA}
-    echo -e "backend: TkAgg\n" > $HOME/.matplotlib/matplotlibrc
-    conda config --set always_yes yes --set changeps1 no
-    conda update -q conda
-    conda create --name coordgen_build $(compiler) cmake \
-        boost-cpp=$(boost_version) boost=$(boost_version) \
-        py-boost=$(boost_version) libboost=$(boost_version)
-  displayName: Setup build environment
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate coordgen_build
-    export BASE_PATH=$(pwd)
-    export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
-    export CONDA_BUILD_SYSROOT=${SDKROOT}
-    mkdir build && cd build && \
-    cmake .. \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCOORDGEN_RIGOROUS_BUILD=ON \
-    -DBoost_NO_SYSTEM_PATHS=ON \
-    -DCMAKE_OSX_SYSROOT=${SDKROOT} \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=$(target_platform) \
-    -DCMAKE_INCLUDE_PATH="${CONDA_PREFIX}/include" \
-    -DCMAKE_LIBRARY_PATH="${CONDA_PREFIX}/lib" \
-    -DCMAKE_INSTALL_PREFIX=${BASE_PATH}/install
-  displayName: Configure build (Run CMake)
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate coordgen_build
-    export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
-    export CONDA_BUILD_SYSROOT=${SDKROOT}
-    cd build
-    make -j $( $(number_of_cores) ) install
-  displayName: Build
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate coordgen_build
-    export DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH}
-    export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
-    export CONDA_BUILD_SYSROOT=${SDKROOT}
-    cd build
-    ctest -j $( $(number_of_cores) ) --output-on-failure -T Test
-  displayName: Run tests
-- task: PublishTestResults@2
-  inputs:
-    testResultsFormat: 'CTest'
-    testResultsFiles: 'build/Testing/*/Test.xml'
-    testRunTitle: $(system.phasedisplayname) CTest Test Run
+  - bash: |
+      wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX$(target_platform).sdk.tar.xz
+      tar Jxvf MacOSX$(target_platform).sdk.tar.xz
+    displayName: Install MacOSX $(target_platform) SDK
+  - script: |
+      echo "Removing homebrew from Azure to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+    displayName: Remove homebrew
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      sudo chown -R ${USER} ${CONDA}
+      echo -e "backend: TkAgg\n" > $HOME/.matplotlib/matplotlibrc
+      conda config --set always_yes yes --set changeps1 no
+      conda update -q conda
+      conda create --name coordgen_build $(compiler) cmake \
+          boost-cpp=$(boost_version) boost=$(boost_version) \
+          py-boost=$(boost_version) libboost=$(boost_version)
+    displayName: Setup build environment
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      conda activate coordgen_build
+      export BASE_PATH=$(pwd)
+      export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
+      export CONDA_BUILD_SYSROOT=${SDKROOT}
+      mkdir build && cd build && \
+      cmake .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCOORDGEN_RIGOROUS_BUILD=ON \
+      -DBoost_NO_SYSTEM_PATHS=ON \
+      -DCMAKE_OSX_SYSROOT=${SDKROOT} \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET=$(target_platform) \
+      -DCMAKE_INCLUDE_PATH="${CONDA_PREFIX}/include" \
+      -DCMAKE_LIBRARY_PATH="${CONDA_PREFIX}/lib" \
+      -DCMAKE_INSTALL_PREFIX="${BASE_PATH}/install" \
+      -DCOORDGEN_BUILD_SHARED_LIBS=$(shared_lib)
+    displayName: Configure build (Run CMake)
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      conda activate coordgen_build
+      export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
+      export CONDA_BUILD_SYSROOT=${SDKROOT}
+      cd build
+      make -j $( $(number_of_cores) ) install
+    displayName: Build
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      conda activate coordgen_build
+      export DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH}
+      export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
+      export CONDA_BUILD_SYSROOT=${SDKROOT}
+      cd build
+      ctest -j $( $(number_of_cores) ) --output-on-failure -T Test
+    displayName: Run tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: "CTest"
+      testResultsFiles: "build/Testing/*/Test.xml"
+      testRunTitle: $(system.phasedisplayname) CTest Test Run

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -1,40 +1,41 @@
 steps:
-- powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-  displayName: Setup build environment
-- script: |
-    conda config --set always_yes yes --set changeps1 no
-    conda info -a
-    conda create --name coordgen_build $(compiler) cmake ^
-        boost-cpp=$(boost_version) boost=$(boost_version) ^
-        py-boost=$(boost_version) libboost=$(boost_version)
-  displayName: Install dependencies
-- script: |
-    set Boost_ROOT=
-    set BASE_PATH=%cd%
-    mkdir build && cd build
-    call activate coordgen_build
-    cmake .. ^
-    -G "Visual Studio 15 2017 Win64" ^
-    -DCMAKE_BUILD_TYPE=Release ^
-    -DCOORDGEN_RIGOROUS_BUILD=ON ^
-    -DBoost_NO_SYSTEM_PATHS=ON ^
-    -DCMAKE_INCLUDE_PATH=%CONDA_PREFIX%/Library/include ^
-    -DCMAKE_LIBRARY_PATH=%CONDA_PREFIX%/Library/lib ^
-    -DCMAKE_INSTALL_PREFIX=%BASE_PATH%/install
-  displayName: Configure build (Run CMake)
-- script: |
-    call activate coordgen_build
-    cd build
-    cmake --build . --config Release --target install -j $(number_of_cores)
-  displayName: Build
-- script: |
-    call activate coordgen_build
-    set PATH=%cd%/install/bin;%PATH%
-    cd build
-    ctest -j $(number_of_cores) --output-on-failure -T Test -C Release
-  displayName: Run tests
-- task: PublishTestResults@2
-  inputs:
-    testResultsFormat: 'CTest'
-    testResultsFiles: 'build/Testing/*/Test.xml'
-    testRunTitle: $(system.phasedisplayname)  CTest Test Run
+  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+    displayName: Setup build environment
+  - script: |
+      conda config --set always_yes yes --set changeps1 no
+      conda info -a
+      conda create --name coordgen_build $(compiler) cmake ^
+          boost-cpp=$(boost_version) boost=$(boost_version) ^
+          py-boost=$(boost_version) libboost=$(boost_version)
+    displayName: Install dependencies
+  - script: |
+      set Boost_ROOT=
+      set BASE_PATH=%cd%
+      mkdir build && cd build
+      call activate coordgen_build
+      cmake .. ^
+      -G "Visual Studio 15 2017 Win64" ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DCOORDGEN_RIGOROUS_BUILD=ON ^
+      -DBoost_NO_SYSTEM_PATHS=ON ^
+      -DCMAKE_INCLUDE_PATH=%CONDA_PREFIX%/Library/include ^
+      -DCMAKE_LIBRARY_PATH=%CONDA_PREFIX%/Library/lib ^
+      -DCMAKE_INSTALL_PREFIX=%BASE_PATH%/install ^
+      -DCOORDGEN_BUILD_SHARED_LIBS=$(shared_lib)
+    displayName: Configure build (Run CMake)
+  - script: |
+      call activate coordgen_build
+      cd build
+      cmake --build . --config Release --target install -j $(number_of_cores)
+    displayName: Build
+  - script: |
+      call activate coordgen_build
+      set PATH=%cd%/install/bin;%PATH%
+      cd build
+      ctest -j $(number_of_cores) --output-on-failure -T Test -C Release
+    displayName: Run tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: "CTest"
+      testResultsFiles: "build/Testing/*/Test.xml"
+      testRunTitle: $(system.phasedisplayname)  CTest Test Run

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ option(COORDGEN_RIGOROUS_BUILD "Abort the build if the compiler issues \
        any warnings" OFF )
 option(COORDGEN_BUILD_TESTS "Whether test executables should be built" ON)
 option(COORDGEN_BUILD_EXAMPLE "Whether to build the sample executable" ON)
+option(COORDGEN_BUILD_SHARED_LIBS "Build coordgen as a shared library \
+       (turn off for a static one)" ON)
 
 # Use the maeparser_DIR variable to tell CMake where to search for the
 # maeparser library.
@@ -20,6 +22,7 @@ if(MSVC)
     # (returning a vector of things)
     add_definitions(/wd4251 /wd4275 /wd4996 /D_SCL_SECURE_NO_WARNINGS
                     /D_CRT_SECURE_NO_WARNINGS)
+    add_definitions(-DBOOST_ALL_NO_LIB)
 endif(MSVC)
 
 if(COORDGEN_RIGOROUS_BUILD)
@@ -30,26 +33,35 @@ else(MSVC)
 endif(MSVC)
 endif(COORDGEN_RIGOROUS_BUILD)
 
-# Dependencies
-find_package(Boost COMPONENTS iostreams REQUIRED)
 
+# Source files & headers
+file(GLOB SOURCES "*.cpp")
+
+# Build Targets & Configuration -- coordgen library
+if(COORDGEN_BUILD_SHARED_LIBS)
+    add_library(coordgen SHARED ${SOURCES})
+    target_compile_definitions(coordgen PRIVATE "IN_COORDGEN")
+    set_property(TARGET coordgen PROPERTY CXX_VISIBILITY_PRESET "hidden")
+else(COORDGEN_BUILD_SHARED_LIBS)
+    add_library(coordgen STATIC ${SOURCES})
+    target_compile_definitions(coordgen PRIVATE "STATIC_MAEPARSER")
+    target_compile_definitions(coordgen PRIVATE "STATIC_COORDGEN")
+endif(COORDGEN_BUILD_SHARED_LIBS)
+
+# Dependencies
 if(TARGET maeparser)
     message(STATUS "Using externally defined maeparser target to "
     "build coordgen")
 else()
     include(CoordgenUtils)
+    set(MAEPARSER_BUILD_SHARED_LIBS ${COORDGEN_BUILD_SHARED_LIBS} CACHE BOOL "Library type for maeparser")
     find_or_clone_maeparser()
 endif()
-
-# Source files & headers
-file(GLOB SOURCES "*.cpp")
-include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${maeparser_INCLUDE_DIRS})
 
-# Build Targets & Configuration -- coordgen library
-add_library(coordgen SHARED ${SOURCES})
-target_compile_definitions(coordgen PRIVATE IN_COORDGEN)
-set_property(TARGET coordgen PROPERTY CXX_VISIBILITY_PRESET "hidden")
+find_package(Boost REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
+
 target_link_libraries(coordgen ${maeparser_LIBRARIES})
 
 set_target_properties(coordgen

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,39 +1,79 @@
 trigger:
-- master
-- dev/*
+  - master
+  - dev/*
 
 jobs:
-- job: Ubuntu_16_04_x64
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-16.04
-  variables:
-    compiler: gxx_linux-64=7.2.0
-    boost_version: 1.67.0
-    number_of_cores: nproc
-    python_name: python37
-  steps:
-  - template: .azure-pipelines/linux_build.yml
-- job: macOS_10_13_x64
-  timeoutInMinutes: 90
-  pool:
-    vmImage: macos-10.13
-  variables:
-    compiler: clangxx_osx-64
-    boost_version: 1.67.0
-    number_of_cores: sysctl -n hw.ncpu
-    python_name: python37
-    target_platform: 10.9
-  steps:
-  - template: .azure-pipelines/mac_build.yml
-- job: Windows_VS2017_x64
-  timeoutInMinutes: 90
-  pool:
-    vmImage: vs2017-win2016
-  variables:
-    compiler: vs2017_win-64
-    boost_version: 1.67.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python_name: python37
-  steps:
-  - template: .azure-pipelines/vs_build.yml
+  - job: Ubuntu_16_04_x64
+    timeoutInMinutes: 90
+    pool:
+      vmImage: ubuntu-16.04
+    variables:
+      compiler: gxx_linux-64=7.2.0
+      boost_version: 1.67.0
+      number_of_cores: nproc
+      python_name: python37
+      shared_lib: ON
+    steps:
+      - template: .azure-pipelines/linux_build.yml
+  - job: Ubuntu_16_04_x64_static
+    timeoutInMinutes: 90
+    pool:
+      vmImage: ubuntu-16.04
+    variables:
+      compiler: gxx_linux-64=7.2.0
+      boost_version: 1.67.0
+      number_of_cores: nproc
+      python_name: python37
+      shared_lib: OFF
+    steps:
+      - template: .azure-pipelines/linux_build.yml
+  - job: macOS_10_13_x64
+    timeoutInMinutes: 90
+    pool:
+      vmImage: macos-10.13
+    variables:
+      compiler: clangxx_osx-64
+      boost_version: 1.67.0
+      number_of_cores: sysctl -n hw.ncpu
+      python_name: python37
+      target_platform: 10.9
+      shared_lib: ON
+    steps:
+      - template: .azure-pipelines/mac_build.yml
+  - job: macOS_10_13_x64_static
+    timeoutInMinutes: 90
+    pool:
+      vmImage: macos-10.13
+    variables:
+      compiler: clangxx_osx-64
+      boost_version: 1.67.0
+      number_of_cores: sysctl -n hw.ncpu
+      python_name: python37
+      target_platform: 10.9
+      shared_lib: OFF
+    steps:
+      - template: .azure-pipelines/mac_build.yml
+  - job: Windows_VS2017_x64
+    timeoutInMinutes: 90
+    pool:
+      vmImage: vs2017-win2016
+    variables:
+      compiler: vs2017_win-64
+      boost_version: 1.67.0
+      number_of_cores: "%NUMBER_OF_PROCESSORS%"
+      python_name: python37
+      shared_lib: ON
+    steps:
+      - template: .azure-pipelines/vs_build.yml
+  - job: Windows_VS2017_x64_static
+    timeoutInMinutes: 90
+    pool:
+      vmImage: vs2017-win2016
+    variables:
+      compiler: vs2017_win-64
+      boost_version: 1.67.0
+      number_of_cores: "%NUMBER_OF_PROCESSORS%"
+      python_name: python37
+      shared_lib: OFF
+    steps:
+      - template: .azure-pipelines/vs_build.yml

--- a/example_dir/CMakeLists.txt
+++ b/example_dir/CMakeLists.txt
@@ -1,2 +1,15 @@
 add_executable(example example.cpp)
-target_link_libraries(example coordgen)
+
+if(COORDGEN_BUILD_SHARED_LIBS)
+    target_compile_definitions(example PRIVATE "BOOST_ALL_DYN_LINK")
+else(COORDGEN_BUILD_SHARED_LIBS)
+    set(Boost_USE_STATIC_LIBS ON)
+    target_compile_definitions(example PRIVATE "STATIC_MAEPARSER")
+    target_compile_definitions(example PRIVATE "STATIC_COORDGEN")
+endif(COORDGEN_BUILD_SHARED_LIBS)
+
+# Workaround for CI: Boost regex seems to be missing icu symbols in
+# some conda builds. The filesystem lib seems to have them.
+find_package(Boost COMPONENTS filesystem REQUIRED)
+
+target_link_libraries(example coordgen Boost::filesystem)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,19 @@
 # Use the example executable as a test
 add_test(example ${CMAKE_BINARY_DIR}/example_dir/example)
 
-# Require Boost testing framework for real tests
-find_package(Boost COMPONENTS unit_test_framework filesystem REQUIRED)
-
 add_executable(test_coordgen test_coordgen.cpp)
-target_link_libraries(test_coordgen coordgen Boost::unit_test_framework Boost::filesystem)
+
+if(COORDGEN_BUILD_SHARED_LIBS)
+    target_compile_definitions(test_coordgen PRIVATE "BOOST_ALL_DYN_LINK")
+else(COORDGEN_BUILD_SHARED_LIBS)
+    set(Boost_USE_STATIC_LIBS ON)
+    target_compile_definitions(test_coordgen PRIVATE "STATIC_MAEPARSER")
+    target_compile_definitions(test_coordgen PRIVATE "STATIC_COORDGEN")
+endif(COORDGEN_BUILD_SHARED_LIBS)
+
+find_package(Boost COMPONENTS filesystem unit_test_framework REQUIRED)
+
+target_link_libraries(test_coordgen coordgen ${maeparser_LIBRARIES} ${boost_link_options} Boost::unit_test_framework Boost::filesystem)
 
 # Set the path for the input files
 get_filename_component(TEST_SAMPLES_PATH ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)

--- a/test/test_coordgen.cpp
+++ b/test/test_coordgen.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE Test_Coordgen
 
 #include <boost/filesystem.hpp>


### PR DESCRIPTION
This PR implements an option to switch between building shared and static libraries. This is more or less the same I did in maeparser (https://github.com/schrodinger/maeparser/pull/57). Please note that this PR depends on the one in maeparser, and should not be merged before that one.

- Added the `COORDGEN_BUILD_SHARED_LIBS` flag: `ON` == shared library, `OFF` == static. The required dependencies (boost, zlib), as well as the unit tests, will use the same linking type as specified by the flag. If maeparser needs to be built from source, it will also use the same linking type as indicated here.

- In the tests:  removed the `BOOST_TEST_DYN_LINK` macro.

- Added some new Azure pipelines to build static libs. These have also been reformatted, looking like bigger changes that they actually are.

These changes have also been tested in my CI builds (https://dev.azure.com/ricrogz/mycoordgen/_build/results?buildId=391).

Please note that the Travis and appveyor builds do neither exercise the static builds.

As mentioned in the maeparser PR, I tested that, one these changes are live in maeparser and coordgen, RDKit and Openbabel won't break, and will still be able to build without any changes.
