### PR TITLE
Allow CoordGen to build as DLL on Windows in RDKit

### DIFF
--- a/sketcherMinimizer.h
+++ b/sketcherMinimizer.h
@@ -12,6 +12,7 @@
 #include <stack>
 #include <vector>
 
+#include "CoordgenConfig.hpp"
 #include "sketcherMinimizerAtom.h"
 #include "sketcherMinimizerBond.h"
 #include "sketcherMinimizerResidue.h"
@@ -23,7 +24,6 @@
 #include "sketcherMinimizerRing.h"
 #include <iostream>
 
-#include "CoordgenConfig.hpp"
 #include "CoordgenFragmentBuilder.h"
 #include "CoordgenMinimizer.h"
 

--- a/sketcherMinimizerFragment.h
+++ b/sketcherMinimizerFragment.h
@@ -9,11 +9,13 @@
 #ifndef sketcherMINIMIZERFRAGMENT
 #define sketcherMINIMIZERFRAGMENT
 
-#include "sketcherMinimizerMaths.h"
 #include <cassert>
 #include <iostream>
 #include <map>
 #include <vector>
+
+#include "CoordgenConfig.hpp"
+#include "sketcherMinimizerMaths.h"
 
 class sketcherMinimizerAtom;
 class sketcherMinimizerBond;
@@ -23,7 +25,7 @@ class sketcherMinimizerFragment;
 /*
  abstract class for fragment degree of freedom
  */
-class CoordgenFragmentDOF
+class EXPORT_COORDGEN CoordgenFragmentDOF
 {
   public:
     CoordgenFragmentDOF(sketcherMinimizerFragment* fragment);


### PR DESCRIPTION
I have just noticed that the current RDKit master branch fails to build the `CoordGen` DLL on Windows.
These small changes got the DLL built.
Thanks in advance!