### PR TITLE
remove chirality and pseudo-chirality (_S_, _R_, _ANS_, and _ANR_) tags

### DIFF
--- a/templates.mae
+++ b/templates.mae
@@ -146,7 +146,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   2
-  9_R_8_6_10 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -1554,8 +1553,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   17
-  3_S_4_6_2 
-  7_S_8_9_6_10 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -2106,7 +2103,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   23
-  23_S_24_30_22 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -2323,7 +2319,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   25
-  5_S_10_6_4 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -2478,8 +2473,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   27
-  11_R_13_12_10 
-  26_S_29_25_27 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -2895,8 +2888,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   31
-  6_S_5_9_1_17 
-  5_S_7_6_4 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -2991,8 +2982,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   32
-  4_S_5_3_11 
-  31_S_32_30_33 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -3269,7 +3258,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   35
-  1_R_12_9_2 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -3349,7 +3337,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   36
-  12_S_14_13_11 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -3466,11 +3453,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   37
-  3_S_4_2_5 
-  7_R_9_8_6 
-  11_R_15_10_12 
-  9_S_17_7_10_14 
-  10_S_9_11_18 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -4360,13 +4342,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   47
-  3_ANS_1_4_6 
-  6_S_7_17_3 
-  16_ANS_2_5_15_17 
-  15_R_18_16_14 
-  17_S_6_12_16_20 
-  3_ANS_1_4_6 
-  16_ANS_2_5_15_17 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -4474,9 +4449,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   48
-  4_S_5_15_3 
-  13_R_16_14_12 
-  15_S_4_10_14_18 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -4974,9 +4946,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   53
-  15_R_14_16_27 
-  18_R_17_19_21 
-  41_S_20_42_40 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -5140,7 +5109,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   54
-  2_S_6_1_3 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -5506,12 +5474,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   58
-  4_R_5_7_3 
-  7_R_9_4_8 
-  9_S_6_10_7_1 
-  10_R_9_11_12 
-  11_R_10_8_15_17 
-  14_S_15_16_13 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -5614,12 +5576,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   59
-  3_R_5_4_1 
-  5_S_7_3_6 
-  7_S_9_5_8 
-  10_S_9_11_4 
-  11_R_12_10_15 
-  15_R_11_8_14_6 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -5717,11 +5673,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   60
-  4_S_16_5_3 
-  7_R_8_10_6 
-  11_R_10_12_16 
-  15_R_16_14_1 
-  16_R_9_11_15_4 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -5817,9 +5768,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   61
-  4_S_5_6_3 
-  8_R_5_7_9 
-  5_ANR_1_4_8_11 
   templates->templates->templates 
   templates->templates1->templates11 
   0
@@ -6636,7 +6584,6 @@ f_m_ct {
   /Users/nicola/schrodinger/coordgen_standalone 
   templates.mae 
   70
-  16_S_17_20_15 
   templates->templates->templates 
   templates->templates1->templates11 
   0


### PR DESCRIPTION
This came up during the discussion of rdkit/rdkit#2883
