### PR TITLE
Do not allow the minimizer to flip constrained fragments

### DIFF
--- a/CoordgenFragmenter.cpp
+++ b/CoordgenFragmenter.cpp
@@ -149,16 +149,16 @@ void CoordgenFragmenter::initializeInformation(
 bool CoordgenFragmenter::setFixedInfo(sketcherMinimizerFragment* fragment)
 {
     fragment->fixed =
-        (find_if(fragment->atoms().begin(), fragment->atoms().end(),
-                 isAtomFixed) != fragment->atoms().end());
+        (count_if(fragment->atoms().begin(), fragment->atoms().end(),
+                 isAtomFixed) > 1);
     return fragment->fixed;
 }
 
 bool CoordgenFragmenter::setConstrainedInfo(sketcherMinimizerFragment* fragment)
 {
     fragment->constrained =
-        (find_if(fragment->atoms().begin(), fragment->atoms().end(),
-                 isAtomConstrained) != fragment->atoms().end());
+        (count_if(fragment->atoms().begin(), fragment->atoms().end(),
+                 isAtomConstrained) > 1);
     return fragment->constrained;
 }
 
@@ -238,7 +238,7 @@ CoordgenFragmenter::getValueOfCheck(const sketcherMinimizerFragment* fragment,
     case 4:
         return fragment->_interFragmentBonds.size();
     case 5:
-        return fragment->countHeavyAtoms();
+        return fragment->countHeteroAtoms();
     case 6:
         return fragment->totalWeight();
     case 7:

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -1177,7 +1177,7 @@ bool CoordgenMinimizer::flipFragments(sketcherMinimizerMolecule* molecule,
     vector<sketcherMinimizerFragment*> fragments = molecule->getFragments();
     reverse(fragments.begin(), fragments.end());
     for (auto fragment : fragments) {
-        if (!fragment->fixed) {
+        if (!fragment->fixed && !fragment->constrained) {
             for (auto dof : fragment->getDofs()) {
                 if (dof->numberOfStates() > 1) {
                     dofs.push_back(dof);

--- a/sketcherMinimizerFragment.cpp
+++ b/sketcherMinimizerFragment.cpp
@@ -405,7 +405,7 @@ unsigned int sketcherMinimizerFragment::countDoubleBonds() const
     }
     return n;
 }
-unsigned int sketcherMinimizerFragment::countHeavyAtoms() const
+unsigned int sketcherMinimizerFragment::countHeteroAtoms() const
 {
     int n = 0;
     for (auto m_atom : m_atoms) {

--- a/sketcherMinimizerFragment.h
+++ b/sketcherMinimizerFragment.h
@@ -190,7 +190,7 @@ class sketcherMinimizerFragment
     unsigned int countDoubleBonds() const;
 
     /* return the number of heavy atoms in the fragment */
-    unsigned int countHeavyAtoms() const;
+    unsigned int countHeteroAtoms() const;
 
     /* return the number of constrained atoms in the fragment */
     unsigned int countConstrainedAtoms() const;


### PR DESCRIPTION
Hello,

working with the RDKit interface to `CoordGen` I noticed that when I do a constrained depiction in RDKit using `rdDepictor.GenerateDepictionMatching2DStructure` and my constrained scaffold consists of two ring systems connected by a rotatable bond, `CoordGen` may flip the two rings with respect to each other in the attempt to escape a steric clash.
This is a simple reproducible:
```
from rdkit import Chem
from rdkit.Chem import rdDepictor
from rdkit.Chem.Draw import IPythonConsole, MolsToGridImage
IPythonConsole.drawOptions.addAtomIndices = True

simple_scaffold = Chem.MolFromMolBlock("""
  MJ201100                      

 17 19  0  0  0  0  0  0  0  0999 V2000
   -2.9134    0.2011    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -3.7383    0.2011    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -4.1508   -0.5134    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -3.7384   -1.2278    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -2.9134   -1.2278    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -2.5008   -0.5133    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -2.6583    0.9857    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -3.3257    1.4706    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
   -3.9932    0.9857    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
   -1.6758   -0.5133    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.8737    1.2405    0.0000 *   0  0  0  0  0  0  0  0  0  0  0  0
   -1.2634   -1.2277    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
   -0.4383   -1.2277    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -0.0257   -0.5133    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -0.4382    0.2011    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.2633    0.2011    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.6758    0.9156    0.0000 *   0  0  0  0  0  0  0  0  0  0  0  0
  1  2  2  0  0  0  0
  2  3  1  0  0  0  0
  3  4  2  0  0  0  0
  4  5  1  0  0  0  0
  5  6  2  0  0  0  0
  6  1  1  0  0  0  0
  1  7  1  0  0  0  0
  6 10  1  0  0  0  0
  7  8  2  0  0  0  0
  2  9  1  0  0  0  0
  8  9  1  0  0  0  0
  7 11  1  0  0  0  0
 13 14  2  0  0  0  0
 14 15  1  0  0  0  0
 15 16  2  0  0  0  0
 16 10  1  0  0  0  0
 12 13  1  0  0  0  0
 10 12  2  0  0  0  0
 16 17  1  0  0  0  0
M  END
""")

simple_mol = Chem.MolFromMolBlock("""
  MJ201100                      

 18 20  0  0  0  0  0  0  0  0999 V2000
   -2.9134    0.2011    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -3.7383    0.2011    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -4.1508   -0.5134    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -3.7384   -1.2278    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -2.9134   -1.2278    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -2.5008   -0.5133    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -2.6583    0.9857    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -3.3257    1.4706    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
   -3.9932    0.9857    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
   -1.6758   -0.5133    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.8737    1.2405    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
   -1.2634   -1.2277    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
   -0.4383   -1.2277    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -0.0257   -0.5133    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -0.4382    0.2011    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.2633    0.2011    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.6758    0.9156    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.4209    1.7002    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
  1  2  2  0  0  0  0
  2  3  1  0  0  0  0
  3  4  2  0  0  0  0
  4  5  1  0  0  0  0
  5  6  2  0  0  0  0
  6  1  1  0  0  0  0
  1  7  1  0  0  0  0
  6 10  1  0  0  0  0
  7  8  2  0  0  0  0
  2  9  1  0  0  0  0
  8  9  1  0  0  0  0
 13 14  2  0  0  0  0
 14 15  1  0  0  0  0
 15 16  2  0  0  0  0
 16 10  1  0  0  0  0
 12 13  1  0  0  0  0
 10 12  2  0  0  0  0
  7 11  1  0  0  0  0
 16 17  1  0  0  0  0
 17 18  1  0  0  0  0
M  END
""")

rdDepictor.SetPreferCoordGen(True)
rdDepictor.GenerateDepictionMatching2DStructure(simple_mol, simple_scaffold);

MolsToGridImage((simple_mol, simple_scaffold), subImgSize=(500,500))
```
![image](https://user-images.githubusercontent.com/5244385/115007507-56092180-9eaa-11eb-88a4-98dfa7de2d24.png)


I think this is undesirable as the resulting 2D layout does not honor the original constraint anymore.
I did a bit of investigation and I have seen that while `sketcherMinimizer::alignWithParentDirectionConstrained` indeed prevents the flip at the `CoordgenMinimizer::buildMoleculeFromFragments` stage, at the `CoordgenMinimizer::avoidClashes` stage the flip may still take place in an attempt to escape the clash between the amino group and the ethyl group.

With the change proposed in this PR, that prevents the possibility to flip in `CoordgenMinimizer::flipFragments` also for constrained fragments and not only for fixed fragments, the above flip does not take place anymore, but if the clash is quite bad the molecule is still allowed to bend to alleviate the clash. This still does not look great as it would be better to rather rotate by 180 degrees the ethyl substituent around the 15-16 bond:
![image](https://user-images.githubusercontent.com/5244385/115019724-e13de380-9eb9-11eb-9d9d-8f0501b85d72.png)

You may have better solutions to this issue than the one proposed in this PR, but I hope what I described makes sense to you.
When I tried to switch the RDKit `CoordGen` interface to use `fixed` rather than `constrained` results I got really bad layouts, so I guess that's not an option at the moment.

In passing, I have also introduced a change into the `sketcherMinimizerFragment::countHeavyAtoms`, that does not seem to do what is written on the tin at the moment :-).