### PR TITLE
build: use `PROJECT_VERSION` and install `coordgen-config-version.cmake`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
-project(coordgen)
+project(coordgen VERSION 3.0.2)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
@@ -86,7 +86,7 @@ endif()
 
 set_target_properties(coordgen
     PROPERTIES
-        VERSION 3.0.2
+        VERSION ${PROJECT_VERSION}
         SOVERSION 3
 )
 
@@ -129,6 +129,12 @@ install(FILES
 
 install(EXPORT coordgen-targets
     FILE ${PROJECT_NAME}-config.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    COMPATIBILITY AnyNewerVersion)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 
 # Example


### PR DESCRIPTION
https://cmake.org/cmake/help/v3.2/module/CMakePackageConfigHelpers.html#command:write_basic_package_version_file

This will install `${CMAKE_INSTALL_LIBDIR}/cmake/coordgen-config-version.cmake`, which would be helpful for `find_package` versioning.