### PR TITLE
Use ${CMAKE_INSTALL_INCLUDEDIR} for headers installation path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ install(FILES
     sketcherMinimizerResidueInteraction.h
     sketcherMinimizerRing.h
     sketcherMinimizerStretchInteraction.h
-    DESTINATION include/coordgen)
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/coordgen)
 
 install(EXPORT coordgen-targets
     FILE ${PROJECT_NAME}-config.cmake


### PR DESCRIPTION
Haiku doesn't use /usr/share/include or the likes
This makes it uniform to GNUInstallDirs