### PR TITLE
Address recent performance regression

### DIFF
--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -37,7 +37,7 @@ static const unsigned int MAXIMUM_NUMBER_OF_SCORED_SOLUTIONS = 10000;
 static const float REJECTED_SOLUTION_SCORE = 99999999.f;
 CoordgenMinimizer::CoordgenMinimizer()
 {
-    m_maxIterations = 10000;
+    m_maxIterations = 1000;
     skipMinimization = false;
     skipFlipFragments = false;
     skipAvoidClashes = false;


### PR DESCRIPTION
Reported in the schrödinger bug tracker as SHARED-7789

Our performance monitoring tests noticed that coordgen got about
10x slower after PR #81. I guess the inner loop of minimization
must be hitting the max pretty frequently! We should address
that too.

(this doubles the max iterations from before #81, but that's ok
because #81 included a tidy refactor that halved the calls to this
function)

Before this commit:

    slowest:  1.442s
    average: 0.044s
    # above 0.1s: 566
    # above 1s: 9

After this commit:

    slowest: 0.151s
    average: 0.006s
    molecules above 0.1s: 12
    molecules above 1s: 0

