### PR TITLE
COORDGEN-262

### DIFF
--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -177,7 +177,7 @@ void sketcherMinimizer::initialize(
         if (_bond->skip) {
             continue;
         }
-        if (getTreatAllBondsToMetalAsZOBs()) {
+        if (getTreatNonterminalBondsToMetalAsZOBs()) {
             if (_bond->bondOrder == 1 || _bond->bondOrder == 2) {
                 bool terminalBond = bondsToAtom[_bond->startAtom] == 1 || bondsToAtom[_bond->endAtom] == 1;
                 if (!terminalBond && (sketcherMinimizerAtom::isMetal(

--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -168,15 +168,21 @@ void sketcherMinimizer::initialize(
     _referenceAtoms = minMol->_atoms;
     _referenceBonds = minMol->_bonds;
 
+    std::map<sketcherMinimizerAtom*, int> bondsToAtom;
+    for (auto& _bond : minMol->_bonds) {
+        bondsToAtom[_bond->startAtom]++;
+        bondsToAtom[_bond->endAtom]++;
+    }
     for (auto& _bond : minMol->_bonds) {
         if (_bond->skip) {
             continue;
         }
         if (getTreatAllBondsToMetalAsZOBs()) {
             if (_bond->bondOrder == 1 || _bond->bondOrder == 2) {
-                if (sketcherMinimizerAtom::isMetal(
+                bool terminalBond = bondsToAtom[_bond->startAtom] == 1 || bondsToAtom[_bond->endAtom] == 1;
+                if (!terminalBond && (sketcherMinimizerAtom::isMetal(
                                                    _bond->startAtom->atomicNumber) ||
-                    sketcherMinimizerAtom::isMetal(_bond->endAtom->atomicNumber)) {
+                    sketcherMinimizerAtom::isMetal(_bond->endAtom->atomicNumber))) {
                     _bond->bondOrder = 0;
                 }
             }

--- a/sketcherMinimizer.h
+++ b/sketcherMinimizer.h
@@ -460,13 +460,13 @@ class EXPORT_COORDGEN sketcherMinimizer
     static void loadTemplates();
     static CoordgenTemplates m_templates;
 
-    bool getTreatAllBondsToMetalAsZOBs() {return m_treatAllBondsToMetalAsZOBs;}
-    void setTreatAllBondsToMetalAsZOBs(bool b) {m_treatAllBondsToMetalAsZOBs = b;}
+    bool getTreatNonterminalBondsToMetalAsZOBs() {return m_treatNonterminalBondsToMetalAsZOBs;}
+    void setTreatNonterminalBondsToMetalAsZOBs(bool b) {m_treatNonterminalBondsToMetalAsZOBs = b;}
 
 private:
-    /*all bonds to a metal atom are treated as if they were zero order bonds (this usually results
+    /*all non-terminal bonds to a metal atom are treated as if they were zero order bonds (this usually results
      in a longer bond*/
-    bool m_treatAllBondsToMetalAsZOBs = true;
+    bool m_treatNonterminalBondsToMetalAsZOBs = true;
 };
 
 // EXPORT_COORDGEN sketcherMinimizerMolecule*

--- a/test/nonterminalMetalZobs.mae
+++ b/test/nonterminalMetalZobs.mae
@@ -1,0 +1,56 @@
+{ 
+ s_m_m2io_version
+ :::
+ 2.0.0 
+} 
+
+f_m_ct { 
+ s_m_title
+ s_m_entry_id
+ s_m_entry_name
+ s_m_Source_Path
+ s_m_Source_File
+ i_m_Source_File_Index
+ i_m_ct_format
+ :::
+ Structure1 
+  1 
+  entry 
+  /Users/nicola/schrodinger/coordgenlibs/test 
+  metalZobs.mae 
+  1
+  2
+ m_atom[6] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_color
+  i_m_atomic_number
+  s_m_color_rgb
+  i_rdk_index
+  :::
+  1 158 0.000000 0.000000 0.000000 19 13 E11EE1  0
+  2 26 1.970000 0.000000 0.000000 43 7 5757FF  1
+  3 41 -0.801858 1.375985 -0.000000 21 1 FFFFFF  <>
+  4 41 -0.801888 -1.375976 -0.000019 21 1 FFFFFF  <>
+  5 43 2.307145 -0.952068 -0.000000 21 1 FFFFFF  <>
+  6 43 2.307145 0.477048 -0.823929 21 1 FFFFFF  <>
+  :::
+ } 
+ m_bond[5] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  :::
+  1 1 2 1
+  2 1 3 1
+  3 1 4 1
+  4 2 5 1
+  5 2 6 1
+  :::
+ } 
+} 
+

--- a/test/test_coordgen.cpp
+++ b/test/test_coordgen.cpp
@@ -186,6 +186,38 @@ BOOST_AUTO_TEST_CASE(DisableMetalZOBs)
     // Load a molecule with a single bond to a metal. Make sure that disabling the automatic conversion
     // to zob behaves as expected
 
+    const std::string testfile = (test_samples_path / "nonterminalMetalZobs.mae").string();
+
+    mae::Reader r(testfile);
+    auto block = r.next(mae::CT_BLOCK);
+    BOOST_REQUIRE(block != nullptr);
+
+    auto* mol = mol_from_mae_block(*block);
+    BOOST_REQUIRE(mol != nullptr);
+
+    sketcherMinimizer minimizer;
+    minimizer.setTreatNonterminalBondsToMetalAsZOBs(false);
+    auto Al = mol->getAtoms().at(0);
+    auto N = mol->getAtoms().at(1);
+    //make sure we got the right atoms
+    BOOST_REQUIRE_EQUAL(Al->atomicNumber, 13);
+    BOOST_REQUIRE_EQUAL(N->atomicNumber, 7);
+
+    minimizer.initialize(mol); // minimizer takes ownership of mol
+    minimizer.runGenerateCoordinates();
+    auto bondLength = (Al->coordinates - N->coordinates).length();
+    auto expectedLength = 50.f;
+    auto tolerance = 2.f;
+    BOOST_REQUIRE ((bondLength > expectedLength-tolerance) && (bondLength < expectedLength+tolerance));
+    auto indices = getReportingIndices(*mol);
+    BOOST_CHECK(areBondsNearIdeal(*mol, indices));
+}
+
+
+BOOST_AUTO_TEST_CASE(terminalMetalZOBs)
+{
+    // Load a molecule with a single bond to a terminal metal. Make sure the bondlength is consistant with a terminal bond
+
     const std::string testfile = (test_samples_path / "metalZobs.mae").string();
 
     mae::Reader r(testfile);
@@ -196,7 +228,6 @@ BOOST_AUTO_TEST_CASE(DisableMetalZOBs)
     BOOST_REQUIRE(mol != nullptr);
 
     sketcherMinimizer minimizer;
-    minimizer.setTreatAllBondsToMetalAsZOBs(false);
     auto Al = mol->getAtoms().at(0);
     auto N = mol->getAtoms().at(1);
     //make sure we got the right atoms


### PR DESCRIPTION
Always trust bond order for terminal metals (in other words never convert bonds to terminal atoms to zero order bonds), this means that terminal atoms are treated as part of the same molecule for depiction purposes, so the bond is always a standard length.