### PR TITLE
Allow two penalties to be used in getCurrentPenalty

### DIFF
--- a/sketcherMinimizerFragment.cpp
+++ b/sketcherMinimizerFragment.cpp
@@ -83,15 +83,15 @@ CoordgenFlipFragmentDOF::CoordgenFlipFragmentDOF(
 
 float CoordgenFlipFragmentDOF::getCurrentPenalty() const
 {
+    float penalty = 0.f;
+    if (m_currentState != 0 && m_fragment->constrainedFlip) {
+        penalty += FLIP_CONSTRAINED_FRAGMENT_PENALTY;
+    }
     if (m_fragment->isChain && m_fragment->getParent() &&
         m_fragment->getParent()->isChain) {
-        return BREAK_CHAIN_PENALTY;
+        penalty += BREAK_CHAIN_PENALTY;
     }
-
-    if (m_currentState != 0 && m_fragment->constrainedFlip) {
-        return FLIP_CONSTRAINED_FRAGMENT_PENALTY;
-    }
-    return 0.f;
+    return penalty;
 }
 
 int CoordgenFlipFragmentDOF::numberOfStates() const


### PR DESCRIPTION
I noticed some chains were flipped, and I think it was because the FLIP_CONSTRAINED_FRAGMENT_PENALTY was not being applied when BREAK_CHAIN_PENALTY was. I should've fixed this in the last PR :)