### PR TITLE
Adds an approximate timeout to coordgen

### DIFF
--- a/CoordgenFragmentBuilder.cpp
+++ b/CoordgenFragmentBuilder.cpp
@@ -553,6 +553,11 @@ CoordgenFragmentBuilder::listOfCoordinatesFromListofRingAtoms(
     return out;
 }
 
+void CoordgenFragmentBuilder::setApproximateTimeout(const std::chrono::milliseconds timeout) {
+    m_macrocycleBuilder.setApproximateTimeout(timeout);
+}
+
+
 void CoordgenFragmentBuilder::buildNonRingAtoms(
     sketcherMinimizerFragment* fragment) const
 {

--- a/CoordgenFragmentBuilder.h
+++ b/CoordgenFragmentBuilder.h
@@ -6,6 +6,7 @@
 #ifndef COORDGEN_FRAGMENT_BUILDER_H
 #define COORDGEN_FRAGMENT_BUILDER_H
 
+#include <chrono>
 #include <queue>
 #include <set>
 #include <stack>
@@ -63,10 +64,14 @@ class EXPORT_COORDGEN CoordgenFragmentBuilder
     }
 
     /* set precision of the calculations. Higher precisions settings result
-     better
-     quality but slower
-     calculations */
+     better quality but slower calculations */
     void setPrecision(float f) { m_macrocycleBuilder.setPrecision(f); }
+
+    /* Set a timeout (in seconds) for construction of each fragment.
+       This timeout also applies to assembly of the fragments, so a 0.1s
+       timeout could lead to, for instance, a 0.3s total time.
+     */
+    void setApproximateTimeout(std::chrono::milliseconds timeout);
 
     /*
      all bonds are placed at even intervals around the atom, as opposed for

--- a/CoordgenMacrocycleBuilder.cpp
+++ b/CoordgenMacrocycleBuilder.cpp
@@ -637,6 +637,12 @@ void CoordgenMacrocycleBuilder::setPrecision(float f)
     m_precision = f;
 }
 
+void CoordgenMacrocycleBuilder::setApproximateTimeout(const std::chrono::milliseconds timeout)
+{
+    m_timeout = timeout;
+    m_useTimeout = true;
+}
+
 vector<sketcherMinimizerPointF> CoordgenMacrocycleBuilder::newMacrocycle(
     sketcherMinimizerRing* ring, vector<sketcherMinimizerAtom*> atoms) const
 {
@@ -761,6 +767,9 @@ bool CoordgenMacrocycleBuilder::openCycleAndGenerateCoords(
 {
     map<sketcherMinimizerAtom*, sketcherMinimizerAtom*> atomMap;
     sketcherMinimizer min(getPrecision());
+    if (m_useTimeout) {
+        min.setApproximateTimeout(m_timeout);
+    }
     min.m_minimizer.skipMinimization = true;
     min.m_fragmentBuilder.setForceOpenMacrocycles(true);
     auto* minMol = new sketcherMinimizerMolecule;

--- a/CoordgenMacrocycleBuilder.h
+++ b/CoordgenMacrocycleBuilder.h
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <vector>
+#include <chrono>
 
 class sketcherMinimizerAtom;
 class sketcherMinimizerRing;
@@ -307,12 +308,17 @@ class EXPORT_COORDGEN CoordgenMacrocycleBuilder
 
     void setPrecision(float f);
 
+    void setApproximateTimeout(std::chrono::milliseconds timeout);
+
   private:
     /*
      precision of calculation. Higher values result in better results but longer
      calculation times
      */
     float m_precision;
+
+    std::chrono::milliseconds m_timeout;
+    bool m_useTimeout{false};
 
     /* build polyominos with the given number of vertices */
     std::vector<Polyomino> buildSquaredShapes(int totVertices) const;

--- a/CoordgenMinimizer.h
+++ b/CoordgenMinimizer.h
@@ -7,6 +7,7 @@
 #define COORDGEN_MINIMIZER_H
 
 #include "CoordgenConfig.hpp"
+#include <chrono>
 #include <iostream>
 #include <map>
 #include <set>
@@ -88,6 +89,8 @@ class EXPORT_COORDGEN CoordgenMinimizer
     CoordgenMinimizer();
 
     ~CoordgenMinimizer();
+
+    void setTimeout(std::chrono::milliseconds timeout);
 
     /* clear all the interactions loaded in the minimizer and free memory */
     void clearInteractions();
@@ -202,16 +205,6 @@ class EXPORT_COORDGEN CoordgenMinimizer
                         const std::vector<CoordgenFragmentDOF*>& dofs,
                         int levels, float& clashE,
                         CoordgenDOFSolutions& solutions);
-
-    /*
-     iteratively grow the pool of solutions by mutating the best scoring one by
-     one degree of freedom
-     */
-    bool growSolutions(
-        std::set<std::vector<short unsigned int>>& allScoredSolutions,
-        int& currentTier,
-        std::map<std::vector<short unsigned int>, float>& growingSolutions,
-        CoordgenDOFSolutions& solutions, float& bestScore);
 
     /*
      run the search to find good scoring solutions to the problem. Each degree
@@ -390,6 +383,8 @@ class EXPORT_COORDGEN CoordgenMinimizer
 
     float m_maxIterations;
     float m_precision;
+    bool m_useTimeout {false};
+    std::chrono::milliseconds m_timeout;
 };
 
 #endif /* defined(COORDGEN_MINIMIZER_H) */

--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -56,6 +56,15 @@ sketcherMinimizer::~sketcherMinimizer()
     clear();
 }
 
+void sketcherMinimizer::setApproximateTimeout(const std::chrono::milliseconds timeout)
+{
+    m_useTimeout = true;
+    m_timeout = timeout;
+    m_minimizer.setTimeout(timeout);
+    m_fragmentBuilder.setApproximateTimeout(timeout);
+
+}
+
 void sketcherMinimizer::setScoreResidueInteractions(bool b)
 {
     m_minimizer.m_scoreResidueInteractions = b;

--- a/sketcherMinimizer.h
+++ b/sketcherMinimizer.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <stack>
 #include <vector>
+#include <chrono>
 
 #include "sketcherMinimizerAtom.h"
 #include "sketcherMinimizerBond.h"
@@ -100,6 +101,14 @@ class EXPORT_COORDGEN sketcherMinimizer
     /* run coordinates generation and return true if the pose is considered
      * optimal */
     bool runGenerateCoordinates();
+
+    /* Set a timeout for macrocyle clash minimization.
+
+      Macrocycle clash minimization is typically the rate limiting
+      step for runGenerateCoordinates(). It may be run several
+      times on complex molecules, up to once for each macrocycle.
+     */
+    void setApproximateTimeout(std::chrono::milliseconds timeout);
 
     /* return true if the molecules structure is reasonable (e.g. reasonable
      * amount of fused rings) */
@@ -459,6 +468,10 @@ class EXPORT_COORDGEN sketcherMinimizer
     static void setTemplateFileDir(std::string dir);
     static void loadTemplates();
     static CoordgenTemplates m_templates;
+
+private:
+    bool m_useTimeout{false};
+    std::chrono::milliseconds m_timeout;
 };
 
 // EXPORT_COORDGEN sketcherMinimizerMolecule*


### PR DESCRIPTION
The timeout governs the "degree of freedom" optimization
step (`CoordgenMinimizer::runSearch()`).  For slow
molecules, this step takes the bulk of the time in
`sketcherMinimizer::runGenerateCoordinates()` calls.

However, there may be more than one call to `runSearch()`- it's
done for each macrocycle and then again to combine
the macrocycles. That being said, most slow molecules that
I've seen do 1-2 slow `runSearch()` calls, not _so_ many.

Here's a typical minimization for a slow molecule (that actually
did _three_ `runSearch()` calls).

<img width="513" alt="Typical minimization" src="https://user-images.githubusercontent.com/3013277/85475147-8160ff80-b56a-11ea-9035-f3ce5b1e5cc7.png">

The first two minimization cycles are for the macrocyle
fragments, the last one is to combine those two. For this
molecule, I didn't see an interesting difference in the final
coordinates for a timeout of 0.05s (50milliseconds).

Use like:

    sketcherMinimizer minimizer;
    minimizer.initialize(mol);
    minimizer.setApproximateTimeout(static_cast<std::chrono::milliseconds>(100));
    minimizer.runGenerateCoordinates();
