### PR TITLE
Minor header cleanup, make warnings=error the default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # Options
 option(COORDGEN_RIGOROUS_BUILD "Abort the build if the compiler issues \
-       any warnings" OFF )
+       any warnings" ON )
 option(COORDGEN_BUILD_TESTS "Whether test executables should be built" ON)
 option(COORDGEN_BUILD_EXAMPLE "Whether to build the sample executable" ON)
 option(COORDGEN_USE_MAEPARSER "Whether to allow loading of run-time templates" OFF)

--- a/CoordgenFragmentBuilder.cpp
+++ b/CoordgenFragmentBuilder.cpp
@@ -11,6 +11,7 @@
 #include "CoordgenMinimizer.h"
 #include "sketcherMinimizer.h"
 #include "sketcherMinimizerFragment.h"
+#include "sketcherMinimizerRing.h"
 #include "sketcherMinimizerStretchInteraction.h"
 
 using namespace std;

--- a/CoordgenFragmenter.h
+++ b/CoordgenFragmenter.h
@@ -2,9 +2,7 @@
    Contributors: Nicola Zonta
    Copyright Schrodinger, LLC. All rights reserved
  */
-
-#ifndef COORDGEN_FRAGMENTER_H
-#define COORDGEN_FRAGMENTER_H
+#pragma once
 #include "CoordgenConfig.hpp"
 
 #include <cstddef>
@@ -154,5 +152,3 @@ class EXPORT_COORDGEN CoordgenFragmenter
     orderFragments(std::vector<sketcherMinimizerFragment*>& fragments,
                    sketcherMinimizerFragment* mainFragment);
 };
-
-#endif /* defined(COORDGEN_FRAGMENTER_H) */

--- a/CoordgenMacrocycleBuilder.cpp
+++ b/CoordgenMacrocycleBuilder.cpp
@@ -2,14 +2,16 @@
  Contributors: Nicola Zonta
  Copyright Schrodinger, LLC. All rights reserved
  */
+#include <algorithm>
+#include <queue>
 
 #include "CoordgenMacrocycleBuilder.h"
 #include "CoordgenMinimizer.h"
 #include "sketcherMinimizer.h"
 #include "sketcherMinimizerMaths.h"
+#include "sketcherMinimizerRing.h"
 #include "sketcherMinimizerStretchInteraction.h"
-#include <algorithm>
-#include <queue>
+
 
 #define MAX_MACROCYCLES 40
 #define PATH_FAILED -1000

--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -25,6 +25,7 @@
 #include "sketcherMinimizerClashInteraction.h"
 #include "sketcherMinimizerMaths.h"
 #include "sketcherMinimizerStretchInteraction.h"
+#include "sketcherMinimizerRing.h"
 
 using namespace std;
 using namespace schrodinger;

--- a/sketcherMinimizer.h
+++ b/sketcherMinimizer.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  *  sketcherMinimizer.h
  *
@@ -5,27 +6,20 @@
  *   Copyright Schrodinger, LLC. All rights reserved.
  *
  */
-#ifndef sketcherMINIMIZER
-#define sketcherMINIMIZER
-
 #include <map>
-#include <stack>
 #include <vector>
-
-#include "sketcherMinimizerAtom.h"
-#include "sketcherMinimizerBond.h"
-#include "sketcherMinimizerResidue.h"
-#include "sketcherMinimizerResidueInteraction.h"
-
-#include "sketcherMinimizerFragment.h"
-#include "sketcherMinimizerMarchingSquares.h"
-#include "sketcherMinimizerMolecule.h"
-#include "sketcherMinimizerRing.h"
 #include <iostream>
 
 #include "CoordgenConfig.hpp"
+
 #include "CoordgenFragmentBuilder.h"
 #include "CoordgenMinimizer.h"
+#include "sketcherMinimizerFragment.h"
+#include "sketcherMinimizerMarchingSquares.h"
+#include "sketcherMinimizerMolecule.h"
+#include "sketcherMinimizerResidue.h"
+#include "sketcherMinimizerResidueInteraction.h"
+#include "sketcherMinimizerRing.h"
 
 static const float SKETCHER_STANDARD_PRECISION = 1.f;
 static const float SKETCHER_QUICK_PRECISION = 0.2f;
@@ -33,7 +27,6 @@ static const float SKETCHER_BEST_PRECISION = 3.f;
 
 class sketcherAtom;
 class sketcherBond;
-class sketcherMolecule;
 class sketcherMinimimizerInteraction;
 
 namespace schrodinger
@@ -468,8 +461,3 @@ private:
      in a longer bond*/
     bool m_treatAllBondsToMetalAsZOBs = true;
 };
-
-// EXPORT_COORDGEN sketcherMinimizerMolecule*
-// mol_from_mae_block(schrodinger::mae::Block& block);
-
-#endif // sketcherMINIMIZER

--- a/sketcherMinimizerAtom.cpp
+++ b/sketcherMinimizerAtom.cpp
@@ -6,14 +6,16 @@
  *
  */
 
+#include <algorithm>
+#include <numeric>
+#include <queue>
+
 #include "sketcherMinimizerAtom.h"
 #include "sketcherMinimizer.h"
 #include "sketcherMinimizerBond.h"
 #include "sketcherMinimizerMaths.h"
+#include "sketcherMinimizerRing.h"
 
-#include <algorithm>
-#include <numeric>
-#include <queue>
 
 using namespace std;
 


### PR DESCRIPTION
We're hoping to do another round of performance improvements
and code cleanup on coordgen. This commit removes some header
inclusion to lower the build-time cost of header changes.