### PR TITLE
CRDGEN-255: Do not allow constrained fragments to flip

### DIFF
--- a/CoordgenFragmenter.cpp
+++ b/CoordgenFragmenter.cpp
@@ -150,8 +150,8 @@ void CoordgenFragmenter::initializeInformation(
 bool CoordgenFragmenter::setFlipInfo(sketcherMinimizerFragment* fragment)
 {
     fragment->constrainedFlip = false;
-    if (fragment->getAtoms().size() < 2 && fragment->countConstrainedAtoms() == 1) {
-        // fragment has one or two atoms. should only be constrained if a child is constrained
+    if (fragment->getAtoms().size() == 1 && fragment->countConstrainedAtoms() == 1) {
+        // fragment has exactly 1 atom. should only be constrained if a child is constrained
         for (auto child : fragment->_children) {
             if(child->constrained) {
                 fragment->constrainedFlip = true;

--- a/CoordgenFragmenter.cpp
+++ b/CoordgenFragmenter.cpp
@@ -144,6 +144,23 @@ void CoordgenFragmenter::initializeInformation(
     orderFragments(fragments, mainFragment);
     molecule->setMainFragment(mainFragment);
     molecule->setFragments(fragments);
+    for_each(fragments.begin(), fragments.end(), setFlipInfo);
+}
+
+bool CoordgenFragmenter::setFlipInfo(sketcherMinimizerFragment* fragment)
+{
+    fragment->constrainedFlip = false;
+    if (fragment->getAtoms().size() < 2 && fragment->countConstrainedAtoms() == 1) {
+        // fragment has one or two atoms. should only be constrained if a child is constrained
+        for (auto child : fragment->_children) {
+            if(child->constrained) {
+                fragment->constrainedFlip = true;
+            }
+        }
+    } else {
+        fragment->constrainedFlip  = (fragment->countConstrainedAtoms() > 1);
+    }
+    return fragment->constrainedFlip;
 }
 
 bool CoordgenFragmenter::setFixedInfo(sketcherMinimizerFragment* fragment)

--- a/CoordgenFragmenter.h
+++ b/CoordgenFragmenter.h
@@ -25,7 +25,7 @@ class EXPORT_COORDGEN CoordgenFragmenter
      */
     static void splitIntoFragments(sketcherMinimizerMolecule* molecule);
 
-  // private:
+  private:
     /*
      put all atoms and bonds of fragment2 into fragment1 and delete it
      */

--- a/CoordgenFragmenter.h
+++ b/CoordgenFragmenter.h
@@ -25,7 +25,7 @@ class EXPORT_COORDGEN CoordgenFragmenter
      */
     static void splitIntoFragments(sketcherMinimizerMolecule* molecule);
 
-  private:
+  // private:
     /*
      put all atoms and bonds of fragment2 into fragment1 and delete it
      */

--- a/CoordgenFragmenter.h
+++ b/CoordgenFragmenter.h
@@ -77,6 +77,11 @@ class EXPORT_COORDGEN CoordgenFragmenter
     static bool setFixedInfo(sketcherMinimizerFragment* fragment);
 
     /*
+     check if fragment can be flipped and sets the appropriate flag
+     */
+    static bool setFlipInfo(sketcherMinimizerFragment* fragment);
+
+    /*
      check if fragment has constrained coordinates and set the appropriate flag
      */
     static bool setConstrainedInfo(sketcherMinimizerFragment* fragment);

--- a/CoordgenFragmenter.h
+++ b/CoordgenFragmenter.h
@@ -66,42 +66,6 @@ class EXPORT_COORDGEN CoordgenFragmenter
                           sketcherMinimizerMolecule* molecule);
 
     /*
-     check if fragment is part of an aliphatic chain and sets the appropriate
-     flag
-     */
-    static void setChainInfo(sketcherMinimizerFragment* fragment);
-
-    /*
-     check if fragment has fixed coordinates and sets the appropriate flag
-     */
-    static bool setFixedInfo(sketcherMinimizerFragment* fragment);
-
-    /*
-     check if fragment can be flipped and sets the appropriate flag
-     */
-    static bool setFlipInfo(sketcherMinimizerFragment* fragment);
-
-    /*
-     check if fragment has constrained coordinates and set the appropriate flag
-     */
-    static bool setConstrainedInfo(sketcherMinimizerFragment* fragment);
-
-    /*
-     check if atom has fixed cooordinates
-     */
-    static bool isAtomFixed(const sketcherMinimizerAtom* atom);
-
-    /*
-     check if atom has constrained cooordinates
-     */
-    static bool isAtomConstrained(const sketcherMinimizerAtom* atom);
-
-    /*
-     check if fragment is part of an aliphatic chain
-     */
-    static bool isChain(const sketcherMinimizerFragment* fragment);
-
-    /*
       compare two fragments for priority (e.g. to find the main fragment)
      */
     static bool hasPriority(const sketcherMinimizerFragment* fragment1,

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -1177,18 +1177,7 @@ bool CoordgenMinimizer::flipFragments(sketcherMinimizerMolecule* molecule,
     vector<sketcherMinimizerFragment*> fragments = molecule->getFragments();
     reverse(fragments.begin(), fragments.end());
     for (auto fragment : fragments) {
-        bool no_flip = false;
-        if (fragment->getAtoms().size() < 2 && fragment->countConstrainedAtoms() == 1) {
-            // fragment has one or two atoms. should only be constrained if a child is constrained
-            for (auto child : fragment->_children) {
-                if(child->constrained) {
-                    no_flip = true;
-                }
-            }
-        } else {
-            no_flip = (fragment->countConstrainedAtoms() > 1);
-        }
-        if (!fragment->fixed && !no_flip) {
+        if (!fragment->fixed) {
             for (auto dof : fragment->getDofs()) {
                 if (dof->numberOfStates() > 1) {
                     dofs.push_back(dof);

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "CoordgenMinimizer.h"
-#include "CoordgenFragmenter.h"
 #include "sketcherMinimizer.h" // should be removed at the end of refactoring
 #include "sketcherMinimizerAtom.h"
 #include "sketcherMinimizerBendInteraction.h"

--- a/sketcherMinimizerFragment.cpp
+++ b/sketcherMinimizerFragment.cpp
@@ -16,6 +16,7 @@ static const float ROTATE_FRAGMENT_PENALTY = 400.f;
 static const float BREAK_CHAIN_PENALTY = 10.f;
 static const float CHANGE_PARENT_BOND_PENALTY = 200.f;
 static const float FLIP_RING_PENALTY = 200.f;
+static const float FLIP_CONSTRAINED_FRAGMENT_PENALTY = 1000.f;
 
 static const int FLIP_FRAGMENT_TIER = 0;
 static const int INVERT_BOND_TIER = 1;
@@ -85,6 +86,10 @@ float CoordgenFlipFragmentDOF::getCurrentPenalty() const
     if (m_fragment->isChain && m_fragment->getParent() &&
         m_fragment->getParent()->isChain) {
         return BREAK_CHAIN_PENALTY;
+    }
+
+    if (m_currentState != 0 && m_fragment->constrainedFlip) {
+        return FLIP_CONSTRAINED_FRAGMENT_PENALTY;
     }
     return 0.f;
 }

--- a/sketcherMinimizerFragment.h
+++ b/sketcherMinimizerFragment.h
@@ -258,7 +258,7 @@ class sketcherMinimizerFragment
     std::map<sketcherMinimizerAtom*, sketcherMinimizerPointF> _coordinates;
     sketcherMinimizerPointF _bondToParentCoordinatesStart;
     sketcherMinimizerPointF _bondToParentCoordinatesEnd;
-    bool fixed, isTemplated, constrained;
+    bool fixed, isTemplated, constrained, constrainedFlip;
     bool isChain;
     sketcherMinimizerBond* _bondToParent;
     float longestChainFromHere;

--- a/test/test_coordgen.cpp
+++ b/test/test_coordgen.cpp
@@ -4,6 +4,7 @@
 #include <boost/test/unit_test.hpp>
 #include <unordered_set>
 
+#include "../CoordgenFragmenter.h"
 #include "../sketcherMinimizer.h"
 #include "../sketcherMinimizerMaths.h"
 #include "../sketcherMinimizerStretchInteraction.h"
@@ -478,4 +479,71 @@ BOOST_AUTO_TEST_CASE(testbicyclopentane)
     BOOST_TEST(distance1 > minimumDistance);
     BOOST_TEST(distance2 > minimumDistance);
     BOOST_TEST(distance3 > minimumDistance);
+}
+
+BOOST_AUTO_TEST_CASE(testCoordgenFragmenter)
+{
+    /*
+     Test that a molecule is fragmented as expected and fragments are given the
+     correct flags. Atoms 3-8 and 11 are constrained.
+                            6
+                          /   \
+     1 -- 2 -- 3 -- 4 -- 5     7 -- 8 -- 9 -- 10
+                          \   /
+                            11
+    */
+    auto mol = "CCCCC1CC(CCC)C1"_smiles;
+    auto atoms = mol->getAtoms();
+    for (int i = 3; i <= 8; ++i) {
+        atoms[i-1]->constrained = true;
+    }
+    atoms[10]->constrained = true;
+    auto atom_map = getReportingIndices(*mol);
+
+    sketcherMinimizer minimizer;
+    minimizer.initialize(mol);
+    CoordgenFragmenter::splitIntoFragments(mol);
+
+    std::vector<std::set<int>> expected_fragments = {{1, 2}, {3}, {4}, {5, 6, 7, 11}, {8}, {9, 10}};
+    std::vector<std::set<int>> actual_fragments;
+    for (auto fragment : mol->_fragments) {
+        std::set<int> fragment_idices;
+        for (auto at : fragment->getAtoms()) {
+            fragment_idices.insert(atom_map[at]);
+        }
+        actual_fragments.push_back(fragment_idices);
+    }
+    std::sort(actual_fragments.begin(), actual_fragments.end());
+
+    // Check that the fragmenting is correct
+    BOOST_REQUIRE_EQUAL(actual_fragments.size(), expected_fragments.size());
+    for (size_t i = 0; i < actual_fragments.size(); ++i) {
+        BOOST_CHECK_EQUAL_COLLECTIONS(expected_fragments[i].begin(), expected_fragments[i].end(), actual_fragments[i].begin(), actual_fragments[i].end());
+    }
+
+    // Fragment containing atoms (1, 2)
+    BOOST_TEST(atoms[0]->fragment->constrained == false);
+    BOOST_TEST(atoms[0]->fragment->constrainedFlip == false);
+
+    // Fragment containing atom 3. Flip should not be constrained since
+    // the fragment does not have any constrained child fragments
+    BOOST_TEST(atoms[2]->fragment->constrained == true);
+    BOOST_TEST(atoms[2]->fragment->constrainedFlip == false);
+
+    // Fragment containing atom 4. Flip should be constrained since fragment
+    // has a child fragment that is constrained
+    BOOST_TEST(atoms[3]->fragment->constrained == true);
+    BOOST_TEST(atoms[3]->fragment->constrainedFlip == true);
+
+    // Fragment containing atoms (5, 6, 7, 11)
+    BOOST_TEST(atoms[4]->fragment->constrained == true);
+    BOOST_TEST(atoms[4]->fragment->constrainedFlip == true);
+
+    // Fragment containing atom 8
+    BOOST_TEST(atoms[7]->fragment->constrained == true);
+    BOOST_TEST(atoms[7]->fragment->constrainedFlip == false);
+
+    // Fragment containing atoms (9, 10)
+    BOOST_TEST(atoms[8]->fragment->constrained == false);
+    BOOST_TEST(atoms[8]->fragment->constrainedFlip == false);
 }


### PR DESCRIPTION
This is my attempt (inspired by [Paolo's PR](https://github.com/schrodinger/coordgenlibs/pull/91)) to prohibit flipping fragments that are in a given scaffold/template unless the flip would not affect constrained atoms. The problem I ran into when testing the previous changes was that some 1-2 atom fragments with exactly 1 constrained atom would not be considered constrained, allowing them to flip. Now, these specific fragments can only flip if they have no constrained children. Here is an example of where this seemed to help:

Original molecule and the scaffold:
<p float="left">
<img width="350" alt="Screen Shot 2021-04-22 at 12 23 15 PM" src="https://user-images.githubusercontent.com/39069546/115939039-9724a700-a451-11eb-83dc-2a8712c91d69.png">
<img width="300" alt="Screen Shot 2021-04-22 at 12 25 35 PM" src="https://user-images.githubusercontent.com/39069546/115939054-a1df3c00-a451-11eb-85eb-cbd19232e965.png">
</p>

Generating coordinates with [these](https://github.com/schrodinger/coordgenlibs/pull/91) changes:
<img width="422" alt="Screen Shot 2021-04-22 at 12 26 41 PM" src="https://user-images.githubusercontent.com/39069546/115939058-a73c8680-a451-11eb-9fd0-58906aad258c.png">

Now when generating coordinates, the 13-14 fragment is considered constrained because it has constrained children:
<img width="460" alt="Screen Shot 2021-04-23 at 4 34 39 PM" src="https://user-images.githubusercontent.com/39069546/115939092-d5ba6180-a451-11eb-9eab-21201c7983cc.png">

I ran `rdCoordGen.AddCoords` on ~18k molecule/scaffold pairs (from the dataset Greg provided, ignoring instances where there was more than one scaffold match in the mol). After these changes, the distribution of the RMSD between the core atoms in the resulting molecule and the coordinates of the given scaffold seems to improve. Before, there were 712 instances where the RMSD > 0.5, and now there are 362 instances. Here is a more thorough comparison:
<img width="985" alt="Screen Shot 2021-04-23 at 3 45 28 PM" src="https://user-images.githubusercontent.com/39069546/115939107-e8349b00-a451-11eb-9932-34c2ea126707.png">

I found that the majority of molecules that generated an RMSD larger than .5 included a ring with more than 6 atoms. The other instances mostly occurred when the given scaffold contained part of a ring (but not the entire ring). @d-b-w or @ZontaNicola, do you know where the flips/distortions on the larger rings are occurring, or what type of `CoordgenFragmentDOF` this change would come from? Here is an example:

Original molecule:
<img width="466" alt="Screen Shot 2021-04-23 at 4 37 44 PM" src="https://user-images.githubusercontent.com/39069546/115939233-5711f400-a452-11eb-9de3-1c38cf0c5ed1.png">

Scaffold:
<img width="620" alt="Screen Shot 2021-04-23 at 1 39 09 PM" src="https://user-images.githubusercontent.com/39069546/115939181-2631bf00-a452-11eb-8dac-6d309a40c0a6.png">

Coordinates generated (same before and after this commit -- is this at all related to [issue #81](https://github.com/schrodinger/coordgenlibs/issues/83)?):
<img width="453" alt="Screen Shot 2021-04-23 at 4 37 56 PM" src="https://user-images.githubusercontent.com/39069546/115939219-4ceff580-a452-11eb-93a9-30cd2f68965c.png">

Finally, I think that @ZontaNicola's idea of assigning a large penalty to flipping these constrained fragments would be a better alternative to these changes once we can determine what needs to be penalized in the macrocycle cases. Let me know if you have suggestions on what sort of penalty we should give.