### PR TITLE
Bump Azure CI Mac image to macos-11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,10 +27,10 @@ jobs:
       shared_lib: OFF
     steps:
       - template: .azure-pipelines/linux_build.yml
-  - job: macOS_10_15_x64
+  - job: macOS_11_x64
     timeoutInMinutes: 90
     pool:
-      vmImage: macos-10.15
+      vmImage: macos-11
     variables:
       compiler: clangxx_osx-64
       boost_version: 1.67.0
@@ -40,10 +40,10 @@ jobs:
       shared_lib: ON
     steps:
       - template: .azure-pipelines/mac_build.yml
-  - job: macOS_10_15_x64_static
+  - job: macOS_11_x64_static
     timeoutInMinutes: 90
     pool:
-      vmImage: macos-10.15
+      vmImage: macos-11
     variables:
       compiler: clangxx_osx-64
       boost_version: 1.67.0


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#recent-updates, the image we were using, `macos-10.15`, is no longer supporter, and won't run, as in https://github.com/schrodinger/coordgenlibs/runs/16259208536 (CI run for https://github.com/schrodinger/coordgenlibs/pull/125)