### PR TITLE
Add visibility attribute to import declaration

### DIFF
--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -21,7 +21,8 @@ steps:
       -DCMAKE_INCLUDE_PATH=%CONDA_PREFIX%/Library/include ^
       -DCMAKE_LIBRARY_PATH=%CONDA_PREFIX%/Library/lib ^
       -DCMAKE_INSTALL_PREFIX=%BASE_PATH%/install ^
-      -DCOORDGEN_BUILD_SHARED_LIBS=$(shared_lib)
+      -DCOORDGEN_BUILD_SHARED_LIBS=$(shared_lib) ^
+      -DBoost_LIB_PREFIX="$(boost_lib_prefix)"
     displayName: Configure build (Run CMake)
   - script: |
       call activate coordgen_build

--- a/CoordgenConfig.hpp
+++ b/CoordgenConfig.hpp
@@ -2,25 +2,21 @@
 
 #ifndef STATIC_COORDGEN
 
-#ifdef IN_COORDGEN
 #ifdef WIN32
+#ifdef IN_COORDGEN
 #define EXPORT_COORDGEN __declspec(dllexport)
 #else
-#define EXPORT_COORDGEN __attribute__((visibility("default")))
-#endif
-
-#else
-
-#ifdef WIN32
 #define EXPORT_COORDGEN __declspec(dllimport)
-#else
-#define EXPORT_COORDGEN __attribute__((visibility("default")))
-#endif
+#endif // IN_COORDGEN
 
-#endif
+#else
+
+#define EXPORT_COORDGEN __attribute__((visibility("default")))
+
+#endif // WIN32
 
 #else
 
 #define EXPORT_COORDGEN
 
-#endif
+#endif // STATIC_COORDGEN

--- a/CoordgenConfig.hpp
+++ b/CoordgenConfig.hpp
@@ -14,7 +14,7 @@
 #ifdef WIN32
 #define EXPORT_COORDGEN __declspec(dllimport)
 #else
-#define EXPORT_COORDGEN
+#define EXPORT_COORDGEN __attribute__((visibility("default")))
 #endif
 
 #endif

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,7 @@ jobs:
       number_of_cores: "%NUMBER_OF_PROCESSORS%"
       python_name: python37
       shared_lib: ON
+      boost_lib_prefix: ""
     steps:
       - template: .azure-pipelines/vs_build.yml
   - job: Windows_VS2017_x64_static
@@ -75,5 +76,6 @@ jobs:
       number_of_cores: "%NUMBER_OF_PROCESSORS%"
       python_name: python37
       shared_lib: OFF
+      boost_lib_prefix: "lib"
     steps:
       - template: .azure-pipelines/vs_build.yml


### PR DESCRIPTION
Apparently, clang doesn't correctly handle type comparisons with mismatched visibility: even if a library is compiled with default visibility, if the code linking it compiles using "hidden" visibility, types won't be correctly matched, creating problems at least in catching exceptions.

This is better explained in the last few comments in rdkit/rdkit/issues/2753. There are also some links to a proof of concept I built to demonstrate the problem with the RDKit.