### PR TITLE
Fix some set but unused variables

### DIFF
--- a/test/coordgenBasicSMILES.h
+++ b/test/coordgenBasicSMILES.h
@@ -30,7 +30,6 @@ sketcherMinimizerMolecule* approxSmilesParse(const std::string& smiles)
     std::unordered_map<char, sketcherMinimizerAtom*> cycles;
     int bond_order = 1;
 
-    size_t idx = 0;
     for (auto c : smiles) {
         auto atomic_number = elements.find(c);
         if (atomic_number != elements.end()) {
@@ -69,7 +68,6 @@ sketcherMinimizerMolecule* approxSmilesParse(const std::string& smiles)
             msg += " in SMILES: " + smiles;
             throw std::runtime_error(msg);
         }
-        ++idx;
     }
 
     sketcherMinimizerMolecule::assignBondsAndNeighbors(mol->getAtoms(),

--- a/test/test_coordgen.cpp
+++ b/test/test_coordgen.cpp
@@ -310,7 +310,6 @@ BOOST_AUTO_TEST_CASE(testMinimizedRingsShape)
     minimizer.initialize(mol); // minimizer takes ownership of mol
     minimizer.runGenerateCoordinates();
     //check the length of every non macrocycle-ring bond
-    int bondsN = 0;
     for (auto interaction : minimizer.getStretchInteractions()) {
         auto ring = sketcherMinimizer::sameRing(interaction->atom1, interaction->atom2);
         if (ring && !ring->isMacrocycle()) {
@@ -318,10 +317,9 @@ BOOST_AUTO_TEST_CASE(testMinimizedRingsShape)
             auto tolerance = 2.f;
             auto bondLength = (interaction->atom1->coordinates - interaction->atom2->coordinates).length();
             BOOST_REQUIRE ((bondLength > expectedLength-tolerance) && (bondLength < expectedLength+tolerance));
-            bondsN++;
         }
     }
-//    check the angles
+    // check the angles
     int anglesN = 0;
     for (auto interaction : minimizer.getBendInteractions()) {
         if (interaction->isRing) {


### PR DESCRIPTION
Found by Apple clang version 14.0.3

```
    .../coordgenlibs/test/coordgenBasicSMILES.h:33:12: error: variable 'idx' set but not used [-Werror,-Wunused-but-set-variable]
        size_t idx = 0;
               ^
    .../coordgenlibs/test/coordgenBasicSMILES.h:33:12: error: variable 'idx' set but not used [-Werror,-Wunused-but-set-variable]
        size_t idx = 0;
               ^
    .../coordgenlibs/test/test_coordgen.cpp:313:9: error: variable 'bondsN' set but not used [-Werror,-Wunused-but-set-variable]
        int bondsN = 0;
            ^
```