### PR TITLE
Drop some set but unused variables.

### DIFF
--- a/CoordgenFragmentBuilder.cpp
+++ b/CoordgenFragmentBuilder.cpp
@@ -26,7 +26,6 @@ const int NUMBER_OF_FUSED_RINGS_CENTRAL_RING_SCORE = 40;
 const int NUMBER_OF_FUSION_ATOMS_CENTRAL_RING_SCORE = 15;
 const int NEIGHBOR_ALREADY_BUILT_RING_SCORE = 100000;
 
-
 void CoordgenFragmentBuilder::initializeCoordinates(
     sketcherMinimizerFragment* fragment) const
 {
@@ -171,7 +170,8 @@ sketcherMinimizerRing* CoordgenFragmentBuilder::findCentralRingOfSystem(
     size_t high_score = 0;
     for (sketcherMinimizerRing* r : rings) {
         size_t priority = 0;
-        /*keep growing the system building rings neighboring already built rings*/
+        /*keep growing the system building rings neighboring already built
+         * rings*/
         for (auto neighborRing : r->fusedWith) {
             if (neighborRing->coordinatesGenerated) {
                 priority += NEIGHBOR_ALREADY_BUILT_RING_SCORE;
@@ -185,9 +185,11 @@ sketcherMinimizerRing* CoordgenFragmentBuilder::findCentralRingOfSystem(
             priority += 10;
         }
         priority += r->_atoms.size();
-        priority += NUMBER_OF_FUSED_RINGS_CENTRAL_RING_SCORE * (r->fusedWith.size());
+        priority +=
+            NUMBER_OF_FUSED_RINGS_CENTRAL_RING_SCORE * (r->fusedWith.size());
         for (auto fusionAtoms : r->fusionAtoms) {
-            priority+= NUMBER_OF_FUSION_ATOMS_CENTRAL_RING_SCORE * fusionAtoms.size();
+            priority +=
+                NUMBER_OF_FUSION_ATOMS_CENTRAL_RING_SCORE * fusionAtoms.size();
         }
         if (priority > high_score || highest == nullptr) {
             highest = r;
@@ -296,8 +298,10 @@ CoordgenFragmentBuilder::getSharedAtomsWithAlreadyDrawnRing(
     for (auto i : ring->fusedWith) {
         if (i->coordinatesGenerated) {
             if (parent != nullptr) {
-                if (i->getFusionAtomsWith(ring).size() < parent->getFusionAtomsWith(ring).size() ||
-                (i->size() < parent->size())) continue;
+                if (i->getFusionAtomsWith(ring).size() <
+                        parent->getFusionAtomsWith(ring).size() ||
+                    (i->size() < parent->size()))
+                    continue;
             }
             parent = i;
         }
@@ -414,16 +418,13 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
                 coords.size();
             center.normalize();
 
-            int neighborsN = 0;
             sketcherMinimizerPointF neighborsMean(0.f, 0.f);
             for (sketcherMinimizerAtom* neighbor :
                  pivotAtomOnParent->neighbors) {
                 if (parent->containsAtom(neighbor)) {
                     neighborsMean += neighbor->getCoordinates();
-                    ++neighborsN;
                 }
             }
-            assert(neighborsN == 2);
             neighborsMean *= 0.5;
             sketcherMinimizerPointF pivotAtomCoordinates =
                 pivotAtomOnParent->getCoordinates();
@@ -460,7 +461,7 @@ void CoordgenFragmentBuilder::buildRing(sketcherMinimizerRing* ring) const
             for (auto& i : coords2) {
                 i = sketcherMinimizerPointF(i.x(), -i.y());
             }
-            map<sketcherMinimizerAtom *, sketcherMinimizerPointF> map1, map2;
+            map<sketcherMinimizerAtom*, sketcherMinimizerPointF> map1, map2;
             for (unsigned int i = 0; i < atoms.size(); i++) {
                 map1[atoms[i]] = coords[i];
                 map2[atoms[i]] = coords2[i];
@@ -1040,9 +1041,9 @@ void CoordgenFragmentBuilder::simplifyRingSystem(
                         n++;
                     }
                     if (r->fusionAtoms.at(ringCounter).size() == 3 &&
-                        r->size() == 4 &&
-                        fusedRing->size() == 4) {
-                        /* don't separate rings of bicyclo (1,1,1) pentane so we can use a template instead */
+                        r->size() == 4 && fusedRing->size() == 4) {
+                        /* don't separate rings of bicyclo (1,1,1) pentane so we
+                         * can use a template instead */
                         n++;
                     }
                 }

--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -25,8 +25,8 @@
 #include "sketcherMinimizerBendInteraction.h"
 #include "sketcherMinimizerClashInteraction.h"
 #include "sketcherMinimizerMaths.h"
-#include "sketcherMinimizerStretchInteraction.h"
 #include "sketcherMinimizerRing.h"
+#include "sketcherMinimizerStretchInteraction.h"
 
 using namespace std;
 using namespace schrodinger;
@@ -337,17 +337,17 @@ void sketcherMinimizer::flagCrossAtoms()
 
 void sketcherMinimizer::clear()
 {
-    for (auto& _referenceAtom :  m_referenceAtoms) {
+    for (auto& _referenceAtom : m_referenceAtoms) {
         delete _referenceAtom;
     }
-     m_referenceAtoms.clear();
+    m_referenceAtoms.clear();
     m_residues.clear();
 
     for (auto& _referenceBond : m_referenceBonds) {
         delete _referenceBond;
     }
 
-   m_referenceBonds.clear();
+    m_referenceBonds.clear();
 
     for (auto& m_extraBond : m_extraBonds) {
         delete m_extraBond;
@@ -366,7 +366,7 @@ void sketcherMinimizer::clear()
         delete _molecule;
     }
 
-   m_molecules.clear();
+    m_molecules.clear();
 }
 
 void sketcherMinimizer::splitIntoMolecules(
@@ -1018,7 +1018,8 @@ void sketcherMinimizer::bestRotation()
     }
 }
 
-void sketcherMinimizer::writeMinimizationData() {
+void sketcherMinimizer::writeMinimizationData()
+{
     // print all coordinates to output file
     sketcherMinimizerPointF center(centerX, centerY);
     std::ofstream energy_file("minimization_data.txt");
@@ -1028,7 +1029,8 @@ void sketcherMinimizer::writeMinimizationData() {
             sketcherMinimizerPointF v = coord - center;
             v.rotate(sin_flip, cos_flip);
             sketcherMinimizerPointF new_coord = center + v;
-            energy_file << new_coord.x() * flipX << "," << new_coord.y() * flipY << ";";
+            energy_file << new_coord.x() * flipX << "," << new_coord.y() * flipY
+                        << ";";
         }
         energy_file << "\n";
     }
@@ -1192,11 +1194,12 @@ std::vector<sketcherMinimizerResidue*> sketcherMinimizer::orderResiduesOfChains(
             vec.push_back(res);
         }
     }
-    sort(vec.begin(), vec.end(), [](const sketcherMinimizerResidue* firstRes,
-                                    const sketcherMinimizerResidue* secondRes) {
-        return firstRes->residueInteractions.size() >
-               secondRes->residueInteractions.size();
-    });
+    sort(vec.begin(), vec.end(),
+         [](const sketcherMinimizerResidue* firstRes,
+            const sketcherMinimizerResidue* secondRes) {
+             return firstRes->residueInteractions.size() >
+                    secondRes->residueInteractions.size();
+         });
     std::set<sketcherMinimizerResidue*> visitedResidues;
     std::queue<sketcherMinimizerResidue*> residueQueue;
     std::vector<sketcherMinimizerResidue*> finalVec;
@@ -1237,11 +1240,9 @@ void sketcherMinimizer::placeResiduesProteinOnlyModeLIDStyle(
     shortenInteractions(chains);
     auto residues = orderResiduesOfChains(chains);
     for (auto res : residues) {
-        int partnersAlreadySet = 0;
         sketcherMinimizerResidue* firstPartner = nullptr;
         for (auto partner : res->residueInteractionPartners) {
             if (partner->coordinatesSet) {
-                ++partnersAlreadySet;
                 auto partnerResidue =
                     static_cast<sketcherMinimizerResidue*>(partner);
                 if (!firstPartner && partnerResidue->chain != res->chain) {
@@ -1297,12 +1298,12 @@ void sketcherMinimizer::placeResiduesInCrowns()
                  interactionsOfSecond += res->residueInteractions.size();
              }
              float interactionScaling = 3.f;
-             float score1 =
-                 firstSSE.size() +
-                 interactionScaling * interactionsOfFirst / firstSSE.size();
-             float score2 =
-                 secondSSE.size() +
-                 interactionScaling * interactionsOfSecond / secondSSE.size();
+             float score1 = firstSSE.size() + interactionScaling *
+                                                  interactionsOfFirst /
+                                                  firstSSE.size();
+             float score2 = secondSSE.size() + interactionScaling *
+                                                   interactionsOfSecond /
+                                                   secondSSE.size();
              return score1 > score2;
          });
     bool needOtherShape = true;
@@ -1663,10 +1664,11 @@ vector<sketcherMinimizerPointF> sketcherMinimizer::shapeAroundLigand(int crownN)
     ms.setThreshold(0);
     ms.run();
     auto result = ms.getOrderedCoordinatesPoints();
-    sort(result.begin(), result.end(), [](const vector<float>& firstContour,
-                                          const vector<float>& secondContour) {
-        return firstContour.size() > secondContour.size();
-    });
+    sort(result.begin(), result.end(),
+         [](const vector<float>& firstContour,
+            const vector<float>& secondContour) {
+             return firstContour.size() > secondContour.size();
+         });
     vector<sketcherMinimizerPointF> returnValue;
     if (!result.empty()) {
         for (unsigned int i = 0; i < result.at(0).size(); i += 2) {
@@ -2295,9 +2297,9 @@ void sketcherMinimizer::placeMoleculesWithProximityRelations(
 
     for (auto molecule : min.m_molecules) {
         if (!molecule->_rings.empty()) {
-                 // if at least three molecules are connected to each other
-                 // (i.e. two residues are connected to each other and both to
-                 // the ligand) abort the ligandResidue display style)
+            // if at least three molecules are connected to each other
+            // (i.e. two residues are connected to each other and both to
+            // the ligand) abort the ligandResidue display style)
             ligandResidueStyle = false;
         }
     }
@@ -2988,7 +2990,7 @@ sketcherMinimizerAtom*
 sketcherMinimizer::pickBestAtom(vector<sketcherMinimizerAtom*>& atoms)
 {
 
-    vector<sketcherMinimizerAtom *> candidates, oldCandidates;
+    vector<sketcherMinimizerAtom*> candidates, oldCandidates;
 
     {
         size_t biggestSize = atoms[0]->fragment->numberOfChildrenAtoms;
@@ -3060,10 +3062,10 @@ void sketcherMinimizer::constrainAllAtoms()
 
 void sketcherMinimizer::constrainAtoms(const vector<bool>& constrained)
 {
-    if (constrained.size() ==  m_referenceAtoms.size()) {
+    if (constrained.size() == m_referenceAtoms.size()) {
         for (unsigned int i = 0; i < constrained.size(); i++) {
             if (constrained[i]) {
-                 m_referenceAtoms[i]->constrained = true;
+                m_referenceAtoms[i]->constrained = true;
             }
         }
     } else {
@@ -3074,10 +3076,10 @@ void sketcherMinimizer::constrainAtoms(const vector<bool>& constrained)
 
 void sketcherMinimizer::fixAtoms(const vector<bool>& fixed)
 {
-    if (fixed.size() ==  m_referenceAtoms.size()) {
+    if (fixed.size() == m_referenceAtoms.size()) {
         for (unsigned int i = 0; i < fixed.size(); i++) {
             if (fixed[i]) {
-                 m_referenceAtoms[i]->fixed = true;
+                m_referenceAtoms[i]->fixed = true;
             }
         }
     } else {
@@ -3648,17 +3650,20 @@ int sketcherMinimizer::morganScores(const vector<sketcherMinimizerAtom*>& atoms,
 }
 
 // interactions with m_minimizer and m_fragmentBuilder
-const std::vector<sketcherMinimizerBendInteraction*>& sketcherMinimizer::getBendInteractions() const
+const std::vector<sketcherMinimizerBendInteraction*>&
+sketcherMinimizer::getBendInteractions() const
 {
     return m_minimizer.getBendInteractions();
 }
 
-const std::vector<sketcherMinimizerStretchInteraction*>& sketcherMinimizer::getStretchInteractions() const
+const std::vector<sketcherMinimizerStretchInteraction*>&
+sketcherMinimizer::getStretchInteractions() const
 {
     return m_minimizer.getStretchInteractions();
 }
 
-const std::vector<sketcherMinimizerInteraction*>& sketcherMinimizer::getInteractions() const
+const std::vector<sketcherMinimizerInteraction*>&
+sketcherMinimizer::getInteractions() const
 {
     return m_minimizer.getInteractions();
 }

--- a/sketcherMinimizerAtom.cpp
+++ b/sketcherMinimizerAtom.cpp
@@ -10,12 +10,11 @@
 #include <numeric>
 #include <queue>
 
-#include "sketcherMinimizerAtom.h"
 #include "sketcherMinimizer.h"
+#include "sketcherMinimizerAtom.h"
 #include "sketcherMinimizerBond.h"
 #include "sketcherMinimizerMaths.h"
 #include "sketcherMinimizerRing.h"
-
 
 using namespace std;
 
@@ -355,8 +354,7 @@ sketcherMinimizerAtom::clockwiseOrderedNeighbors() const
     rankedNeighbors.reserve(neighbors.size());
     for (auto&& neighbor : neighbors) {
         float newAngle = sketcherMinimizerMaths::signedAngle(
-                neighbors[0]->coordinates, coordinates,
-                neighbor->coordinates);
+            neighbors[0]->coordinates, coordinates, neighbor->coordinates);
         if (std::isnan(newAngle)) {
             newAngle = 361;
         } else if (newAngle < 0) {
@@ -984,13 +982,13 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
 
     vector<CIPAtom> AN1, AN2;
 
-    map<sketcherMinimizerAtom *, int> score1,
+    map<sketcherMinimizerAtom*, int> score1,
         score2; // used to keep track if a parent atom has been found to have
                 // priority over another
-    map<sketcherMinimizerAtom *, vector<int>> medals1,
+    map<sketcherMinimizerAtom*, vector<int>> medals1,
         medals2; // marks if an atom is a parent of the atoms being evaluated in
                  // the current iteration
-    map<sketcherMinimizerAtom *, int> visited1,
+    map<sketcherMinimizerAtom*, int> visited1,
         visited2; // marks at which iteration this atom was evaluated
 
     visited1[center] = 1;
@@ -998,11 +996,11 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
     visited1[at1] = 2;
     visited2[at2] = 2;
 
-    vector<pair<int, sketcherMinimizerAtom *>> v1, v2;
+    vector<pair<int, sketcherMinimizerAtom*>> v1, v2;
     v1.emplace_back(at1->atomicNumber, at1);
     v2.emplace_back(at2->atomicNumber, at2);
 
-    vector<sketcherMinimizerAtom *> parents1, parents2;
+    vector<sketcherMinimizerAtom*> parents1, parents2;
     parents1.push_back(center);
     parents1.push_back(at1);
     parents2.push_back(center);
@@ -1011,11 +1009,7 @@ sketcherMinimizerAtom::CIPPriority(sketcherMinimizerAtom* at1,
     AN1.emplace_back(v1, center, parents1, &score1, &medals1, &visited1);
     AN2.emplace_back(v2, center, parents2, &score2, &medals2, &visited2);
 
-    int level = 1;
-
     while (!AN1.empty() || !AN2.empty()) {
-        level++;
-
         stable_sort(AN1.begin(), AN1.end());
         stable_sort(AN2.begin(), AN2.end());
 
@@ -1113,7 +1107,7 @@ vector<CIPAtom> sketcherMinimizerAtom::expandOneLevel(vector<CIPAtom>& oldV)
                               (*visited)[a] + 1) // closing a ring to an atom
                                                  // already visited in a
                                                  // previous cycle
-                         );
+                        );
                     theseAts.emplace_back(
                         neigh->atomicNumber,
                         ghost ? ((sketcherMinimizerAtom*) nullptr)


### PR DESCRIPTION
Building coordgen under emscripten, which uses a more recent clang version than CI (15.0.6 ?) revealed that 3 variables (`neighborsN`, `level` and `partnersAlreadySet`) were being set/updated, but never used. This commit removes these variables. The rest of the changes are just clang-format.