### PR TITLE
Export the include directory to the .cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,10 @@ set_target_properties(coordgen
         SOVERSION 3
 )
 
+target_include_directories(coordgen PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>)
+
 if(MSVC)
     set(CMAKE_INSTALL_LIBDIR lib)
     set(CMAKE_INSTALL_BINDIR bin)


### PR DESCRIPTION
Without this, the `coordgen` target in the exported .cmake file only specifies the coorden lib link target, but not the includes. that should be added to any target that builds/links against it.