### PR TITLE
Stop force field minimization when energy improvement slows down

### DIFF
--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -36,7 +36,7 @@ static const float RING_BOND_CROSSING_MULTIPLIER = 2.f;
 static const unsigned int MAXIMUM_NUMBER_OF_SCORED_SOLUTIONS = 10000;
 static const float REJECTED_SOLUTION_SCORE = 99999999.f;
 
-static const int ITERATION_HISTORY_SIZE = 100;
+static const unsigned int ITERATION_HISTORY_SIZE = 100;
 static const float MAX_NET_ENERGY_CHANGE = 20.f;
 
 CoordgenMinimizer::CoordgenMinimizer()
@@ -75,7 +75,7 @@ void CoordgenMinimizer::run()
         setupInteractions();
     }
     std::vector<float> energy_list(m_maxIterations);
-    for (int iterations = 0; iterations < m_maxIterations; ++iterations) {
+    for (unsigned int iterations = 0; iterations < m_maxIterations; ++iterations) {
         energy_list[iterations] = scoreInteractions();
         if (!applyForces(0.1f)) {
             break;

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -37,7 +37,7 @@ static const unsigned int MAXIMUM_NUMBER_OF_SCORED_SOLUTIONS = 10000;
 static const float REJECTED_SOLUTION_SCORE = 99999999.f;
 
 static const int ITERATION_HISTORY_SIZE = 100;
-static const int MAX_NET_ENERGY_CHANGE = 20;
+static const float MAX_NET_ENERGY_CHANGE = 20.f;
 
 CoordgenMinimizer::CoordgenMinimizer()
 {

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -35,6 +35,10 @@ static const float RING_BOND_CROSSING_MULTIPLIER = 2.f;
 
 static const unsigned int MAXIMUM_NUMBER_OF_SCORED_SOLUTIONS = 10000;
 static const float REJECTED_SOLUTION_SCORE = 99999999.f;
+
+static const int ITERATION_HISTORY_SIZE = 100;
+static const int MAX_NET_ENERGY_CHANGE = 20;
+
 CoordgenMinimizer::CoordgenMinimizer()
 {
     m_maxIterations = 1000;
@@ -70,10 +74,16 @@ void CoordgenMinimizer::run()
     if (!_interactions.size()) {
         setupInteractions();
     }
-
+    std::vector<float> energy_list(m_maxIterations);
     for (int iterations = 0; iterations < m_maxIterations; ++iterations) {
-        scoreInteractions();
+        energy_list[iterations] = scoreInteractions();
         if (!applyForces(0.1f)) {
+            break;
+        }
+        if (iterations < 2 * ITERATION_HISTORY_SIZE) {
+            continue;
+        }
+        if (energy_list[iterations - ITERATION_HISTORY_SIZE] - energy_list[iterations] < MAX_NET_ENERGY_CHANGE) {
             break;
         }
     }

--- a/CoordgenMinimizer.cpp
+++ b/CoordgenMinimizer.cpp
@@ -80,17 +80,17 @@ void CoordgenMinimizer::run()
     float min_energy = std::numeric_limits<float>::max();
     for (unsigned int iterations = 0; iterations < m_maxIterations; ++iterations) {
         local_energy_list[iterations] = scoreInteractions();
-        if (!applyForces(0.1f)) {
-            break;
-        }
-        if (iterations < 2 * ITERATION_HISTORY_SIZE) {
-            continue;
-        }
         // track coordinates with lowest energy
         if (local_energy_list[iterations] < min_energy) {
             for (size_t i = 0; i < _atoms.size(); ++i) {
                 lowest_energy_coords[i] = _atoms[i]->coordinates;
             }
+        }
+        if (!applyForces(0.1f)) {
+            break;
+        }
+        if (iterations < 2 * ITERATION_HISTORY_SIZE) {
+            continue;
         }
         if (local_energy_list[iterations - ITERATION_HISTORY_SIZE] - local_energy_list[iterations] < MAX_NET_ENERGY_CHANGE) {
             break;

--- a/CoordgenMinimizer.h
+++ b/CoordgenMinimizer.h
@@ -390,7 +390,7 @@ private:
              std::vector<sketcherMinimizerInteraction*>>
         _extraInteractionsOfMolecule;
 
-    float m_maxIterations;
+    unsigned int m_maxIterations;
     float m_precision;
 };
 


### PR DESCRIPTION
When tracking the energy after each force field minimization step, we noticed that the energy tends to 'converge' far before hitting 1000 iterations:
<img width="646" alt="all_mols" src="https://user-images.githubusercontent.com/39069546/116486701-11cf3700-a843-11eb-9a16-3aa3fd5d25f0.png">

For many of these molecules, there is still a small energy decrease over every few iterations after converging (however the energy levels tend to oscillate). I started looking into how small changes in energy (~10-50) impact coordinates, and it does not seem to make a huge visual difference. For example, this is the energy after each iteration for one molecule:
<img width="581" alt="Screen Shot 2021-04-28 at 2 24 11 PM" src="https://user-images.githubusercontent.com/39069546/116486737-26133400-a843-11eb-8636-899a95953ae2.png">

And here is a short animation that shows how the coordinates change on each iteration:
https://user-images.githubusercontent.com/39069546/116486757-33c8b980-a843-11eb-860f-dd467d8b7705.mov

The energy drops by around 50 between iterations 200 and 1000, however most of the significant movements occur in the first 200 iterations. After this commit, the minimization would stop once the net energy decrease in the last `ITERATION_HISTORY_SIZE` iterations is less than `MAX_NET_ENERGY_CHANGE`. I currently have these values set to 100 and 20 respectively. This change caused 99% of the minimizations in the first graph to stop early (97% stop before hitting 300 iterations). Here are a few examples of the early stopping -- the grey shows where the energy would go if the minimization continued:
<img width="655" alt="Screen Shot 2021-04-28 at 4 31 31 PM" src="https://user-images.githubusercontent.com/39069546/116486846-670b4880-a843-11eb-8e78-61d326e1c4f5.png">

Finally, this change does give a substantial performance improvement (but is still nowhere near RDKit's coordinate generator). I ran `rdDepictor.Compute2DCoords(mol)` on 4184 molecules:
|                                     | Total time elapsed | Minimizations that took >.1s |
|-------------------------------------|--------------------|------------------------------|
| Before these changes                | 24.001s            | 13                           |
| After these changes                 | 10.949s            | 2                            |
| RDKit's native coordinate generator | 0.877s             | 0                            |


These are my main questions now:
1. Do we think this is a good approach?
2. Do the current `ITERATION_HISTORY_SIZE` and `MAX_NET_ENERGY_CHANGE` values seem reasonable, or should we change them?  I chose these arbitrarily, it may make sense to look at a smaller history anytime after ~150-200 iterations.