### PR TITLE
Fixed bug in vertexCoords::operator<

### DIFF
--- a/CoordgenMacrocycleBuilder.h
+++ b/CoordgenMacrocycleBuilder.h
@@ -49,11 +49,11 @@ struct vertexCoords {
     }
     bool operator<(const vertexCoords& rhs) const
     {
-        if (x < rhs.x) {
-            return true;
+        if (x != rhs.x) {
+            return (x < rhs.x);
         }
-        if (y < rhs.y) {
-            return true;
+        if (y != rhs.y) {
+            return (y < rhs.y);
         }
         if (z < rhs.z) {
             return true;


### PR DESCRIPTION
The existing `vertexCoords::operator<` is invalid for some coordinates.  For example for `a = vertexCoords(1, 0, 0)` and `b = vertexCoords(0, 1, 0)`, both `a < b` and `b < a` return true, which isn't valid.  This is hit in the use of `set<vertexCoords>` in `CoordgenMacrocycleBuilder::scorePathRestraints`.  Windows debug builds will throw an exception if a pair of coordinates has both `a < b` and `b < a` in `std::set`, which is how this bug was found, via tests in the RDKit.  This change fixes the condition.