### PR TITLE
Fixes #44

### DIFF
--- a/CoordgenFragmentBuilder.cpp
+++ b/CoordgenFragmentBuilder.cpp
@@ -447,7 +447,7 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
             for (auto& i : coords2) {
                 i = sketcherMinimizerPointF(i.x(), -i.y());
             }
-            map<sketcherMinimizerAtom *, sketcherMinimizerPointF> map1, map2;
+            map<sketcherMinimizerAtom*, sketcherMinimizerPointF> map1, map2;
             for (unsigned int i = 0; i < atoms.size(); i++) {
                 map1[atoms[i]] = coords[i];
                 map2[atoms[i]] = coords2[i];
@@ -1030,7 +1030,7 @@ void CoordgenFragmentBuilder::simplifyRingSystem(
                         /* disable macrocycles */
                         n++;
                     }
-                    if (r->fusionAtoms.at(ringCounter).size() > 3) {
+                    if (r->fusionAtoms.at(ringCounter).size() > 2) {
                         /* disable rings that share too many atoms */
                         n++;
                     }

--- a/templates.mae
+++ b/templates.mae
@@ -7562,3 +7562,58 @@ f_m_ct {
  } 
 } 
 
+f_m_ct { 
+ s_m_title
+ s_m_entry_id
+ s_m_entry_name
+ s_m_subgroup_title
+ s_m_subgroupid
+ b_m_subgroup_collapsed
+ i_m_ct_format
+ :::
+ norbornane
+  81 
+  norbornane.1 
+  templates 
+  templates 
+  0
+  2
+ m_atom[7] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_residue_number
+  i_m_color
+  i_m_atomic_number
+  s_m_color_rgb
+  s_m_atom_name
+  :::
+  1 4 -1.808000  0.490200 0.000000 900 2 6 A0A0A0  "" 
+  2 5 -2.522500  0.077700 0.000000 900 2 6 A0A0A0  "" 
+  3 5 -2.522500 -0.747400 0.000000 900 2 6 A0A0A0  "" 
+  4 4 -1.808000 -1.159800 0.000000 900 2 6 A0A0A0  "" 
+  5 5 -1.093500 -0.747400 0.000000 900 2 6 A0A0A0  "" 
+  6 5 -1.093500  0.077700 0.000000 900 2 6 A0A0A0  "" 
+  7 5 -1.507100 -0.312700 0.000000 900 2 6 A0A0A0  "" 
+  :::
+ } 
+ m_bond[8] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  :::
+  1 1 2 1
+  2 1 6 1
+  3 1 7 1
+  4 2 3 1
+  5 3 4 1
+  6 4 5 1
+  7 4 7 1
+  8 5 6 1
+  :::
+ } 
+} 
+


### PR DESCRIPTION
This addresses the issues in the coordinate generation for norbornane presented in #44:

1- templates were not applied to norbornane because coordgen counted only one central ring, while it should have found 2. The problem here was side rings were allowed to have up to 3 atoms in common with central rings. This has been corrected, and now only 2 common atoms are allowed. I'm not quite sure about the impact this might have.

2- A template for norbornane has been added.

I checked that the coordinates are now ok by using the same check as @greglandrum  used in #44:
![image](https://user-images.githubusercontent.com/7498185/72448692-71581f00-3785-11ea-8690-9fa2ef10ddb8.png)
