### PR TITLE
Don't copy vector when not needed.

### DIFF
--- a/sketcherMinimizerAtom.h
+++ b/sketcherMinimizerAtom.h
@@ -104,8 +104,11 @@ class EXPORT_COORDGEN sketcherMinimizerAtom
         fragment = fragmentToSet;
     }
     sketcherMinimizerFragment* getFragment() const { return fragment; }
-    std::vector<sketcherMinimizerBond*> getBonds() const { return bonds; }
-    std::vector<sketcherMinimizerRing*> getRings() const { return rings; }
+    const std::vector<sketcherMinimizerBond*>& getBonds() const
+    {
+        return bonds;
+    }
+    const std::vector<sketcherMinimizerRing*>& getRings() const { return rings; }
     sketcherMinimizerMolecule* getMolecule() const { return molecule; }
 
     /*


### PR DESCRIPTION
The copy of the bonds vector was, seriously, 10% of total
duration for some example molecules that I looked at.
(because of copies that occured while checking whether
some atom is terminal)

Also fixes an extra copy for the ring vector, but that
doesn't have an impact that I know of. It's just odd.