### PR TITLE
Reduce number of copies of some vectors

### DIFF
--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -788,8 +788,8 @@ float CoordgenMinimizer::scoreClashes(
 float CoordgenMinimizer::scoreDofs(sketcherMinimizerMolecule* molecule) const
 {
     float E = 0.f;
-    for (auto fragment : molecule->getFragments()) {
-        for (auto dof : fragment->getDofs()) {
+    for (const auto& fragment : molecule->getFragments()) {
+        for (const auto& dof : fragment->getDofs()) {
             E += dof->getCurrentPenalty();
         }
     }

--- a/CoordgenMinimizer.h
+++ b/CoordgenMinimizer.h
@@ -68,7 +68,7 @@ class CoordgenDOFSolutions
      */
     bool hasSolution(const std::vector<short unsigned int>& solution);
 
-    std::vector<CoordgenFragmentDOF*> getAllDofs() { return m_allDofs; }
+    std::vector<CoordgenFragmentDOF*>& getAllDofs() { return m_allDofs; }
 
   private:
     const CoordgenMinimizer* m_minimizer;

--- a/sketcherMinimizerFragment.cpp
+++ b/sketcherMinimizerFragment.cpp
@@ -382,7 +382,7 @@ void sketcherMinimizerFragment::addDof(CoordgenFragmentDOF* dof)
     m_dofs.push_back(dof);
 }
 
-std::vector<CoordgenFragmentDOF*> sketcherMinimizerFragment::getDofs()
+const std::vector<CoordgenFragmentDOF*>& sketcherMinimizerFragment::getDofs()
 {
     return m_dofs;
 }

--- a/sketcherMinimizerFragment.h
+++ b/sketcherMinimizerFragment.h
@@ -139,7 +139,7 @@ class CoordgenChangeParentBondLengthFragmentDOF : public CoordgenFragmentDOF
 };
 
 /*
- invert the direction of a bond (e.g. a substituent to a macrocycle can be
+ Invert the direction of a bond (e.g. a substituent to a macrocycle can be
  placed towards the inside
  of the ring)
  */
@@ -211,7 +211,7 @@ class sketcherMinimizerFragment
     void addDof(CoordgenFragmentDOF* dof);
 
     /* get all degrees of freedom of this fragment */
-    std::vector<CoordgenFragmentDOF*> getDofs();
+    const std::vector<CoordgenFragmentDOF*>& getDofs();
 
     /* mark the given bond as interfragment */
     void addInterFragmentBond(sketcherMinimizerBond* bond)


### PR DESCRIPTION
By returning references and iterating over references. Copying
vectors unnecessarily can be a source of slowdown. `getAllDofs()` 
is called so frequently that this is worth about a 15% speedup
in some of the slower cases.