### PR TITLE
I ran clang-tidy to do some automated refactors

### DIFF
--- a/CoordgenFragmentBuilder.cpp
+++ b/CoordgenFragmentBuilder.cpp
@@ -71,7 +71,7 @@ void CoordgenFragmentBuilder::rotateMainFragment(
     float rotMat[4];
     sketcherMinimizer::alignmentMatrix(v1, v2, rotMat);
     vector<sketcherMinimizerPointF> rotatedV2;
-    for (auto p : v2) {
+    for (const auto& p : v2) {
         auto rotatedPoint =
             sketcherMinimizerPointF(p.x() * rotMat[0] + p.y() * rotMat[1],
                                     p.x() * rotMat[2] + p.y() * rotMat[3]);

--- a/CoordgenMacrocycleBuilder.cpp
+++ b/CoordgenMacrocycleBuilder.cpp
@@ -708,6 +708,7 @@ vector<sketcherMinimizerPointF> CoordgenMacrocycleBuilder::newMacrocycle(
         atoms.at(0)->molecule->requireMinimization();
     }
     vector<sketcherMinimizerPointF> coordinates;
+    coordinates.reserve(atoms.size());
     foreach (sketcherMinimizerAtom* atom, atoms) {
         coordinates.push_back(atom->getCoordinates());
     }
@@ -846,9 +847,10 @@ CoordgenMacrocycleBuilder::listOfEquivalents(const vector<Polyomino>& l) const
     return out;
 }
 
-vector<Polyomino> CoordgenMacrocycleBuilder::listOfEquivalent(
-    Polyomino p) const // build a list of polyominoes with the same number of
-                       // vertices by removing hexagons with 3 neighbors
+vector<Polyomino>
+CoordgenMacrocycleBuilder::listOfEquivalent(const Polyomino& p)
+    const // build a list of polyominoes with the same number of
+          // vertices by removing hexagons with 3 neighbors
 {
     vector<Polyomino> out;
     vector<Hex*> l = p.m_list;
@@ -881,7 +883,7 @@ vector<ringConstraint> CoordgenMacrocycleBuilder::getRingConstraints(
     vector<sketcherMinimizerAtom*>& atoms) const
 {
     vector<ringConstraint> out;
-    for (int i = 0; i < (int) atoms.size(); i++) {
+    for (int i = 0; i < static_cast<int>(atoms.size()); i++) {
         sketcherMinimizerAtom* a = atoms[i];
         if (a->rings.size() > 1) {
             for (unsigned int rr = 0; rr < a->rings.size(); rr++) {
@@ -1161,6 +1163,7 @@ CoordgenMacrocycleBuilder::getVertexNeighborNs(Polyomino& p,
                                                vector<vertexCoords>& path) const
 {
     vector<int> out;
+    out.reserve(path.size());
     for (auto i : path) {
         out.push_back(static_cast<int>(p.hexagonsAtVertex(i)));
     }
@@ -1238,10 +1241,7 @@ bool CoordgenMacrocycleBuilder::matchPolyomino(Polyomino& p,
             }
         }
     }
-    if (bestScore > PATH_FAILED) {
-        return true;
-    }
-    return false;
+    return bestScore > PATH_FAILED;
 }
 
 sketcherMinimizerPointF

--- a/CoordgenMacrocycleBuilder.h
+++ b/CoordgenMacrocycleBuilder.h
@@ -73,10 +73,7 @@ struct vertexCoords {
 
     bool operator==(const vertexCoords& rhs) const
     {
-        if (x == rhs.x && y == rhs.y && z == rhs.z) {
-            return true;
-        }
-        return false;
+        return x == rhs.x && y == rhs.y && z == rhs.z;
     }
 
     vertexCoords(int ix, int iy, int iz)
@@ -110,10 +107,7 @@ struct hexCoords {
     }
     bool operator==(const hexCoords& rhs) const
     {
-        if (x == rhs.x && y == rhs.y) {
-            return true;
-        }
-        return false;
+        return x == rhs.x && y == rhs.y;
     }
     int x, y;
     int distanceFrom(const hexCoords& origin) const
@@ -346,7 +340,7 @@ class EXPORT_COORDGEN CoordgenMacrocycleBuilder
 
     /* build a list of polyominoes with the same number of vertices by removing
      * hexagons with 3 neighbors */
-    std::vector<Polyomino> listOfEquivalent(Polyomino p) const;
+    std::vector<Polyomino> listOfEquivalent(const Polyomino& p) const;
 
     std::vector<Polyomino>
     listOfEquivalents(const std::vector<Polyomino>& l) const;

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -105,10 +105,7 @@ bool CoordgenMinimizer::applyForces(float maxd)
         distance += displacement.squareLength();
         atom->force = sketcherMinimizerPointF(0, 0);
     }
-    if (distance < delta) {
-        return false;
-    }
-    return true;
+    return distance >= delta;
 }
 
 /* store extra interaction to be used when minimizing molecule.
@@ -644,7 +641,7 @@ void CoordgenMinimizer::setupInteractionsProteinOnly(
     clearInteractions();
     std::set<sketcherMinimizerBond*> interactions;
     std::set<sketcherMinimizerResidue*> residues;
-    for (auto chain : chains) {
+    for (const auto& chain : chains) {
         for (auto res : chain.second) {
             residues.insert(res);
             for (auto interaction : res->residueInteractions) {
@@ -802,7 +799,7 @@ float CoordgenMinimizer::scoreDofs(sketcherMinimizerMolecule* molecule) const
 float CoordgenMinimizer::scoreCrossBonds(sketcherMinimizerMolecule* molecule,
                                          bool residueInteractions) const
 {
-    if (m_scoreResidueInteractions == false) {
+    if (!m_scoreResidueInteractions) {
         residueInteractions = false;
     }
 
@@ -1089,7 +1086,8 @@ bool CoordgenMinimizer::growSolutions(
     float bestScoreForRun = bestScore;
     std::vector<std::pair<float, std::vector<short unsigned int>>>
         bestSolutions;
-    for (auto solution : growingSolutions) {
+    bestSolutions.reserve(growingSolutions.size());
+    for (const auto& solution : growingSolutions) {
         bestSolutions.emplace_back(solution.second, solution.first);
     }
     sort(bestSolutions.begin(), bestSolutions.end());
@@ -1100,7 +1098,7 @@ bool CoordgenMinimizer::growSolutions(
     }
     int n = 0;
 
-    for (auto solution : bestSolutions) {
+    for (const auto& solution : bestSolutions) {
         if (n > maxN) {
             break;
         }
@@ -1167,7 +1165,7 @@ bool CoordgenMinimizer::runLocalSearch(sketcherMinimizerMolecule* molecule,
     auto combinationsOfDofs = buildTuplesOfDofs(dofs, levels);
     do {
         downhill = false;
-        for (auto combinationOfDofs : combinationsOfDofs) {
+        for (const auto& combinationOfDofs : combinationsOfDofs) {
             float lastResult = clashE;
             bool foundOptimalPosition = runExhaustiveSearch(
                 molecule, combinationOfDofs, clashE, solutions);

--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -226,7 +226,7 @@ void sketcherMinimizer::initialize(
     // order independent
     canonicalOrdering(minMol);
 
-    foreach (sketcherMinimizerAtom* a, minMol->_atoms) {
+    for (auto a : minMol->_atoms) {
         if (!a->hidden) {
             _atoms.push_back(a);
         }
@@ -235,7 +235,7 @@ void sketcherMinimizer::initialize(
         }
     }
 
-    foreach (sketcherMinimizerBond* b, minMol->_bonds) {
+    for (auto b : minMol->_bonds) {
         if (!b->startAtom->hidden && !b->endAtom->hidden) {
             _bonds.push_back(b);
         }
@@ -248,7 +248,7 @@ void sketcherMinimizer::initialize(
     minMol->forceUpdateStruct(minMol->_atoms, minMol->_bonds, minMol->_rings);
     splitIntoMolecules(minMol, _molecules);
 
-    foreach (sketcherMinimizerBond* b, m_proximityRelations) {
+    for (auto& b : m_proximityRelations) {
         b->startAtom->molecule->m_proximityRelations.push_back(b);
         if (b->endAtom != b->startAtom) {
             b->endAtom->molecule->m_proximityRelations.push_back(b);
@@ -294,17 +294,18 @@ bool sketcherMinimizer::runGenerateCoordinates()
 
 void sketcherMinimizer::flagCrossAtoms()
 {
-    foreach (sketcherMinimizerAtom* at, _atoms)
+    for (auto at : _atoms) {
         if (at->atomicNumber == 16 || at->atomicNumber == 15) {
             at->crossLayout = true;
         }
+    }
 
-    foreach (sketcherMinimizerAtom* at, _atoms) {
+    for (auto at : _atoms) {
         if (at->crossLayout) {
             continue;
         }
         int cross = 0;
-        foreach (sketcherMinimizerAtom* n, at->neighbors) {
+        for (auto n : at->neighbors) {
             if (n->neighbors.size() > 3) {
                 cross++;
             }
@@ -357,11 +358,12 @@ void sketcherMinimizer::splitIntoMolecules(
         mols.push_back(mol);
         return;
     }
-    foreach (sketcherMinimizerAtom* a, mol->_atoms)
+    for (sketcherMinimizerAtom* a : mol->_atoms) {
         a->_generalUseVisited = false;
+    }
     queue<sketcherMinimizerAtom*> q;
     q.push(mol->_atoms[0]);
-    foreach (sketcherMinimizerAtom* a, mol->_atoms) {
+    for (sketcherMinimizerAtom* a : mol->_atoms) {
         if (!a->hidden) {
             q.push(a);
             break;
@@ -371,7 +373,7 @@ void sketcherMinimizer::splitIntoMolecules(
         sketcherMinimizerAtom* a = q.front();
         q.pop();
         a->_generalUseVisited = true;
-        foreach (sketcherMinimizerAtom* n, a->neighbors) {
+        for (sketcherMinimizerAtom* n : a->neighbors) {
             if (!n->_generalUseVisited && !n->hidden) {
                 q.push(n);
             }
@@ -379,15 +381,15 @@ void sketcherMinimizer::splitIntoMolecules(
     }
     vector<sketcherMinimizerAtom*> newAtoms;
 
-    foreach (sketcherMinimizerAtom* a, mol->_atoms) {
+    for (sketcherMinimizerAtom* a : mol->_atoms) {
         if (!a->_generalUseVisited && !a->hidden) {
             newAtoms.push_back(a);
         }
     }
     if (!newAtoms.size()) {
         mols.push_back(mol);
-        foreach (sketcherMinimizerMolecule* m, mols) {
-            foreach (sketcherMinimizerAtom* a, m->_atoms) {
+        for (sketcherMinimizerMolecule* m : mols) {
+            for (sketcherMinimizerAtom* a : m->_atoms) {
                 a->_generalUseVisited = false;
             }
         }
@@ -526,27 +528,25 @@ void sketcherMinimizer::assignPseudoZ()
                         if (b->hasStereochemistryDisplay) {
                             if (b->isWedge) {
                                 if ((b->startAtom == lastAtom &&
-                                     b->isReversed == false) ||
-                                    (b->endAtom == lastAtom &&
-                                     b->isReversed == true)) {
+                                     !b->isReversed) ||
+                                    (b->endAtom == lastAtom && b->isReversed)) {
                                     Z += 1.f;
                                 } else if ((b->startAtom == lastAtom &&
-                                            b->isReversed == true) ||
+                                            b->isReversed) ||
                                            (b->endAtom == lastAtom &&
-                                            b->isReversed == false)) {
+                                            !b->isReversed)) {
                                     Z -= 1.f;
                                 }
 
                             } else {
                                 if ((b->startAtom == lastAtom &&
-                                     b->isReversed == false) ||
-                                    (b->endAtom == lastAtom &&
-                                     b->isReversed == true)) {
+                                     !b->isReversed) ||
+                                    (b->endAtom == lastAtom && b->isReversed)) {
                                     Z -= 1.f;
                                 } else if ((b->startAtom == lastAtom &&
-                                            b->isReversed == true) ||
+                                            b->isReversed) ||
                                            (b->endAtom == lastAtom &&
-                                            b->isReversed == false)) {
+                                            !b->isReversed)) {
                                     Z += 1.f;
                                 }
                             }
@@ -1025,7 +1025,7 @@ void sketcherMinimizer::placeResiduesProteinOnlyModeCircleStyle(
         static_cast<float>(totalResiduesNumber * residueRadius * 2);
     const auto radius = static_cast<float>(circumference * 0.5 / M_PI);
     int i = 0;
-    for (auto chain : chains) {
+    for (const auto& chain : chains) {
         ++i; // gap between chains
         auto residues = chain.second;
         sort(residues.begin(), residues.end(),
@@ -1055,14 +1055,14 @@ sketcherMinimizer::computeChainsStartingPositionsMetaMol(
     map<std::string, sketcherMinimizerAtom*> molMap;
 
     auto* metaMol = new sketcherMinimizerMolecule;
-    for (auto chainPair : chains) {
+    for (const auto& chainPair : chains) {
         auto* a = new sketcherMinimizerAtom;
         a->molecule = metaMol;
         metaMol->_atoms.push_back(a);
         molMap[chainPair.first] = a;
     }
 
-    for (auto chainPair : chains) {
+    for (const auto& chainPair : chains) {
         for (auto residue : chainPair.second) {
             for (auto interaction : residue->residueInteractions) {
                 if (interaction->startAtom->isResidue() &&
@@ -1109,7 +1109,7 @@ sketcherMinimizer::computeChainsStartingPositionsMetaMol(
         min.arrangeMultipleMolecules();
     }
     std::map<std::string, sketcherMinimizerPointF> positions;
-    for (auto iter : molMap) {
+    for (const auto& iter : molMap) {
         positions[iter.first] = iter.second->coordinates * 10.;
     }
     return positions;
@@ -1118,7 +1118,7 @@ sketcherMinimizer::computeChainsStartingPositionsMetaMol(
 void sketcherMinimizer::shortenInteractions(
     const std::map<std::string, std::vector<sketcherMinimizerResidue*>>& chains)
 {
-    for (auto chain : chains) {
+    for (const auto& chain : chains) {
         for (auto res : chain.second) {
             for (auto interaction : res->residueInteractions) {
                 sketcherMinimizerPointF midPoint =
@@ -1134,7 +1134,7 @@ std::vector<sketcherMinimizerResidue*> sketcherMinimizer::orderResiduesOfChains(
     const std::map<std::string, std::vector<sketcherMinimizerResidue*>>& chains)
 {
     std::vector<sketcherMinimizerResidue*> vec;
-    for (auto chain : chains) {
+    for (const auto& chain : chains) {
         for (auto res : chain.second) {
             vec.push_back(res);
         }
@@ -1175,7 +1175,7 @@ void sketcherMinimizer::placeResiduesProteinOnlyModeLIDStyle(
 {
     auto positions = computeChainsStartingPositionsMetaMol(chains);
     sketcherMinimizerPointF p;
-    for (auto chain : chains) {
+    for (const auto& chain : chains) {
         p = positions[chain.first];
         for (auto res : chain.second) {
             res->coordinates = p;
@@ -1272,7 +1272,7 @@ bool sketcherMinimizer::fillShape(
 {
     vector<bool> penalties(shape.size(), false);
     std::set<sketcherMinimizerResidue*> outliers;
-    for (auto SSE : SSEs) {
+    for (const auto& SSE : SSEs) {
         placeSSE(SSE, shape, shapeN, penalties, outliers);
     }
     return !outliers.empty();
@@ -1681,7 +1681,6 @@ void sketcherMinimizer::placeResidues(
 
     placeResiduesInCrowns();
     m_minimizer.minimizeResidues();
-    return;
 }
 
 /*
@@ -2689,7 +2688,7 @@ bool sketcherMinimizer::alignWithParentDirectionConstrained(
         flippedCoordinates;
     float sine = sin(angle);
     float cosine = cos(angle);
-    for (auto atom : fragment->_coordinates) {
+    for (const auto& atom : fragment->_coordinates) {
         if (atom.first->constrained) {
             sketcherMinimizerPointF plainCoordinatesAtom = atom.second;
             sketcherMinimizerPointF flippedCoordinatesAtom(
@@ -2830,7 +2829,7 @@ sketcherMinimizerPointF sketcherMinimizer::scoreDirections(
             scoreModifier = bond->endAtom->fragment->longestChainFromHere *
                             SCORE_MULTIPLIER_FOR_FRAGMENTS;
         }
-        for (auto direction : directions) {
+        for (const auto& direction : directions) {
             float scorePlain =
                 testAlignment(bondDirectionPlain, direction) * scoreModifier;
             if (scorePlain > bestScore) {
@@ -3444,7 +3443,7 @@ void sketcherMinimizer::checkIdentity(
                             break;
                         }
                     }
-                    if (check == false) {
+                    if (!check) {
                         break;
                     }
                 }

--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -998,7 +998,7 @@ void sketcherMinimizer::findFragments()
 {
 
     assert(_molecules.size());
-    foreach (sketcherMinimizerMolecule* mol, _molecules) {
+    for (sketcherMinimizerMolecule* mol : _molecules) {
         CoordgenFragmenter::splitIntoFragments(mol);
         if (!mol->_fragments.size()) {
             continue;
@@ -2666,17 +2666,18 @@ void sketcherMinimizer::initializeFragments()
         return;
     }
 
-    foreach (sketcherMinimizerFragment* indf, _independentFragments) {
-        assignNumberOfChildrenAtomsFromHere(
-            indf); // recursively assign it to children
+    for (sketcherMinimizerFragment* indf : _independentFragments) {
+        // recursively assign it to children
+        assignNumberOfChildrenAtomsFromHere(indf);
     }
 
-    foreach (sketcherMinimizerFragment* f, _fragments) {
+    for (sketcherMinimizerFragment* f : _fragments) {
         m_fragmentBuilder.initializeCoordinates(f);
     }
 
-    foreach (sketcherMinimizerFragment* indf, _independentFragments) {
-        assignLongestChainFromHere(indf); // recursively assign it to children
+    for (sketcherMinimizerFragment* indf : _independentFragments) {
+        // recursively assign it to children
+        assignLongestChainFromHere(indf);
     }
 }
 
@@ -3558,11 +3559,10 @@ int sketcherMinimizer::morganScores(const vector<sketcherMinimizerAtom*>& atoms,
     int n = 0;
     size_t idx1, idx2;
     size_t oldTies = atoms.size();
-    size_t newTies = oldTies;
     unsigned int i = 0, j = 0;
     do {
-        n++;
-        for (i = 0; i < bonds.size(); i++) {
+        ++n;
+        for (i = 0; i < bonds.size(); ++i) {
             idx1 = bonds[i]->startAtom->_generalUseN;
             idx2 = bonds[i]->endAtom->_generalUseN;
             newScores[idx1] += oldScores[idx2];
@@ -3570,7 +3570,7 @@ int sketcherMinimizer::morganScores(const vector<sketcherMinimizerAtom*>& atoms,
         }
         orderedScores = newScores;
         stable_sort(orderedScores.begin(), orderedScores.end());
-        newTies = 0;
+        size_t newTies = 0;
         for (j = 1; j < orderedScores.size(); j++) {
             if (orderedScores[j] == orderedScores[j - 1]) {
                 newTies++;

--- a/sketcherMinimizerAtom.cpp
+++ b/sketcherMinimizerAtom.cpp
@@ -573,8 +573,7 @@ void sketcherMinimizerAtom::writeStereoChemistry() // sets stereochemistry for
                             // sketcher coords and readStereo in coordgen coords
                             // (flipped y)
 
-            if ((readS == -1 && isR == true) ||
-                (readS == 1 && isR == false)) { // inverting
+            if ((readS == -1 && isR) || (readS == 1 && !isR)) { // inverting
                 invert = true;
 
                 if (b1) {
@@ -989,13 +988,13 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
 
     vector<CIPAtom> AN1, AN2;
 
-    map<sketcherMinimizerAtom*, int> score1,
+    map<sketcherMinimizerAtom *, int> score1,
         score2; // used to keep track if a parent atom has been found to have
                 // priority over another
-    map<sketcherMinimizerAtom*, vector<int>> medals1,
+    map<sketcherMinimizerAtom *, vector<int>> medals1,
         medals2; // marks if an atom is a parent of the atoms being evaluated in
                  // the current iteration
-    map<sketcherMinimizerAtom*, int> visited1,
+    map<sketcherMinimizerAtom *, int> visited1,
         visited2; // marks at which iteration this atom was evaluated
 
     visited1[center] = 1;
@@ -1003,11 +1002,11 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
     visited1[at1] = 2;
     visited2[at2] = 2;
 
-    vector<pair<int, sketcherMinimizerAtom*>> v1, v2;
+    vector<pair<int, sketcherMinimizerAtom *>> v1, v2;
     v1.emplace_back(at1->atomicNumber, at1);
     v2.emplace_back(at2->atomicNumber, at2);
 
-    vector<sketcherMinimizerAtom*> parents1, parents2;
+    vector<sketcherMinimizerAtom *> parents1, parents2;
     parents1.push_back(center);
     parents1.push_back(at1);
     parents2.push_back(center);
@@ -1118,7 +1117,7 @@ vector<CIPAtom> sketcherMinimizerAtom::expandOneLevel(vector<CIPAtom>& oldV)
                               (*visited)[a] + 1) // closing a ring to an atom
                                                  // already visited in a
                                                  // previous cycle
-                        );
+                         );
                     theseAts.emplace_back(
                         neigh->atomicNumber,
                         ghost ? ((sketcherMinimizerAtom*) nullptr)

--- a/sketcherMinimizerAtom.h
+++ b/sketcherMinimizerAtom.h
@@ -108,7 +108,11 @@ class EXPORT_COORDGEN sketcherMinimizerAtom
     {
         return bonds;
     }
-    const std::vector<sketcherMinimizerRing*>& getRings() const { return rings; }
+    const std::vector<sketcherMinimizerRing*>& getRings() const
+    {
+        return rings;
+    }
+
     sketcherMinimizerMolecule* getMolecule() const { return molecule; }
 
     /*

--- a/sketcherMinimizerBond.cpp
+++ b/sketcherMinimizerBond.cpp
@@ -188,10 +188,7 @@ bool sketcherMinimizerBond::isStereo() const
     }
     sketcherMinimizerRing* ring =
         sketcherMinimizerAtom::shareARing(getStartAtom(), getEndAtom());
-    if (ring && !ring->isMacrocycle()) {
-        return false;
-    }
-    return true;
+    return !(ring && !ring->isMacrocycle());
 }
 
 void sketcherMinimizerBond::flip()

--- a/sketcherMinimizerConstraintInteraction.h
+++ b/sketcherMinimizerConstraintInteraction.h
@@ -17,9 +17,9 @@ class sketcherMinimizerConstraintInteraction
     : public sketcherMinimizerInteraction
 {
   public:
-    sketcherMinimizerConstraintInteraction(sketcherMinimizerAtom* at1,
-                                           sketcherMinimizerPointF position)
-        : sketcherMinimizerInteraction(at1, at1), origin(std::move(position))
+    sketcherMinimizerConstraintInteraction(
+        sketcherMinimizerAtom* at1, const sketcherMinimizerPointF& position)
+        : sketcherMinimizerInteraction(at1, at1), origin(position)
     {
         k = CONSTRAINT_SCALE;
     }
@@ -33,11 +33,7 @@ class sketcherMinimizerConstraintInteraction
     }
 
     /* calculate the forces and apply them */
-    void score(float& totalE, bool = false) override
-    {
-        energy(totalE);
-        return;
-    }
+    void score(float& totalE, bool = false) override { energy(totalE); }
 
   private:
     sketcherMinimizerPointF origin;

--- a/sketcherMinimizerFragment.cpp
+++ b/sketcherMinimizerFragment.cpp
@@ -454,14 +454,14 @@ void sketcherMinimizerFragment::addRing(sketcherMinimizerRing* ring)
 
 void sketcherMinimizerFragment::setAllCoordinatesToTemplate()
 {
-    foreach (sketcherMinimizerAtom* atom, m_atoms) {
+    for (sketcherMinimizerAtom* atom : m_atoms) {
         atom->setCoordinatesToTemplate();
     }
     if (_bondToParent) {
         _bondToParent->startAtom->setCoordinatesToTemplate();
         _bondToParent->endAtom->setCoordinatesToTemplate();
     }
-    foreach (sketcherMinimizerFragment* child, _children) {
+    for (sketcherMinimizerFragment* child : _children) {
         child->_bondToParent->startAtom->setCoordinatesToTemplate();
         child->_bondToParent->endAtom->setCoordinatesToTemplate();
     }
@@ -500,8 +500,8 @@ void sketcherMinimizerFragment::storeCoordinateInformation()
     }
 }
 
-void sketcherMinimizerFragment::setCoordinates(sketcherMinimizerPointF position,
-                                               float angle)
+void sketcherMinimizerFragment::setCoordinates(
+    const sketcherMinimizerPointF& position, float angle)
 {
     float sine = sin(angle);
     float cosine = cos(angle);

--- a/sketcherMinimizerFragment.h
+++ b/sketcherMinimizerFragment.h
@@ -267,7 +267,7 @@ class sketcherMinimizerFragment
 
     /* translate and rotate the fragment and set the resulting coordinates to
      * every atom */
-    void setCoordinates(sketcherMinimizerPointF position, float angle);
+    void setCoordinates(const sketcherMinimizerPointF& position, float angle);
 
     /* get the dof that refers to flipping this fragment */
     CoordgenFragmentDOF* getFlipDof() const { return m_dofs[0]; }

--- a/sketcherMinimizerMarchingSquares.cpp
+++ b/sketcherMinimizerMarchingSquares.cpp
@@ -156,7 +156,7 @@ sketcherMinimizerMarchingSquares::getOrderedCoordinatesPoints() const
         newShape = false;
         nextPoint = nullptr;
         for (auto m_point : m_points) {
-            if (m_point->visited == false) {
+            if (!m_point->visited) {
                 newShape = true;
                 nextPoint = m_point;
                 break;
@@ -188,14 +188,14 @@ sketcherMinimizerMarchingSquares::getOrderedCoordinatesPoints() const
 
                 bool found = false;
                 if (followingPoint1) {
-                    if (followingPoint1->visited == false) {
+                    if (!followingPoint1->visited) {
                         nextPoint = followingPoint1;
                         found = true;
                     }
                 }
                 if (!found) {
                     if (followingPoint2) {
-                        if (followingPoint2->visited == false) {
+                        if (!followingPoint2->visited) {
                             nextPoint = followingPoint2;
                             found = true;
                         }

--- a/sketcherMinimizerMaths.h
+++ b/sketcherMinimizerMaths.h
@@ -275,9 +275,9 @@ struct sketcherMinimizerMaths {
            parallel but do not intersect.
         */
 
-        sketcherMinimizerPointF p = s1p1;
+        const sketcherMinimizerPointF& p = s1p1;
         sketcherMinimizerPointF r = s1p2 - s1p1;
-        sketcherMinimizerPointF q = s2p1;
+        const sketcherMinimizerPointF& q = s2p1;
         sketcherMinimizerPointF s = s2p2 - s2p1;
         float rxs = crossProduct(r, s);
         if (rxs > -SKETCHER_EPSILON &&
@@ -360,7 +360,7 @@ struct sketcherMinimizerMaths {
         //    ///cerr << "("<<p1.x()<<","<<p1.y()<<") ("<<p2.x
         //    ()<<","<<p2.y()<<")  ("<<lineP1.x()<<","<<lineP1.y()<<")
         //    ("<<lineP2.x ()<<","<<lineP2.y()<<")"<<endl;
-        if (fabs(float(x)) > fabs((float) (y))) { // what about q?
+        if (fabs(float(x)) > fabs((y))) { // what about q?
             float m = y / x;
 
             float d1 = p1.y() - lineP1.y() - m * (p1.x() - lineP1.x());
@@ -454,7 +454,7 @@ struct sketcherMinimizerMaths {
                a.size() == rhs.size());
         assert(b[0] != 0.f);
 
-        auto n = (unsigned int) rhs.size();
+        auto n = static_cast<unsigned int>(rhs.size());
         std::vector<float> u(n);
         std::vector<float> gam(n);
 
@@ -481,7 +481,7 @@ struct sketcherMinimizerMaths {
                                           const std::vector<float>& rhs)
     {
         assert(a.size() == b.size() && a.size() == c.size());
-        auto n = (unsigned int) b.size();
+        auto n = static_cast<unsigned int>(b.size());
         assert(n > 2);
         float gamma = -b[0]; // Avoid subtraction error in forming bb[0].
         // Set up the diagonal of the modified tridiagonal system.
@@ -540,7 +540,7 @@ struct sketcherMinimizerMaths {
         std::vector<sketcherMinimizerPointF>& secondControlPoints)
     {
 
-        auto n = (unsigned int) knots.size();
+        auto n = static_cast<unsigned int>(knots.size());
         if (n <= 2) {
             return;
         }

--- a/sketcherMinimizerMolecule.h
+++ b/sketcherMinimizerMolecule.h
@@ -5,9 +5,10 @@
  *   Copyright Schrodinger, LLC. All rights reserved.
  *
  */
-#include <vector>
-#include <iostream>
 #include "CoordgenConfig.hpp"
+#include <iostream>
+#include <utility>
+#include <vector>
 
 #ifndef sketcherMINIMIZERMOLECULE_H
 #define sketcherMINIMIZERMOLECULE_H
@@ -44,7 +45,7 @@ class EXPORT_COORDGEN sketcherMinimizerMolecule
     }
     void setFragments(std::vector<sketcherMinimizerFragment*> fragments)
     {
-        _fragments = fragments;
+        _fragments = std::move(fragments);
     }
 
     /* set this molecule to require force-field minimization */

--- a/sketcherMinimizerResidue.cpp
+++ b/sketcherMinimizerResidue.cpp
@@ -10,7 +10,7 @@
 
 using namespace std;
 
-sketcherMinimizerResidue::sketcherMinimizerResidue() : sketcherMinimizerAtom()
+sketcherMinimizerResidue::sketcherMinimizerResidue()
 {
     m_closestLigandAtom = nullptr;
 }

--- a/sketcherMinimizerRing.cpp
+++ b/sketcherMinimizerRing.cpp
@@ -166,10 +166,7 @@ bool sketcherMinimizerRing::contains(const sketcherMinimizerPointF& p)
             }
         }
     }
-    if ((n % 2) != 0) {
-        return true;
-    }
-    return false;
+    return (n % 2) != 0;
 }
 
 //    std::vector <sketcherMinimizerBond *> _bonds;

--- a/sketcherMinimizerRing.h
+++ b/sketcherMinimizerRing.h
@@ -35,7 +35,7 @@ class EXPORT_COORDGEN sketcherMinimizerRing
     std::vector<sketcherMinimizerBond*> fusionBonds;
     bool visited, coordinatesGenerated, side /* not central */;
     std::vector<sketcherMinimizerAtom*> getAtoms() const { return _atoms; }
-    int size() const { return (int) _atoms.size(); }
+    int size() const { return static_cast<int>(_atoms.size()); }
     bool isMacrocycle() const { return size() >= MACROCYCLE; }
     std::vector<sketcherMinimizerAtom*> _atoms;
     std::vector<sketcherMinimizerBond*> _bonds;

--- a/test/test_coordgen.cpp
+++ b/test/test_coordgen.cpp
@@ -52,9 +52,7 @@ bool areBondsNearIdeal(sketcherMinimizerMolecule& mol,
 
     return passed;
 }
-
-} // unnamed namespace
-
+} // namespace
 
 BOOST_AUTO_TEST_CASE(SampleTest)
 {


### PR DESCRIPTION
 Specifically, I ran these checks:

   `-checks=performance-*,modernize-*,-modernize-use-noexcept,misc-throw-by-value-catch-by-reference,misc-unused-alias-decls,misc-unused-using-decls,google-readability-*,-google-readability-todo,readability-redundant-*,readability-simplify-*`

There is also a commit in here that I wrote manually, but which is in the same spirit. The manual commit is swap to use erase/remove instead of a bunch of separate erases. Just something I did while trying to understand code flow.