### PR TITLE
Include GNUInstallDirs in CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ set_target_properties(coordgen
 if(MSVC)
     set(CMAKE_INSTALL_LIBDIR lib)
     set(CMAKE_INSTALL_BINDIR bin)
+else(MSVC)
+    include(GNUInstallDirs)
 endif(MSVC)
 
 # Install configuration


### PR DESCRIPTION
Apparently, `CMAKE_INSTALL_LIBDIR` and `CMAKE_INSTALL_BINDIR` aren't always available by default: at least the MacOs 10.14 and cmake 3.13.5 combination doesn't have it, which causes the CMake configuration fail with the error:

```
[stderr] CMake Error at CMakeLists.txt:94 (install):
[stderr]   install TARGETS given no LIBRARY DESTINATION for shared library target
[stderr]   "coordgen".
[stderr] 
```

Forcing the inclusion of this module solves the issue.