### PR TITLE
Fix linux build with older GCC (6.4.0)

### DIFF
--- a/test/coordgenBasicSMILES.h
+++ b/test/coordgenBasicSMILES.h
@@ -6,40 +6,32 @@
  * us sidestep using a full chemistry toolkit when writing tests.
  */
 
-
 #include <algorithm>
-#include <string>
-#include <stack>
-#include <vector>
-#include <unordered_map>
 #include <iostream>
-#include <algorithm>
+#include <stack>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "../sketcherMinimizerMolecule.h"
-
 
 namespace schrodinger
 {
 
 sketcherMinimizerMolecule* approxSmilesParse(const std::string& smiles)
 {
-    const std::unordered_map<char, int> elements {
-        {'H', 1},
-        {'C', 6},
-        {'N', 7},
-        {'S', 16},
-        {'O', 8}
-    };
+    const std::unordered_map<char, int> elements{
+        {'H', 1}, {'C', 6}, {'N', 7}, {'S', 16}, {'O', 8}};
 
     auto mol = new sketcherMinimizerMolecule();
     std::stack<std::stack<sketcherMinimizerAtom*>> tree;
-    tree.push({});
+    tree.emplace();
     auto* prev = &tree.top();
     std::unordered_map<char, sketcherMinimizerAtom*> cycles;
     int bond_order = 1;
 
     size_t idx = 0;
-    for (auto c: smiles) {
+    for (auto c : smiles) {
         auto atomic_number = elements.find(c);
         if (atomic_number != elements.end()) {
             auto atom = mol->addNewAtom();
@@ -49,7 +41,6 @@ sketcherMinimizerMolecule* approxSmilesParse(const std::string& smiles)
                 auto bond = mol->addNewBond(atom, prev->top());
                 bond->setBondOrder(bond_order);
                 bond_order = 1;
-
             }
             prev->push(atom);
         } else if (c == '=') {
@@ -66,7 +57,7 @@ sketcherMinimizerMolecule* approxSmilesParse(const std::string& smiles)
             }
         } else if (c == '(') {
             auto old = prev->top();
-            tree.push({});
+            tree.emplace();
             prev = &tree.top();
             prev->push(old);
         } else if (c == ')') {
@@ -81,7 +72,8 @@ sketcherMinimizerMolecule* approxSmilesParse(const std::string& smiles)
         ++idx;
     }
 
-    sketcherMinimizerMolecule::assignBondsAndNeighbors(mol->getAtoms(), mol->getBonds());
+    sketcherMinimizerMolecule::assignBondsAndNeighbors(mol->getAtoms(),
+                                                       mol->getBonds());
     return mol;
 }
 


### PR DESCRIPTION
The build on linux with GCC 6.4.0 fails with the errors below. This patch fixes it.

```
/home/rodrigue/Documents/code/coordgenlibs/coordgenlibs/test/coordgenBasicSMILES.h: In function ‘sketcherMinimizerMolecule* schrodinger::approxSmilesParse(const string&)’:
/home/rodrigue/Documents/code/coordgenlibs/coordgenlibs/test/coordgenBasicSMILES.h:36:17: error: converting to ‘std::stack<std::stack<sketcherMinimizerAtom*> >::value_type {aka std::stack<sketcherMinimizerAtom*>}’ from initializer list would use explicit constructor ‘std::stack<_Tp, _Sequence>::stack(_Sequence&&) [with _Tp = sketcherMinimizerAtom*; _Sequence = std::deque<sketcherMinimizerAtom*, std::allocator<sketcherMinimizerAtom*> >]’ [-Werror]
     tree.push({});
                 ^
/home/rodrigue/Documents/code/coordgenlibs/coordgenlibs/test/coordgenBasicSMILES.h:36:17: note: in C++11 and above a default constructor can be explicit
/home/rodrigue/Documents/code/coordgenlibs/coordgenlibs/test/coordgenBasicSMILES.h:69:25: error: converting to ‘std::stack<std::stack<sketcherMinimizerAtom*> >::value_type {aka std::stack<sketcherMinimizerAtom*>}’ from initializer list would use explicit constructor ‘std::stack<_Tp, _Sequence>::stack(_Sequence&&) [with _Tp = sketcherMinimizerAtom*; _Sequence = std::deque<sketcherMinimizerAtom*, std::allocator<sketcherMinimizerAtom*> >]’ [-Werror]
             tree.push({});
                         ^
/home/rodrigue/Documents/code/coordgenlibs/coordgenlibs/test/coordgenBasicSMILES.h:69:25: note: in C++11 and above a default constructor can be explicit
In file included from /home/rodrigue/Documents/code/coordgenlibs/coordgenlibs/test/test_smilesparser.cpp:7:0:
/home/rodrigue/Documents/code/coordgenlibs/coordgenlibs/test/coordgenBasicSMILES.h: In function ‘sketcherMinimizerMolecule* schrodinger::approxSmilesParse(const string&)’:
/home/rodrigue/Documents/code/coordgenlibs/coordgenlibs/test/coordgenBasicSMILES.h:36:17: error: converting to ‘std::stack<std::stack<sketcherMinimizerAtom*> >::value_type {aka std::stack<sketcherMinimizerAtom*>}’ from initializer list would use explicit constructor ‘std::stack<_Tp, _Sequence>::stack(_Sequence&&) [with _Tp = sketcherMinimizerAtom*; _Sequence = std::deque<sketcherMinimizerAtom*, std::allocator<sketcherMinimizerAtom*> >]’ [-Werror]
     tree.push({});
                 ^
/home/rodrigue/Documents/code/coordgenlibs/coordgenlibs/test/coordgenBasicSMILES.h:36:17: note: in C++11 and above a default constructor can be explicit
/home/rodrigue/Documents/code/coordgenlibs/coordgenlibs/test/coordgenBasicSMILES.h:69:25: error: converting to ‘std::stack<std::stack<sketcherMinimizerAtom*> >::value_type {aka std::stack<sketcherMinimizerAtom*>}’ from initializer list would use explicit constructor ‘std::stack<_Tp, _Sequence>::stack(_Sequence&&) [with _Tp = sketcherMinimizerAtom*; _Sequence = std::deque<sketcherMinimizerAtom*, std::allocator<sketcherMinimizerAtom*> >]’ [-Werror]
             tree.push({});
                         ^
/home/rodrigue/Documents/code/coordgenlibs/coordgenlibs/test/coordgenBasicSMILES.h:69:25: note: in C++11 and above a default constructor can be explicit
```