### PR TITLE
add EXPORT_COORDGEN to CoordgenFragmenter class

### DIFF
--- a/CoordgenFragmenter.h
+++ b/CoordgenFragmenter.h
@@ -5,6 +5,7 @@
 
 #ifndef COORDGEN_FRAGMENTER_H
 #define COORDGEN_FRAGMENTER_H
+#include "CoordgenConfig.hpp"
 
 #include <cstddef>
 #include <vector>
@@ -18,7 +19,7 @@ class sketcherMinimizerAtom;
 /*
  class to divide a molecule into rigid fragments
  */
-class CoordgenFragmenter
+class EXPORT_COORDGEN CoordgenFragmenter
 {
   public:
     /*


### PR DESCRIPTION
This is required in order to be able to the static methods from this class in other libraries when using DLL linkage on windows.

It came up during the CI builds of https://github.com/rdkit/rdkit/pull/3319